### PR TITLE
fix: harden sync-reviews workflow and add Dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/sync-reviews.yml
+++ b/.github/workflows/sync-reviews.yml
@@ -6,10 +6,14 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch: # Allows manual trigger from GitHub UI
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 10
+
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Added `permissions: contents: read` to `sync-reviews.yml` (principle of least privilege)
- Added `timeout-minutes: 10` to `sync-reviews.yml` (prevents hanging jobs)
- Added `.github/dependabot.yml` to auto-update GitHub Actions versions monthly

## Reasoning
`sync-reviews.yml` was missing the same security defaults already present in `ci.yml`. Dependabot will automatically open PRs when new action versions are released, keeping the pipeline up to date without manual tracking.