### PR TITLE
fix: resolve ESLint warnings from auth guards

### DIFF
--- a/api-services/api/properties.ts
+++ b/api-services/api/properties.ts
@@ -258,7 +258,7 @@ export const propertiesService = {
         }
 
         // Prevent status bypass via general update — only updatePropertyStatus should change status
-        const { status, ical_token, ical_url, last_synced_at: _lt, ...safeUpdates } = updates as any;
+        const { status: _status, ical_token: _icalToken, ical_url: _icalUrl, last_synced_at: _lt, ...safeUpdates } = updates as any;
 
         const { error } = await supabase
             .from('properties')

--- a/api-services/api/services.ts
+++ b/api-services/api/services.ts
@@ -17,7 +17,7 @@ export const servicesService = {
         if (!user) throw new Error('Not authenticated');
 
         const insertData = { ...data, provider_id: user.id };
-        const validatedData = serviceSchema.parse(insertData);
+        serviceSchema.parse(insertData);
 
         const { data: service, error } = await supabase
             .from('services')
@@ -112,7 +112,7 @@ export const servicesService = {
         }
 
         // Prevent status bypass and provider_id hijacking
-        const { status, provider_id, id: _id, created_at, updated_at: _ua, ...safeUpdates } = updates as any;
+        const { status: _status, provider_id: _providerId, id: _id, created_at: _createdAt, updated_at: _updatedAt, ...safeUpdates } = updates as any;
 
         const { error } = await supabase
             .from('services')


### PR DESCRIPTION
## Summary\n- Prefix intentionally unused destructured vars with `_` to satisfy `@typescript-eslint/no-unused-vars`\n- Affected: services.ts (status, provider_id, created_at), properties.ts (status, ical_token, ical_url)\n\n## Testing\n- ESLint clean on changed files