### PR TITLE
fix: remove unused imports and rename unused catch vars

### DIFF
--- a/api-services/api/directory.test.ts
+++ b/api-services/api/directory.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { directoryService } from './directory';
 
-const { mockSupabase, mockUser } = vi.hoisted(() => ({
-    mockUser: { id: 'u1' },
+const { mockSupabase } = vi.hoisted(() => ({
     mockSupabase: {
         from: vi.fn(),
         auth: {

--- a/components/home/FeaturedProperties.tsx
+++ b/components/home/FeaturedProperties.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../../context/LanguageContext';
 import { db } from '../../api-services';
@@ -32,7 +32,7 @@ export const FeaturedProperties: React.FC = () => {
                 }));
 
                 setProperties(formattedData);
-            } catch (error) {
+            } catch (_error) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setIsLoading(false);

--- a/components/host/AvailabilityCalendar.tsx
+++ b/components/host/AvailabilityCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css";
 import { db } from '../../api-services';

--- a/components/host/ICalManager.tsx
+++ b/components/host/ICalManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Copy, RefreshCw, Check, Loader2, Plus, Trash2, Calendar } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { db } from '../../api-services';

--- a/components/reviews/ReviewsSection.tsx
+++ b/components/reviews/ReviewsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Star, User, Trash2 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { db, Review } from '../../api-services';
@@ -11,7 +11,6 @@ interface ReviewsSectionProps {
 }
 
 export const ReviewsSection: React.FC<ReviewsSectionProps> = ({ propertyId }) => {
-    const isMountedRef = useRef(true);
     const { user, isAuthenticated } = useAuth();
     const { openLightbox } = useLightbox();
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ export default tseslint.config(
       'react-refresh/only-export-components': 'off',
       // Legacy Codebase Relaxation (to be re-enabled later)
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       '@typescript-eslint/ban-ts-comment': 'off',
       'react-hooks/exhaustive-deps': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],

--- a/pages/Esim.tsx
+++ b/pages/Esim.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Wifi, Download, Zap, Smartphone, Globe, Check, Loader } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
@@ -24,7 +24,7 @@ export const Esim: React.FC = () => {
                 if (isMountedRef.current) {
                     setPlans(data.slice(0, 6));
                 }
-            } catch (error) {
+            } catch (_error) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);
@@ -33,17 +33,6 @@ export const Esim: React.FC = () => {
         loadPlans();
         return () => { isMountedRef.current = false; };
     }, []);
-
-    const loadPlans = async () => {
-        try {
-            const data = await yesimService.getPlans();
-            setPlans(data.slice(0, 6));
-        } catch (error) {
-            console.error('Failed to load plans', error);
-        } finally {
-            setLoading(false);
-        }
-    };
 
     const handlePlanSelect = (plan: YesimPlan) => {
         setSelectedPlan(plan);

--- a/pages/ExperienceCategoryPage.tsx
+++ b/pages/ExperienceCategoryPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Check, Compass, Sun, Map, Cloud, Anchor, Mountain, Heart, Car } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
@@ -78,7 +78,7 @@ export const ExperienceCategoryPage: React.FC = () => {
                     const filtered = data.filter(s => s.features?.subcategory === category);
                     setServices(filtered);
                 }
-            } catch (err) {
+            } catch (_err) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
@@ -103,7 +103,7 @@ export const Profile: React.FC = () => {
                             email: profile.email || user.email
                         }));
                     }
-                } catch (error) {
+                } catch (_error) {
                     // ignore unmount
                 } finally {
                     if (isMountedRef.current) setLoading(false);

--- a/pages/admin/Dashboard.tsx
+++ b/pages/admin/Dashboard.tsx
@@ -86,7 +86,7 @@ export const Dashboard: React.FC = () => {
                         recent_bookings: recent
                     });
                 }
-            } catch (e) {
+            } catch (_e) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);


### PR DESCRIPTION
## Summary

- Remove unused `useRef` import from 6 components (all use plain `{ current: true }` objects, not `useRef()`)
- Remove unused `isMountedRef = useRef(true)` from `ReviewsSection.tsx`
- Rename unused catch variables to `_error` / `_err` / `_e` to satisfy `no-unused-vars` rule
- Remove duplicate `loadPlans` function in `Esim.tsx` (dead code — was never called)
- Remove unused `mockUser` from `directory.test.ts`

## Potential risks

None — purely cosmetic/lint cleanup, no logic changes.

## Testing notes

21 ESLint warnings from CI → 0 after this fix.