### PR TITLE
fix: resolve ESLint warnings blocking CI

### DIFF
--- a/api-services/api/bookings.integration.test.ts
+++ b/api-services/api/bookings.integration.test.ts
@@ -232,7 +232,7 @@ describe('cancelBooking', () => {
         });
 
         // Второй пользователь пытается обновить чужую бронь
-        const { data, error } = await otherClient
+        const { data, error: _error } = await otherClient
             .from('bookings')
             .update({ status: 'cancelled' })
             .eq('id', bookingId)

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -73,8 +73,6 @@ Deno.serve(async (req: Request) => {
 
             if (guestEmail) {
               const maxRetries = 3
-              let lastError: any
-
               for (let attempt = 1; attempt <= maxRetries; attempt++) {
                 try {
                   await supabase.functions.invoke('send-email', {
@@ -90,10 +88,8 @@ Deno.serve(async (req: Request) => {
                       },
                     },
                   })
-                  console.log(`Email sent successfully for booking ${booking.id}`)
                   break
                 } catch (e: any) {
-                  lastError = e
                   if (attempt < maxRetries) {
                     const delayMs = Math.pow(2, attempt) * 1000
                     console.warn(`Email send failed for booking ${booking.id}, attempt ${attempt}/${maxRetries}. Retrying in ${delayMs}ms...`)

--- a/supabase/functions/stripe.integration.test.ts
+++ b/supabase/functions/stripe.integration.test.ts
@@ -21,7 +21,7 @@ import { createClient } from '@supabase/supabase-js';
 // Use test Supabase instance
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || 'http://localhost:54321';
 const SUPABASE_SERVICE_ROLE_KEY = import.meta.env.SUPABASE_SERVICE_ROLE_KEY || 'test-key';
-const STRIPE_SECRET_KEY = import.meta.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+const _STRIPE_SECRET_KEY = import.meta.env.STRIPE_SECRET_KEY || 'sk_test_mock';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 


### PR DESCRIPTION
## Summary

- Убран `console.log` в `stripe-webhook/index.ts` (заменён на `break` — лог был избыточен)
- Убран неиспользуемый `lastError` в `stripe-webhook/index.ts`
- Переименован `error` → `_error` в `bookings.integration.test.ts`
- Переименован `STRIPE_SECRET_KEY` → `_STRIPE_SECRET_KEY` в `stripe.integration.test.ts`

ESLint: 0 errors, 0 warnings