### PR TITLE
feat: Stripe Checkout with 15-minute payment window

### DIFF
--- a/supabase/functions/cancel-expired-bookings/index.ts
+++ b/supabase/functions/cancel-expired-bookings/index.ts
@@ -8,8 +8,6 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 // Set this secret in Supabase Dashboard → Edge Functions → Secrets
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
-const EXPIRY_HOURS = 24
-
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -24,6 +22,8 @@ Deno.serve(async (req: Request) => {
     const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 
     // 1. Найти все просроченные pending бронирования с данными гостя и хоста
+    // Отменяем только те брони у которых явно выставлен payment_expires_at и он уже прошёл
+    // Брони без Stripe (наличные, банк) не будут затронуты
     const { data: expiredBookings, error: fetchError } = await supabase
       .from('bookings')
       .select(`
@@ -36,7 +36,8 @@ Deno.serve(async (req: Request) => {
         service:services (title, host:profiles!services_provider_id_fkey (email))
       `)
       .eq('status', 'pending')
-      .lt('created_at', new Date(Date.now() - EXPIRY_HOURS * 60 * 60 * 1000).toISOString())
+      .lt('payment_expires_at', new Date().toISOString())
+      .not('payment_expires_at', 'is', null)
 
     if (fetchError) throw fetchError
     if (!expiredBookings || expiredBookings.length === 0) {

--- a/supabase/functions/create-checkout-session/deno.json
+++ b/supabase/functions/create-checkout-session/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "stripe": "npm:stripe@17",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,0 +1,91 @@
+// @ts-ignore
+import Stripe from 'npm:stripe@17'
+// @ts-ignore
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+declare const Deno: any
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY'), {
+  apiVersion: '2025-01-27.acacia',
+})
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL'),
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+)
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const PAYMENT_WINDOW_MINUTES = 15
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { items, userId, email, origin } = await req.json()
+
+    if (!items?.length || !userId || !origin) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required fields' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Stripe Checkout Session (min expires_at = 30 min)
+    const expiresAt = Math.floor(Date.now() / 1000) + 30 * 60
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      customer_email: email,
+      expires_at: expiresAt,
+      line_items: items.map((item: any) => ({
+        price_data: {
+          currency: 'eur',
+          product_data: {
+            name: item.title,
+            ...(item.image ? { images: [item.image] } : {}),
+          },
+          unit_amount: Math.round(item.price * 100), // cents
+        },
+        quantity: 1,
+      })),
+      success_url: `${origin}/booking/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/checkout`,
+      metadata: {
+        userId,
+        bookingIds: items.map((i: any) => i.bookingId).join(','),
+      },
+    })
+
+    // Сохраняем stripe_session_id и payment_expires_at во все брони этого чекаута
+    const paymentExpiresAt = new Date(Date.now() + PAYMENT_WINDOW_MINUTES * 60 * 1000).toISOString()
+    const bookingIds = items.map((i: any) => i.bookingId).filter(Boolean)
+
+    if (bookingIds.length > 0) {
+      await supabase
+        .from('bookings')
+        .update({
+          stripe_session_id: session.id,
+          payment_expires_at: paymentExpiresAt,
+        })
+        .in('id', bookingIds)
+    }
+
+    return new Response(
+      JSON.stringify({ url: session.url }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error: any) {
+    console.error('create-checkout-session error:', error)
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})

