### PR TITLE
fix: CheckoutPaymentSection — extract payment config, copy feedback, CSS cleanup

### DIFF
--- a/components/auth/LoginModal.test.tsx
+++ b/components/auth/LoginModal.test.tsx
@@ -65,8 +65,6 @@ vi.mock('../ui/Modal', () => ({
     }
 }));
 
-import { useModal } from '../../context/ModalContext';
-import { useSubmitShortcut } from '../../hooks/useSubmitShortcut';
 import toast from 'react-hot-toast';
 
 const mockCloseModal = vi.fn();

--- a/components/auth/RegisterModal.test.tsx
+++ b/components/auth/RegisterModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { RegisterModal } from './RegisterModal';
 
@@ -66,8 +66,6 @@ vi.mock('../ui/Modal', () => ({
     }
 }));
 
-import { useModal } from '../../context/ModalContext';
-import { useSubmitShortcut } from '../../hooks/useSubmitShortcut';
 import { supabase } from '../../api-services/supabase';
 
 const mockCloseModal = vi.fn();

--- a/components/checkout/CheckoutPaymentSection.test.tsx
+++ b/components/checkout/CheckoutPaymentSection.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { CheckoutPaymentSection } from './CheckoutPaymentSection';
+import { PAYMENT_DETAILS } from '../../data/payment';
 
 // Mock useLanguage
 vi.mock('../../context/LanguageContext', () => ({
@@ -16,7 +17,8 @@ vi.mock('lucide-react', () => ({
     Banknote: ({ className }: any) => <svg data-testid="banknote-icon" className={className} />,
     Shield: ({ className }: any) => <svg data-testid="shield-icon" className={className} />,
     Bitcoin: ({ className }: any) => <svg data-testid="bitcoin-icon" className={className} />,
-    Copy: ({ className, size }: any) => <svg data-testid="copy-icon" className={className} width={size} height={size} />
+    Copy: ({ className, size }: any) => <svg data-testid="copy-icon" className={className} width={size} height={size} />,
+    Check: ({ className, size }: any) => <svg data-testid="check-icon" className={className} width={size} height={size} />
 }));
 
 // Mock navigator.clipboard
@@ -45,6 +47,11 @@ describe('CheckoutPaymentSection', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockWriteText.mockClear();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     describe('Rendering', () => {
@@ -184,96 +191,100 @@ describe('CheckoutPaymentSection', () => {
             renderComponent({ paymentMethod: 'bank' });
 
             expect(screen.getByText('checkout.method.bank_desc')).toBeInTheDocument();
-            expect(screen.getByText('Ziraat Bankası')).toBeInTheDocument();
-            expect(screen.getByText('Alanya Holidays Ltd.')).toBeInTheDocument();
-            expect(screen.getByText('TR12 3456 7890 1234 5678 9012 34')).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.bank.name)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.bank.accountHolder)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.bank.iban)).toBeInTheDocument();
         });
 
         it('shows crypto payment instruction with details', () => {
             renderComponent({ paymentMethod: 'crypto' });
 
             expect(screen.getByText('checkout.method.crypto_desc')).toBeInTheDocument();
-            expect(screen.getByText('TRC20 (Tron)')).toBeInTheDocument();
-            expect(screen.getByText(/USDT Address/)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.crypto.network)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.crypto.address)).toBeInTheDocument();
         });
 
         it('shows swift payment instruction with details', () => {
             renderComponent({ paymentMethod: 'swift' });
 
             expect(screen.getByText('checkout.method.swift_desc')).toBeInTheDocument();
-            expect(screen.getByText('Garanti BBVA')).toBeInTheDocument();
-            expect(screen.getByText('GATRTRI2')).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.swift.bankName)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.swift.bic)).toBeInTheDocument();
+            expect(screen.getByText(PAYMENT_DETAILS.swift.iban)).toBeInTheDocument();
         });
 
         it('shows copy button for bank IBAN', () => {
             renderComponent({ paymentMethod: 'bank' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             expect(copyButtons.length).toBeGreaterThan(0);
         });
 
         it('shows copy button for crypto address', () => {
             renderComponent({ paymentMethod: 'crypto' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             expect(copyButtons.length).toBeGreaterThan(0);
         });
 
         it('shows copy button for swift BIC', () => {
             renderComponent({ paymentMethod: 'swift' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             expect(copyButtons.length).toBeGreaterThan(0);
         });
     });
 
     describe('Copy to Clipboard', () => {
-        it('copies bank IBAN to clipboard', async () => {
+        it('copies bank IBAN to clipboard and shows feedback', async () => {
             mockWriteText.mockResolvedValue(undefined);
             renderComponent({ paymentMethod: 'bank' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             fireEvent.click(copyButtons[0]);
 
-            await waitFor(() => {
-                expect(mockWriteText).toHaveBeenCalledWith('TR12 3456 7890 1234 5678 9012 34');
+            expect(mockWriteText).toHaveBeenCalledWith(PAYMENT_DETAILS.bank.iban);
+            expect(screen.getByText('Copied!')).toBeInTheDocument();
+            expect(screen.getByTestId('check-icon')).toBeInTheDocument();
+
+            // Feedback should disappear after 2 seconds
+            act(() => {
+                vi.advanceTimersByTime(2000);
             });
+            expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
         });
 
         it('copies crypto address to clipboard', async () => {
             mockWriteText.mockResolvedValue(undefined);
             renderComponent({ paymentMethod: 'crypto' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             fireEvent.click(copyButtons[0]);
 
-            await waitFor(() => {
-                expect(mockWriteText).toHaveBeenCalledWith('TVj7...ExampleAddress...xYz');
-            });
+            expect(mockWriteText).toHaveBeenCalledWith(PAYMENT_DETAILS.crypto.address);
+            expect(screen.getByText('Copied!')).toBeInTheDocument();
         });
 
         it('copies swift BIC to clipboard', async () => {
             mockWriteText.mockResolvedValue(undefined);
             renderComponent({ paymentMethod: 'swift' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             fireEvent.click(copyButtons[0]);
 
-            await waitFor(() => {
-                expect(mockWriteText).toHaveBeenCalledWith('GATRTRI2');
-            });
+            expect(mockWriteText).toHaveBeenCalledWith(PAYMENT_DETAILS.swift.bic);
+            expect(screen.getByText('Copied!')).toBeInTheDocument();
         });
 
         it('copies swift IBAN to clipboard', async () => {
             mockWriteText.mockResolvedValue(undefined);
             renderComponent({ paymentMethod: 'swift' });
 
-            const copyButtons = screen.getAllByTestId('copy-icon');
+            const copyButtons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
             fireEvent.click(copyButtons[1]);
 
-            await waitFor(() => {
-                expect(mockWriteText).toHaveBeenCalledWith('TR00 1234 5678 9000 0000 0000 00');
-            });
+            expect(mockWriteText).toHaveBeenCalledWith(PAYMENT_DETAILS.swift.iban);
+            expect(screen.getByText('Copied!')).toBeInTheDocument();
         });
     });
 
@@ -344,9 +355,8 @@ describe('CheckoutPaymentSection', () => {
 
             const payButton = screen.getByTestId('pay-button');
             expect(payButton).toHaveClass('bg-teal-700');
+            expect(payButton).toHaveClass('dark:bg-cyan-600');
             expect(payButton).toHaveClass('font-bold');
-            expect(payButton).toHaveClass('py-4');
-            expect(payButton).toHaveClass('rounded-xl');
         });
     });
 
@@ -413,9 +423,11 @@ describe('CheckoutPaymentSection', () => {
         it('renders copy icons with proper size', () => {
             renderComponent({ paymentMethod: 'bank' });
 
-            const copyIcons = screen.getAllByTestId('copy-icon');
-            expect(copyIcons[0]).toHaveAttribute('width', '12');
-            expect(copyIcons[0]).toHaveAttribute('height', '12');
+            const copyIcons = screen.getAllByRole('button').filter(b => b.title === 'checkout.copy');
+            // Check size of the first svg child of the button
+            const firstSvg = copyIcons[0].querySelector('svg');
+            expect(firstSvg).toHaveAttribute('width', '12');
+            expect(firstSvg).toHaveAttribute('height', '12');
         });
     });
 

--- a/components/checkout/CheckoutPaymentSection.tsx
+++ b/components/checkout/CheckoutPaymentSection.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { CreditCard, Banknote, Shield, Bitcoin, Copy } from 'lucide-react';
+import { CreditCard, Banknote, Shield, Bitcoin, Copy, Check } from 'lucide-react';
 import { useLanguage } from '../../context/LanguageContext';
+import { PAYMENT_DETAILS } from '../../data/payment';
 
 type PaymentMethod = 'card' | 'bank' | 'crypto' | 'cash' | 'swift';
 
@@ -24,13 +25,24 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
     isDisabled
 }) => {
     const { t } = useLanguage();
-    const [_copied, setCopied] = useState(false);
+    const [copiedId, setCopiedId] = useState<string | null>(null);
 
-    const copyToClipboard = (text: string) => {
+    const copyToClipboard = (text: string, id: string) => {
         navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        setCopiedId(id);
+        setTimeout(() => setCopiedId(null), 2000);
     };
+
+    const CopyButton = ({ text, id }: { text: string; id: string }) => (
+        <button
+            onClick={() => copyToClipboard(text, id)}
+            className="flex items-center gap-1 text-teal-600 dark:text-cyan-400 dark:hover:text-cyan-300 hover:text-teal-800 transition-colors"
+            title={t('checkout.copy')}
+        >
+            {copiedId === id ? <Check size={12} className="text-green-500" /> : <Copy size={12} />}
+            {copiedId === id && <span className="text-[10px] font-bold text-green-500">Copied!</span>}
+        </button>
+    );
 
     return (
         <div className="bg-white dark:bg-slate-800/80 rounded-xl shadow-sm border border-slate-200 dark:border-slate-800/50 p-6">
@@ -47,12 +59,12 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
                         key={method.id}
                         onClick={() => setPaymentMethod(method.id as PaymentMethod)}
                         className={`p-4 rounded-xl border-2 flex flex-col items-center gap-2 transition ${paymentMethod === method.id
-                            ? 'border-teal-600 bg-teal-50 dark:bg-slate-800/50 text-teal-700 dark:text-cyan-400 dark:text-slate-200'
+                            ? 'border-teal-600 bg-teal-50 dark:bg-slate-800/50 text-teal-700 dark:text-cyan-400'
                             : 'border-slate-200 dark:border-slate-800/50 bg-white dark:bg-slate-800/80 hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-slate-700/80'
                             } ${method.id === 'swift' ? 'col-span-2 sm:col-span-1' : ''}`}
                     >
-                        <method.icon className={paymentMethod === method.id ? 'text-teal-600 dark:text-cyan-400 dark:text-slate-200' : 'text-slate-400 dark:text-slate-400'} />
-                        <span className={`text-sm font-bold ${paymentMethod === method.id ? 'text-teal-700 dark:text-cyan-400 dark:text-slate-200' : 'text-slate-600 dark:text-slate-300'}`}>{t(method.label)}</span>
+                        <method.icon className={paymentMethod === method.id ? 'text-teal-600 dark:text-cyan-400' : 'text-slate-400 dark:text-slate-400'} />
+                        <span className={`text-sm font-bold ${paymentMethod === method.id ? 'text-teal-700 dark:text-cyan-400' : 'text-slate-600 dark:text-slate-300'}`}>{t(method.label)}</span>
                     </button>
                 ))}
             </div>
@@ -76,21 +88,21 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
 
             {paymentMethod === 'bank' && (
                 <div className="p-4 border border-teal-100 dark:border-slate-700/50 rounded-lg bg-teal-50 dark:bg-slate-800/50 mb-4 animate-in fade-in slide-in-from-top-2">
-                    <p className="text-sm text-teal-800 dark:text-cyan-400 dark:text-slate-200 font-medium mb-2">{t('checkout.method.bank_desc')}</p>
+                    <p className="text-sm text-teal-800 dark:text-cyan-400 font-medium mb-2">{t('checkout.method.bank_desc')}</p>
                     <div className="space-y-2 text-xs bg-white dark:bg-slate-900 p-3 rounded border border-teal-100 dark:border-slate-700/50">
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">Bank Name</span>
-                            <span className="font-semibold text-slate-700 dark:text-slate-300">Ziraat Bankası</span>
+                            <span className="font-semibold text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.bank.name}</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">Account Holder</span>
-                            <span className="font-semibold text-slate-700 dark:text-slate-300">Alanya Holidays Ltd.</span>
+                            <span className="font-semibold text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.bank.accountHolder}</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">IBAN</span>
                             <div className="flex items-center gap-2">
-                                <code className="font-mono text-slate-700 dark:text-slate-300">TR12 3456 7890 1234 5678 9012 34</code>
-                                <button onClick={() => copyToClipboard('TR12 3456 7890 1234 5678 9012 34')} className="text-teal-600 dark:text-cyan-400 dark:text-slate-200 hover:text-teal-800 dark:text-cyan-400 dark:hover:text-teal-300"><Copy size={12} /></button>
+                                <code className="font-mono text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.bank.iban}</code>
+                                <CopyButton text={PAYMENT_DETAILS.bank.iban} id="bank-iban" />
                             </div>
                         </div>
                     </div>
@@ -103,13 +115,15 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
                     <div className="space-y-2 text-xs bg-white dark:bg-slate-900 p-3 rounded border border-indigo-100 dark:border-indigo-900">
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">Network</span>
-                            <span className="font-semibold text-slate-700 dark:text-slate-300">TRC20 (Tron)</span>
+                            <span className="font-semibold text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.crypto.network}</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">USDT Address</span>
                             <div className="flex items-center gap-2">
-                                <code className="font-mono text-slate-700 dark:text-slate-300 truncate max-w-[200px]">TVj...xYz</code>
-                                <button onClick={() => copyToClipboard('TVj7...ExampleAddress...xYz')} className="text-indigo-600 dark:text-slate-200 hover:text-indigo-800 dark:hover:text-indigo-300"><Copy size={12} /></button>
+                                <code className="font-mono text-slate-700 dark:text-slate-300 truncate max-w-[150px]" title={PAYMENT_DETAILS.crypto.address}>
+                                    {PAYMENT_DETAILS.crypto.address}
+                                </code>
+                                <CopyButton text={PAYMENT_DETAILS.crypto.address} id="crypto-addr" />
                             </div>
                         </div>
                         <p className="text-[10px] text-amber-600 mt-1">⚠️ Please ensure you send only USDT on the TRC20 network.</p>
@@ -123,20 +137,20 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
                     <div className="space-y-2 text-xs bg-white dark:bg-slate-900 p-3 rounded border border-blue-100 dark:border-slate-700/50">
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">{t('checkout.bank_name')}</span>
-                            <span className="font-semibold text-slate-700 dark:text-slate-300">Garanti BBVA</span>
+                            <span className="font-semibold text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.swift.bankName}</span>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">{t('checkout.swift_bic')}</span>
                             <div className="flex items-center gap-2">
-                                <code className="font-mono text-slate-700 dark:text-slate-300">GATRTRI2</code>
-                                <button onClick={() => copyToClipboard('GATRTRI2')} className="text-blue-600 hover:text-blue-700"><Copy size={12} /></button>
+                                <code className="font-mono text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.swift.bic}</code>
+                                <CopyButton text={PAYMENT_DETAILS.swift.bic} id="swift-bic" />
                             </div>
                         </div>
                         <div className="flex justify-between items-center">
                             <span className="text-slate-500">{t('checkout.iban')}</span>
                             <div className="flex items-center gap-2">
-                                <code className="font-mono text-slate-700 dark:text-slate-300">TR00 1234 5678 9000 0000 0000 00</code>
-                                <button onClick={() => copyToClipboard('TR00 1234 5678 9000 0000 0000 00')} className="text-blue-600 hover:text-blue-700"><Copy size={12} /></button>
+                                <code className="font-mono text-slate-700 dark:text-slate-300">{PAYMENT_DETAILS.swift.iban}</code>
+                                <CopyButton text={PAYMENT_DETAILS.swift.iban} id="swift-iban" />
                             </div>
                         </div>
                         <p className="pt-2 text-[10px] text-slate-400 italic">{t('checkout.swift_ref')}</p>
@@ -148,7 +162,7 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
                 onClick={onPay}
                 disabled={isDisabled || isProcessing}
                 data-testid="pay-button"
-                className="w-full bg-teal-700 dark:bg-cyan-600 dark:bg-slate-800/50 text-white font-bold py-4 rounded-xl border-2 border-transparent hover:border-teal-500 dark:hover:border-teal-400 hover:bg-teal-800 dark:bg-cyan-600 dark:hover:bg-teal-700 dark:bg-cyan-600 shadow-lg active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="w-full bg-teal-700 dark:bg-cyan-600 text-white font-bold py-4 rounded-xl border-2 border-transparent hover:border-teal-500 dark:hover:border-cyan-400 hover:bg-teal-800 dark:hover:bg-cyan-700 shadow-lg active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
                 {isProcessing ? (
                     <>Processing...</>
@@ -161,3 +175,4 @@ export const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
         </div>
     );
 };
+

--- a/data/payment.ts
+++ b/data/payment.ts
@@ -1,0 +1,16 @@
+export const PAYMENT_DETAILS = {
+  bank: {
+    name: "Ziraat Bankası",
+    accountHolder: "Alanya Holidays Ltd.",
+    iban: "TR12 3456 7890 1234 5678 9012 34" // Replace with real IBAN
+  },
+  swift: {
+    bankName: "Garanti BBVA",
+    bic: "GATRTRI2", // Replace with real SWIFT/BIC
+    iban: "TR00 1234 5678 9000 0000 0000 00" // Replace with real IBAN
+  },
+  crypto: {
+    network: "TRC20 (Tron)",
+    address: "TVj7R1...PLEASE_UPDATE_ADDRESS...xYz" // Replace with real TRC20 USDT address
+  }
+};

--- a/pages/booking/BookTour.test.tsx
+++ b/pages/booking/BookTour.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../context/CartContext', () => ({
 // Mock Currency Context
 vi.mock('../../context/CurrencyContext', () => ({
     useCurrency: () => ({
-        convertPrice: (price: number, currency: string) => price,
+        convertPrice: (price: number, _currency: string) => price,
         formatPrice: (price: number) => `€${price}`
     })
 }));
@@ -53,7 +53,7 @@ vi.mock('react-router-dom', async () => {
 // Mock DatePicker
 vi.mock('react-datepicker', () => ({
     __esModule: true,
-    default: ({ selected, onChange, minDate, placeholderText, dateFormat, locale, customInput }: any) => (
+    default: ({ selected, onChange, _minDate, placeholderText, _dateFormat, _locale, _customInput }: any) => (
         <input
             type="text"
             data-testid="date-picker"

--- a/pages/booking/BookVehicle.test.tsx
+++ b/pages/booking/BookVehicle.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../api-services', () => ({
 // Mock Currency Context
 vi.mock('../../context/CurrencyContext', () => ({
     useCurrency: () => ({
-        convertPrice: (price: number, currency: string) => price,
+        convertPrice: (price: number, _currency: string) => price,
         formatPrice: (price: number) => `€${price}`
     })
 }));
@@ -41,7 +41,7 @@ vi.mock('react-router-dom', async () => {
 // Mock DatePicker
 vi.mock('react-datepicker', () => ({
     __esModule: true,
-    default: ({ selected, onChange, minDate, placeholderText, dateFormat, locale, customInput, selectsStart, selectsEnd, startDate, endDate }: any) => (
+    default: ({ selected, onChange, _minDate, placeholderText, _dateFormat, _locale, _customInput, selectsStart, selectsEnd, _startDate, _endDate }: any) => (
         <input
             type="text"
             data-testid={selectsStart ? 'start-date-picker' : selectsEnd ? 'end-date-picker' : 'date-picker'}

--- a/pages/booking/BookWellness.test.tsx
+++ b/pages/booking/BookWellness.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../api-services', () => ({
 // Mock Currency Context
 vi.mock('../../context/CurrencyContext', () => ({
     useCurrency: () => ({
-        convertPrice: (price: number, currency: string) => price,
+        convertPrice: (price: number, _currency: string) => price,
         formatPrice: (price: number) => `€${price}`
     })
 }));
@@ -41,7 +41,7 @@ vi.mock('react-router-dom', async () => {
 // Mock DatePicker
 vi.mock('react-datepicker', () => ({
     __esModule: true,
-    default: ({ selected, onChange, minDate, placeholderText, dateFormat, locale, customInput }: any) => (
+    default: ({ selected, onChange, _minDate, placeholderText, _dateFormat, _locale, _customInput }: any) => (
         <input
             type="text"
             data-testid="date-picker"

--- a/pages/booking/Success.test.tsx
+++ b/pages/booking/Success.test.tsx
@@ -13,9 +13,9 @@ vi.mock('../../context/LanguageContext', () => ({
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
-    CheckCircle: ({ size, className }: any) => <svg data-testid="check-circle-icon" className={className} />,
-    Home: ({ size, className }: any) => <svg data-testid="home-icon" className={className} />,
-    Calendar: ({ size, className }: any) => <svg data-testid="calendar-icon" className={className} />
+    CheckCircle: ({ _size, className }: any) => <svg data-testid="check-circle-icon" className={className} />,
+    Home: ({ _size, className }: any) => <svg data-testid="home-icon" className={className} />,
+    Calendar: ({ _size, className }: any) => <svg data-testid="calendar-icon" className={className} />
 }));
 
 // Mock react-router-dom

--- a/supabase/functions/stripe.test.ts
+++ b/supabase/functions/stripe.test.ts
@@ -25,10 +25,10 @@ describe('Stripe Edge Functions - Logic Tests', () => {
     const mockStripeCreate = vi.fn();
     
     // Mock Supabase
-    const mockSupabaseUpdate = vi.fn();
+    const _mockSupabaseUpdate = vi.fn();
     const mockSupabaseIn = vi.fn();
-    
-    const mockSupabaseFrom = vi.fn(() => ({
+
+    const _mockSupabaseFrom = vi.fn(() => ({
       update: vi.fn(() => ({
         in: mockSupabaseIn,
       })),
@@ -269,7 +269,7 @@ describe('Stripe Edge Functions - Logic Tests', () => {
   describe('stripe-webhook', () => {
     // Mock Supabase
     const mockSupabaseUpdate = vi.fn();
-    const mockSupabaseIn = vi.fn();
+    const _mockSupabaseIn = vi.fn();
     const mockSupabaseSingle = vi.fn();
     const mockSupabaseFunctionsInvoke = vi.fn();
 


### PR DESCRIPTION
## Summary

- Extracted hardcoded IBAN, SWIFT, crypto address into `data/payment.ts` — теперь меняется в одном месте
- Починен фидбек копирования: кнопка показывает иконку ✓ + "Copied!" на 2 секунды
- Исправлена несоответствие крипто-адреса (отображался `TVj...xYz`, копировался другой)
- Убраны дублирующиеся и конфликтующие `dark:bg-*` классы на кнопке Pay

## Risks

- `data/payment.ts` содержит placeholder-значения — **нужно заменить на реальные реквизиты перед продом**

## Testing

- 48 тестов в `CheckoutPaymentSection.test.tsx` — все проходят