### PR TITLE
fix: validate Supabase env vars at startup

### DIFF
--- a/api-services/supabase.ts
+++ b/api-services/supabase.ts
@@ -4,8 +4,15 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env?.VITE_SUPABASE_URL || (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : '');
 const supabaseAnonKey = import.meta.env?.VITE_SUPABASE_ANON_KEY || (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_ANON_KEY : '');
 
-if (!supabaseUrl || !supabaseAnonKey) {
-    console.warn('Missing Supabase URL or Anon Key. Authentication will not work.');
+const missing: string[] = [];
+if (!supabaseUrl) missing.push('VITE_SUPABASE_URL');
+if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
+
+if (missing.length > 0) {
+    throw new Error(
+        `Missing required environment variable(s): ${missing.join(', ')}. ` +
+        'These must be set for the Supabase client to initialize.',
+    );
 }
 
-export const supabase = createClient(supabaseUrl || '', supabaseAnonKey || '');
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary\n- Replace `console.warn` with `throw Error` for missing `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`\n- Fails fast at startup instead of silently creating a broken client\n\n## Testing\n- All 1242 tests pass\n- TypeScript clean