### PR TITLE
fix: optimize rendering performance

### DIFF
--- a/components/host/AvailabilityCalendar.tsx
+++ b/components/host/AvailabilityCalendar.tsx
@@ -340,22 +340,23 @@ export const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ prop
                     })()}
 
                     {/* Edit Controls (Only show if we have available dates or manual blocks to edit) */}
-                    {selectedDates.length > 0 && (
+                    {selectedDates.length > 0 && (() => {
+                        // Build a Set of externally-sourced dates (ical) for O(1) lookup
+                        const externalDates = new Set(
+                            availability.filter(a => a.source === 'ical').map(a => a.date)
+                        );
+                        function hasExternalBlock(dates: string[]) {
+                            return dates.some(d => externalDates.has(d));
+                        }
+                        return (
                         <div className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800/50">
 
                             {/* Inputs (Status/Price) - Only if NO external blocks */}
-                            {(() => {
-                                const hasExternalBlock = selectedDates.some(d => {
-                                    const entry = availability.find(a => a.date === d);
-                                    return entry?.source === 'ical';
-                                });
-                                if (hasExternalBlock) return null;
-
-                                return (
-                                    <>
-                                        <div>
-                                            <label className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 block">Status</label>
-                                            <div className="flex bg-slate-100 dark:bg-slate-900 p-1 rounded-lg">
+                            {!hasExternalBlock(selectedDates) && (
+                                <>
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 block">Status</label>
+                                        <div className="flex bg-slate-100 dark:bg-slate-900 p-1 rounded-lg">
                                                 <button
                                                     onClick={() => setStatus('available')}
                                                     className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${status === 'available' ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500 hover:text-slate-700'}`}
@@ -393,31 +394,22 @@ export const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ prop
                                                 </div>
                                             </div>
                                         )}
-                                    </>
-                                )
-                            })()}
+                                </>
+                            )}
 
                             {/* Actions - MOVED TO BOTTOM */}
-                            {(() => {
-                                const hasExternalBlock = selectedDates.some(d => {
-                                    const entry = availability.find(a => a.date === d);
-                                    return entry?.source === 'ical';
-                                });
-
-                                if (hasExternalBlock) return null;
-
-                                return (
-                                    <button
-                                        onClick={handleSave}
-                                        className="w-full py-2 text-sm font-bold text-white bg-slate-900 hover:bg-slate-800 dark:bg-white dark:text-white rounded-lg transition-colors"
-                                    >
-                                        Save Changes
-                                    </button>
-                                );
-                            })()}
+                            {hasExternalBlock(selectedDates) ? null : (
+                                <button
+                                    onClick={handleSave}
+                                    className="w-full py-2 text-sm font-bold text-white bg-slate-900 hover:bg-slate-800 dark:bg-white dark:text-white rounded-lg transition-colors"
+                                >
+                                    Save Changes
+                                </button>
+                            )}
 
                         </div>
-                    )}
+                        );
+                    })()}
                 </div>
             </div>
         </div>

--- a/hooks/usePropertyFilters.ts
+++ b/hooks/usePropertyFilters.ts
@@ -78,20 +78,18 @@ export const usePropertyFilters = ({ checkIn, checkOut, location, guests }: UseP
     });
 
     // Reset pagination ONLY when filters/sort/location/dates actually change
+    // Uses ref comparison to avoid JSON.stringify serialization overhead
     useEffect(() => {
         const prev = prevDeps.current;
         const hasLocationChanged = prev.location !== location;
         const hasDatesChanged = prev.checkIn !== checkIn || prev.checkOut !== checkOut;
         const hasSortChanged = prev.sort !== sort;
-        // Simple shallow comparison for filters object usually sufficient if treated immutably, 
-        // but let's stringify to be safe as it contains arrays
-        const hasFiltersChanged = JSON.stringify(prev.filters) !== JSON.stringify(filters);
+        const hasFiltersChanged = prev.filters !== filters;
 
         if (hasLocationChanged || hasDatesChanged || hasSortChanged || hasFiltersChanged) {
             setPageState(1);
             setSearchParams(prev => { prev.set('page', '1'); return prev; });
 
-            // Update refs after change detected
             prevDeps.current = {
                 location,
                 checkIn,

--- a/pages/host/HostCalendarPage.tsx
+++ b/pages/host/HostCalendarPage.tsx
@@ -46,18 +46,25 @@ export const HostCalendarPage = () => {
         setCurrentDate(new Date(year, currentDate.getMonth() + delta, 1));
     };
 
-    const isDateBooked = (day: number) => {
-        if (!bookings.length) return false;
-        const targetDate = new Date(year, currentDate.getMonth(), day);
-        targetDate.setHours(0, 0, 0, 0);
-
-        return bookings.some(b => {
+    // Build a Map of bookings for O(1) lookup
+    const dateRangeMap = new Map<string, { check_in: string; check_out: string }>();
+    if (bookings.length) {
+        bookings.forEach(b => {
             const start = new Date(b.check_in);
             const end = new Date(b.check_out);
             start.setHours(0, 0, 0, 0);
             end.setHours(0, 0, 0, 0);
-            return targetDate >= start && targetDate <= end;
+            const current = new Date(start);
+            while (current <= end) {
+                dateRangeMap.set(current.toISOString().slice(0, 10), b);
+                current.setDate(current.getDate() + 1);
+            }
         });
+    }
+
+    const isDateBooked = (day: number) => {
+        const dateKey = new Date(year, currentDate.getMonth(), day).toISOString().slice(0, 10);
+        return dateRangeMap.has(dateKey);
     };
 
     return (


### PR DESCRIPTION
## Summary\n- Replace O(n) .some()/.find() with O(1) Map/Set lookups for date checks\n- Remove JSON.stringify from useEffect deps in usePropertyFilters\n\n## Key decisions\n- HostCalendarPage: Map for O(1) date booking lookup\n- AvailabilityCalendar: Set for external dates lookup\n- usePropertyFilters: ref comparison instead of JSON.stringify for filters\n\n## Testing\n- TypeScript: clean\n- Tests: 1242 passed