--- a/supabase/functions/stripe-checkout/README.md
+++ b/supabase/functions/stripe-checkout/README.md
@@ -1,0 +1,158 @@
+# Stripe Checkout + 15-Minute Payment Window
+
+Automated Stripe payment integration with 15-minute payment window for pending bookings.
+
+## Architecture
+
+```
+User creates booking (pending)
+  → Checkout Page
+    → create-checkout-session Edge Function
+      → Stripe Checkout Session (expires in 30 min)
+      → Update bookings: stripe_session_id, payment_expires_at (+15 min)
+        → Redirect to Stripe Checkout
+
+User completes payment
+  → Stripe webhook → stripe-webhook Edge Function
+    → checkout.session.completed event
+    → Update bookings: status='confirmed', payment_status='paid'
+    → Send booking_confirmed email to guest
+
+User doesn't pay within 15 minutes
+  → pg_cron (every 5 minutes) → cancel-expired-bookings Edge Function
+    → Cancel bookings where payment_expires_at < NOW()
+    → Send booking_expired_guest email
+```
+
+## Setup Instructions
+
+### Шаг 1 — Применить миграцию БД
+
+```bash
+supabase db push
+```
+
+Или через Dashboard: **SQL Editor** → выполнить содержимое файла:  
+`supabase/migrations/20260401000000_add_stripe_session_id.sql`
+
+Это добавит колонки:
+- `stripe_session_id` — для поиска брони по вебхуку
+- `payment_expires_at` — момент автоматической отмены брони
+
+### Шаг 2 — Задеплоить Edge Functions
+
+```bash
+# Create Checkout Session function
+supabase functions deploy create-checkout-session
+
+# Stripe Webhook function
+supabase functions deploy stripe-webhook
+```
+
+### Шаг 3 — Добавить секреты в Supabase Dashboard
+
+Перейти: **Dashboard → Edge Functions → Secrets**
+
+Добавить:
+```
+STRIPE_SECRET_KEY       = sk_live_...   (или sk_test_... для теста)
+STRIPE_WEBHOOK_SECRET   = whsec_...
+```
+
+### Шаг 4 — Настроить Stripe Webhook
+
+В **Stripe Dashboard → Developers → Webhooks** добавить endpoint:
+
+```
+https://<PROJECT_REF>.supabase.co/functions/v1/stripe-webhook
+```
+
+**Событие:** `checkout.session.completed`
+
+Скопировать **Signing secret** (начинается с `whsec_...`) — это и есть `STRIPE_WEBHOOK_SECRET` для Шага 3.
+
+### Шаг 5 — Применить миграцию кронджоба
+
+```bash
+supabase db push
+```
+
+Или через Dashboard: **SQL Editor** → выполнить содержимое файла:  
+`supabase/migrations/20260401000001_update_cron_schedule.sql`
+
+Это изменит расписание с каждого часа на **каждые 5 минут**.
+
+### Шаг 6 — Проверить что всё работает
+
+**В SQL Editor:**
+
+```sql
+-- Посмотреть все cron jobs
+select * from cron.job;
+
+-- Посмотреть историю запусков
+select * from cron.job_run_details order by start_time desc limit 10;
+```
+
+**Тестовый сценарий:**
+1. Создать бронирование на сайте
+2. Перейти к оплате
+3.完成тить оплату через Stripe Test Mode
+4. Проверить что booking.status = 'confirmed'
+5. Проверить что email отправлен
+
+## Configuration
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `PAYMENT_WINDOW_MINUTES` | 15 | Время на оплату после создания брони |
+| Stripe `expires_at` | 30 min | Минимальное время жизни сессии (Stripe requirement) |
+| Cron Schedule | `*/5 * * * *` | Проверка каждые 5 минут |
+| Cancelled bookings | Только с `payment_expires_at` | Брони без Stripe не затрагиваются |
+
+## Frontend Integration
+
+### Вызов create-checkout-session
+
+```typescript
+const { data } = await supabase.functions.invoke('create-checkout-session', {
+  body: {
+    items: [
+      {
+        title: 'Property Name',
+        price: 500,
+        image: 'https://...',
+        bookingId: 'uuid-here'
+      }
+    ],
+    userId: user.id,
+    email: user.email,
+    origin: window.location.origin
+  }
+})
+
+// Redirect to Stripe
+window.location.href = data.url
+```
+
+## Files Created/Modified
+
+| File | Purpose |
+|------|---------|
+| `supabase/migrations/20260401000000_add_stripe_session_id.sql` | DB schema |
+| `supabase/migrations/20260401000001_update_cron_schedule.sql` | Cron schedule |
+| `supabase/functions/create-checkout-session/index.ts` | Create Stripe session |
+| `supabase/functions/stripe-webhook/index.ts` | Handle webhook |
+| `supabase/functions/cancel-expired-bookings/index.ts` | Updated for 15-min window |
+
+## Summary
+
+| Что | Где |
+|-----|-----|
+| DB Schema | `bookings` table (stripe_session_id, payment_expires_at) |
+| Checkout Session | `create-checkout-session` Edge Function |
+| Webhook Handler | `stripe-webhook` Edge Function |
+| Payment Window | 15 минут (константа `PAYMENT_WINDOW_MINUTES`) |
+| Cron Schedule | Каждые 5 минут (`*/5 * * * *`) |
+| Email on Success | `booking_confirmed` (через `send-email`) |
+| Email on Expire | `booking_expired_guest` (через `send-email`) |

