### PR TITLE
fix: add index fallback for missing key in RecentBookingsWidget

### DIFF
--- a/components/admin/dashboard/RecentBookingsWidget.tsx
+++ b/components/admin/dashboard/RecentBookingsWidget.tsx
@@ -23,8 +23,8 @@ export const RecentBookingsWidget: React.FC<RecentBookingsWidgetProps> = ({ book
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100 dark:divide-slate-800/50">
-                        {bookings.map((b: any) => (
-                            <tr key={b.id} className="hover:bg-slate-50 dark:hover:bg-slate-700/80 transition-colors">
+                        {bookings.map((b: any, index: number) => (
+                            <tr key={b.id ?? `booking-${index}`} className="hover:bg-slate-50 dark:hover:bg-slate-700/80 transition-colors">
                                 <td className="p-4 pl-6 font-medium text-slate-900 dark:text-white">{b.itemTitle || 'Booking'}</td>
                                 <td className="p-4 text-sm text-slate-600 dark:text-slate-400">
                                     {b.user?.full_name || 'Guest'}


### PR DESCRIPTION
## Summary
- Fixed React "missing key" warning in `RecentBookingsWidget`
- `key={b.id}` silently fails when `b.id` is `undefined`/`null` — React treats it as a missing key
- Changed to `key={b.id ?? \`booking-${index}\`}` — uses UUID when available, falls back to positional index

## Reasoning
The `getAdminBookings()` pipeline enriches bookings via batch fetching and re-mapping. If any booking row comes back without an `id` field, `b.id` is `undefined`, which React treats identically to a missing key. The fallback ensures every row has a unique, stable-enough key.

## Testing
- No functional change — purely a key stability fix
- Existing tests unaffected