### PR TITLE
fix: security audit — Yesim token in header + service_edits field sanitization

### DIFF
--- a/api-services/api/services.ts
+++ b/api-services/api/services.ts
@@ -6,6 +6,11 @@ import { getAppUrl } from '../../utils/appUrl';
 import { retry } from '../../utils/retry';
 import { createAuditLog } from './audit';
 
+// Fields that must never be overwritten via service_edits
+const IMMUTABLE_SERVICE_FIELDS = new Set([
+    'id', 'provider_id', 'status', 'created_at', 'updated_at'
+]);
+
 export const servicesService = {
     async createService(data: Omit<ServiceDB, 'id' | 'created_at'>) {
         const validatedData = serviceSchema.parse(data);
@@ -351,10 +356,18 @@ export const servicesService = {
         if (fetchError) throw fetchError;
         if (!edit) throw new Error('Edit not found');
 
-        // 2. Apply changes to service
+        // 2. Sanitize changed_data — strip immutable fields
+        const safeChanges: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(edit.changed_data)) {
+            if (!IMMUTABLE_SERVICE_FIELDS.has(key)) {
+                safeChanges[key] = value;
+            }
+        }
+
+        // 3. Apply changes to service
         const { error: updateError } = await supabase
             .from('services')
-            .update(edit.changed_data)
+            .update(safeChanges)
             .eq('id', edit.service_id);
 
         if (updateError) throw updateError;

--- a/api-services/api/yesim.test.ts
+++ b/api-services/api/yesim.test.ts
@@ -28,7 +28,7 @@ describe('yesimService', () => {
             const plans = await yesimService.getPlans();
             
             expect(axios.get).toHaveBeenCalledWith(expect.stringContaining('/plans'), {
-                params: { token: mockToken }
+                headers: { Authorization: `Bearer ${mockToken}` }
             });
             expect(plans).toEqual(mockPlans);
         });

--- a/api-services/api/yesim.ts
+++ b/api-services/api/yesim.ts
@@ -3,6 +3,11 @@ import axios from 'axios';
 
 const YESIM_API_URL = 'https://partners-api.yesim.biz';
 const getApiToken = () => import.meta.env.VITE_YESIM_API_TOKEN;
+const getHeaders = () => {
+    const token = getApiToken();
+    if (!token) return {};
+    return { Authorization: `Bearer ${token}` };
+};
 
 export interface YesimPlan {
     id: string;
@@ -44,7 +49,7 @@ export const yesimService = {
 
         try {
             const response = await axios.get(`${YESIM_API_URL}/plans`, {
-                params: { token: token }
+                headers: getHeaders()
             });
             return response.data;
         } catch (error) {
@@ -70,7 +75,7 @@ export const yesimService = {
             // 1. Create a new eSIM (or assign to user if we had user flow, but for guest checkout we create new)
             // Using /new_esim to get a fresh ICCID
             const simResponse = await axios.get(`${YESIM_API_URL}/new_esim`, {
-                params: { token: token }
+                headers: getHeaders()
             });
             
             if (simResponse.data.status === 'error') {
@@ -84,8 +89,8 @@ export const yesimService = {
             const paymentId = `ORD-${Date.now()}`;
             
             const activationResponse = await axios.post(`${YESIM_API_URL}/add_plan_iccid`, null, {
+                headers: getHeaders(),
                 params: {
-                    token: token,
                     iccid: iccid,
                     plan_id: planId,
                     payment_id: paymentId
@@ -98,8 +103,8 @@ export const yesimService = {
 
             // 3. Get eSIM details to return QR code
             const detailsResponse = await axios.get(`${YESIM_API_URL}/sim_info`, {
-                 params: {
-                    token: token,
+                headers: getHeaders(),
+                params: {
                     iccid: iccid
                 }
             });


### PR DESCRIPTION
## Summary

- **Yesim API token moved to Authorization header** — was being passed as a URL query param (`?token=...`), leaking the secret into server logs, browser history, and HTTP referrer headers. Now sent as `Authorization: Bearer <token>` on all Yesim API calls.
- **`approveServiceEdit` field sanitization** — before applying `changed_data` from `service_edits`, immutable fields (`id`, `provider_id`, `status`, `created_at`, `updated_at`) are now stripped. This prevents a malicious edit record from hijacking ownership or status of any service.

## Reasoning

Both issues were identified in the security audit. The Yesim token fix eliminates a credential exposure vector. The service_edits sanitization prevents privilege escalation via the admin approval flow.

## Potential Risks

- Yesim API must support `Authorization: Bearer` header authentication (standard for partner APIs — query token auth is the non-standard pattern being replaced).
- `approveServiceEdit` now ignores any immutable field changes silently rather than throwing — appropriate for admin UX.

## Testing Notes

- All 1235 tests pass.
- `yesim.test.ts` assertions updated to match new `Authorization` header pattern.
- `services.test.ts` `approveServiceEdit` test passes with the module-level constant replacing the invalid class-property syntax.