--- a/supabase/functions/stripe-webhook/deno.json
+++ b/supabase/functions/stripe-webhook/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "stripe": "npm:stripe@17",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,94 @@
+// @ts-ignore
+import Stripe from 'npm:stripe@17'
+// @ts-ignore
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+declare const Deno: any
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY'), {
+  apiVersion: '2025-01-27.acacia',
+})
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL'),
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+)
+
+Deno.serve(async (req: Request) => {
+  const signature = req.headers.get('stripe-signature')
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET')
+  const body = await req.text()
+
+  let event: Stripe.Event
+
+  try {
+    event = await stripe.webhooks.constructEventAsync(body, signature!, webhookSecret)
+  } catch (err: any) {
+    console.error('Webhook signature verification failed:', err.message)
+    return new Response(`Webhook Error: ${err.message}`, { status: 400 })
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session
+
+    if (session.payment_status === 'paid') {
+      const bookingIds = session.metadata?.bookingIds?.split(',').filter(Boolean) ?? []
+
+      if (bookingIds.length > 0) {
+        const { error } = await supabase
+          .from('bookings')
+          .update({
+            status: 'confirmed',
+            payment_status: 'paid',
+          })
+          .in('id', bookingIds)
+
+        if (error) {
+          console.error('Failed to confirm bookings:', error)
+          return new Response('DB update failed', { status: 500 })
+        }
+
+        console.warn(`Confirmed bookings: ${bookingIds.join(', ')}`)
+
+        // Отправляем email гостю по каждой брони
+        for (const bookingId of bookingIds) {
+          const { data: booking } = await supabase
+            .from('bookings')
+            .select(`
+              check_in, check_out, guests,
+              property:properties(title),
+              service:services(title),
+              profile:profiles!bookings_user_id_fkey(email)
+            `)
+            .eq('id', bookingId)
+            .single()
+
+          if (booking) {
+            const itemTitle = (booking.property as any)?.title ?? (booking.service as any)?.title ?? 'Booking'
+            const guestEmail = (booking.profile as any)?.email
+
+            if (guestEmail) {
+              await supabase.functions.invoke('send-email', {
+                body: {
+                  to: guestEmail,
+                  type: 'booking_confirmed',
+                  data: {
+                    itemTitle,
+                    checkIn: booking.check_in,
+                    checkOut: booking.check_out,
+                    guests: String(booking.guests ?? 1),
+                    link: `${Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'}/profile`,
+                  },
+                },
+              }).catch((e: any) => console.error('Email send failed:', e))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+})

--- a/supabase/migrations/20260401000000_add_stripe_session_id.sql
+++ b/supabase/migrations/20260401000000_add_stripe_session_id.sql
@@ -1,0 +1,10 @@
+-- Add Stripe payment columns to bookings table
+
+alter table bookings
+  add column if not exists stripe_session_id text,
+  add column if not exists payment_expires_at timestamptz;
+
+create index if not exists bookings_stripe_session_id_idx on bookings (stripe_session_id);
+
+-- Comment: stripe_session_id is used for webhook lookup
+-- payment_expires_at is the time when the booking auto-cancels (15 minutes for Stripe payments)

--- a/supabase/migrations/20260401000001_update_cron_schedule.sql
+++ b/supabase/migrations/20260401000001_update_cron_schedule.sql
@@ -1,0 +1,32 @@
+-- Update cron schedule to run every 5 minutes instead of every hour
+-- This is needed for 15-minute payment window enforcement
+
+-- First, unschedule the existing job
+select cron.unschedule('cancel-expired-bookings');
+
+-- Reschedule to run every 5 minutes
+select
+  cron.schedule(
+    'cancel-expired-bookings',
+    '*/5 * * * *',  -- every 5 minutes
+    $$
+    select
+      net.http_post(
+        url := (
+          select decrypted_secret
+          from vault.decrypted_secrets
+          where name = 'project_url'
+        ) || '/functions/v1/cancel-expired-bookings',
+        headers := jsonb_build_object(
+          'Content-Type',  'application/json',
+          'Authorization', 'Bearer ' || (
+            select decrypted_secret
+            from vault.decrypted_secrets
+            where name = 'anon_key'
+          )
+        ),
+        body := jsonb_build_object('triggered_at', now()),
+        timeout_milliseconds := 30000
+      ) as request_id;
+    $$
+  );


### PR DESCRIPTION
## Summary

Implements Stripe Checkout with a 15-minute payment window for pending bookings.

- **`create-checkout-session`** — new Edge Function that creates a Stripe Checkout Session, saves `stripe_session_id` and `payment_expires_at` (+15 min) to the booking
- **`stripe-webhook`** — new Edge Function that verifies Stripe signature on `checkout.session.completed` and sets booking `status=confirmed`, `payment_status=paid`, sends confirmation email
- **`cancel-expired-bookings`** — updated to cancel bookings based on `payment_expires_at` column instead of `created_at + 24h`; only affects Stripe bookings (cash/bank bookings untouched)
- **Migration** — adds `stripe_session_id` and `payment_expires_at` columns to `bookings`
- **Cron** — updated from every hour to every 5 minutes to enforce the 15-min window

## Flow

```
Booking created (pending) → create-checkout-session → Stripe page
  ↳ Paid → stripe-webhook → confirmed + email
  ↳ Not paid in 15 min → cron → cancelled + email
```

## Before merging

- Apply migrations via `supabase db push`
- Add `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` to Supabase Edge Functions secrets
- Register webhook endpoint in Stripe Dashboard (`/functions/v1/stripe-webhook`, event: `checkout.session.completed`)
- Deploy functions: `supabase functions deploy create-checkout-session && supabase functions deploy stripe-webhook`