### PR TITLE
fix: auth guards for protected routes + Zod validation for email payloads

### DIFF
--- a/components/auth/AuthRoute.tsx
+++ b/components/auth/AuthRoute.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+import { Loader2 } from 'lucide-react';
+
+interface AuthRouteProps {
+    children: React.ReactNode;
+}
+
+/**
+ * A wrapper component for routes that require the user to be authenticated.
+ * Redirects unauthenticated users to home, preserving the intended destination.
+ */
+export const AuthRoute: React.FC<AuthRouteProps> = ({ children }) => {
+    const { isAuthenticated, isLoading } = useAuth();
+    const location = useLocation();
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-white dark:bg-slate-950">
+                <div className="text-center">
+                    <Loader2 className="h-10 w-10 animate-spin text-teal-600 dark:text-cyan-400 mx-auto mb-4" />
+                    <p className="text-slate-500 animate-pulse">Loading...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return <Navigate to="/" state={{ from: location }} replace />;
+    }
+
+    return <>{children}</>;
+};

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -5,6 +5,7 @@ import { AdminLayout } from '../components/layouts/AdminLayout';
 import { HostLayout } from '../components/layouts/HostLayout';
 import { AdminRoute } from '../components/auth/AdminRoute';
 import { HostRoute } from '../components/auth/HostRoute';
+import { AuthRoute } from '../components/auth/AuthRoute';
 
 // Public Pages - Direct Imports (critical for immediate FCP)
 import { DirectoryHome } from '../pages/DirectoryHome';
@@ -111,7 +112,7 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/login" element={<LoginRedirect mode="login" />} />
                 <Route path="/register" element={<LoginRedirect mode="register" />} />
 
-                <Route path="/checkout" element={<Checkout />} />
+                <Route path="/checkout" element={<AuthRoute><Checkout /></AuthRoute>} />
                 <Route path="/services" element={<ServicesPage />} />
                 <Route path="/services/:category" element={<ServicesPage />} />
                 <Route path="/zero-fees" element={<ZeroFeesPage />} />
@@ -131,13 +132,13 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/services/visa-legal" element={<Visa />} />
                 <Route path="/creative-professionals/:subcategory" element={<CreativeServices />} />
                 <Route path="/shop" element={<Shop />} />
-                <Route path="/profile" element={<Profile />} />
-                <Route path="/add-service" element={<AddService />} />
+                <Route path="/profile" element={<AuthRoute><Profile /></AuthRoute>} />
+                <Route path="/add-service" element={<AuthRoute><AddService /></AuthRoute>} />
                 <Route path="/bookmarks" element={<FavoritesPage />} />
                 <Route path="/book-vehicle/:id" element={<BookVehicle />} />
                 <Route path="/book-tour/:id" element={<BookTour />} />
                 <Route path="/book-wellness/:id" element={<BookWellness />} />
-                <Route path="/inbox" element={<InboxPage />} />
+                <Route path="/inbox" element={<AuthRoute><InboxPage /></AuthRoute>} />
 
                 {/* Host Routes - Protected */}
                 <Route path="/booking/success" element={<BookingSuccess />} />
@@ -314,7 +315,7 @@ export const AppRoutes: React.FC = () => {
                     </AdminRoute>
                 } />
 
-                <Route path="/add-product" element={<AddProduct />} />
+                <Route path="/add-product" element={<AuthRoute><AddProduct /></AuthRoute>} />
 
                 <Route path="*" element={<DirectoryHome />} />
             </Routes>

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,5 +1,7 @@
 // @ts-ignore
 import { createClient } from "npm:@supabase/supabase-js@2"
+// @ts-ignore
+import { z } from "npm:zod@3"
 
 declare const Deno: any;
 
