### PR TITLE
fix: upgrade Node.js from 20 to 24 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
 
     - name: Install Dependencies

--- a/.github/workflows/sync-reviews.yml
+++ b/.github/workflows/sync-reviews.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
 
     - name: Install Dependencies


### PR DESCRIPTION
## Summary
- Updated `node-version: '20'` → `'24'` in both workflow files:
  - `.github/workflows/ci.yml`
  - `.github/workflows/sync-reviews.yml`

## Reasoning
Node.js 20 reaches end-of-life in April 2026. GitHub Actions was emitting deprecation warnings on every CI run. Node.js 24 is the current LTS release.

## Risks
Low — Node.js 24 is fully backwards compatible for this project's dependency set.