@@ -12,12 +14,46 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
+// --- Zod schemas per email type ---
+
+const s = z.string().min(1)
+const sOpt = z.string().optional()
+const bookingBase = { itemTitle: s, checkIn: s, checkOut: s, link: sOpt, itemTypeLabel: sOpt }
+
+const emailDataSchemas = {
+  booking_request_host:  z.object({ ...bookingBase, guestName: s, guests: z.coerce.string(), totalPrice: z.coerce.string(), message: sOpt }),
+  booking_cancelled_host: z.object({ ...bookingBase, guestName: s }),
+  booking_expired_host:  z.object({ ...bookingBase, guestName: s }),
+  booking_created:       z.object({ ...bookingBase, totalPrice: z.coerce.string(), userName: sOpt }),
+  booking_confirmed:     z.object({ ...bookingBase, guests: z.coerce.string(), address: sOpt }),
+  booking_rejected:      z.object({ itemTitle: s, reason: sOpt, searchLink: sOpt }),
+  booking_expired_guest: z.object({ itemTitle: s, link: sOpt }),
+  booking_cancelled:     z.object({ itemTitle: s, link: sOpt }),
+  listing_approved:      z.object({ title: s, link: sOpt }),
+  listing_rejected:      z.object({ title: s, reason: s, link: sOpt }),
+  listing_deleted:       z.object({ title: s, link: sOpt }),
+  service_approved:      z.object({ title: s, link: sOpt }),
+  service_rejected:      z.object({ title: s, reason: s, link: sOpt }),
+  service_updated:       z.object({ title: s, link: sOpt }),
+  welcome_email:         z.object({ name: s, link: sOpt }),
+  trip_reminder:         z.object({ itemTitle: s, guestName: s, checkIn: s, address: s, hostName: s, link: sOpt }),
+  review_reminder:       z.object({ itemTitle: s, guestName: s, link: sOpt }),
+  new_chat_message:      z.object({ senderName: s, messagePreview: s, link: sOpt }),
+  payout_processed:      z.object({ amount: z.coerce.string(), reference: sOpt, link: sOpt }),
+  refund_processed:      z.object({ amount: z.coerce.string(), itemTitle: s, link: sOpt }),
+  new_review:            z.object({ itemTitle: s, guestName: s, rating: z.coerce.number().min(1).max(5), comment: s, link: sOpt }),
+  admin_contact_message: z.object({ subject: s, name: s, email: s, message: s }),
+} as const
+
+type EmailType = keyof typeof emailDataSchemas
+
+const EMAIL_TYPES = Object.keys(emailDataSchemas) as EmailType[]
+
 interface EmailPayload {
   to?: string;
-
   userId?: string;
-  type: 'booking_created' | 'booking_confirmed' | 'booking_rejected' | 'booking_cancelled' | 'listing_approved' | 'listing_rejected' | 'new_review' | 'listing_deleted' | 'booking_request_host' | 'booking_cancelled_host' | 'booking_expired_guest' | 'booking_expired_host' | 'admin_contact_message' | 'welcome_email' | 'service_approved' | 'service_rejected' | 'service_updated' | 'trip_reminder' | 'review_reminder' | 'new_chat_message' | 'payout_processed' | 'refund_processed';
-  data: any; // Dynamic data for templates
+  type: EmailType;
+  data: unknown;
 }
 
 Deno.serve(async (req: Request) => {
@@ -52,12 +88,25 @@ Deno.serve(async (req: Request) => {
     // ----------------------------
     
     // --- Input Validation ---
-    if (!type || typeof type !== 'string') {
-      return new Response(JSON.stringify({ error: 'Missing or invalid "type" field. Must be a valid email type string.' }), {
+    if (!type || !EMAIL_TYPES.includes(type as EmailType)) {
+      return new Response(JSON.stringify({ error: `Invalid "type" field. Must be one of: ${EMAIL_TYPES.join(', ')}` }), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         status: 400,
       })
     }
+
+    const schemaResult = emailDataSchemas[type as EmailType].safeParse(data)
+    if (!schemaResult.success) {
+      return new Response(JSON.stringify({
+        error: 'Invalid "data" payload for email type: ' + type,
+        issues: schemaResult.error.issues.map(i => ({ path: i.path.join('.'), message: i.message })),
+      }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 400,
+      })
+    }
+
+    const validatedData = schemaResult.data
 
     if (to && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to)) {
       return new Response(JSON.stringify({ error: `Invalid email format: "${to}"` }), {
@@ -89,7 +138,7 @@ Deno.serve(async (req: Request) => {
     if (!targetEmail) throw new Error('No target email resolved')
 
     // Generate Content based on Type
-    const { subject, html } = generateEmailContent(type, data);
+    const { subject, html } = generateEmailContent(type, validatedData);
 
     // eslint-disable-next-line no-console
     console.log(`Sending '${type}' email to: ${targetEmail}`)


### PR DESCRIPTION
## Summary

- **`AuthRoute` компонент** — новый guard для маршрутов, требующих аутентификации. Редиректит на `/` с сохранением `location.state.from` для возврата после логина
- **Защищены маршруты**: `/checkout`, `/profile`, `/inbox`, `/add-service`, `/add-product`
- **`send-email` Edge Function** — добавлен `npm:zod@3`, 18 строгих схем для каждого типа письма. `data: any` заменён на валидированный payload — невалидные запросы получают `400` с конкретным описанием ошибки

## Детали реализации

**AuthRoute** работает аналогично существующим `AdminRoute` / `HostRoute`:
- Показывает спиннер пока `isLoading`
- Редиректит на `/` если `!isAuthenticated`

**Zod-схемы** покрывают все типы: `booking_*`, `listing_*`, `service_*`, `welcome_email`, `trip_reminder`, `review_reminder`, `new_chat_message`, `payout_processed`, `refund_processed`, `admin_contact_message`. Числовые поля (`rating`, `amount`, `totalPrice`) используют `z.coerce` для гибкости.

## Потенциальные риски

- Незалогиненные пользователи на `/checkout` теперь попадают на главную — нужно убедиться что UI предлагает логин перед добавлением в корзину
- Zod `safeParse` не бросает исключений — ошибки возвращаются клиенту как `400` с `issues` массивом

🤖 Generated with [Claude Code](https://claude.com/claude-code)