### PR TITLE
fix: resolve page errors across stays, terms and esim pages

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp"]
+    },
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=mdmizeyiyebvhkujjyjg"

--- a/api-services/api/directory.test.ts
+++ b/api-services/api/directory.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { directoryService } from './directory';
 
-const { mockSupabase, mockUser } = vi.hoisted(() => ({
-    mockUser: { id: 'u1' },
+const { mockSupabase } = vi.hoisted(() => ({
     mockSupabase: {
         from: vi.fn(),
         auth: {

--- a/components/home/FeaturedProperties.tsx
+++ b/components/home/FeaturedProperties.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../../context/LanguageContext';
 import { db } from '../../api-services';
@@ -32,7 +32,7 @@ export const FeaturedProperties: React.FC = () => {
                 }));
 
                 setProperties(formattedData);
-            } catch (error) {
+            } catch (_error) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setIsLoading(false);

--- a/components/host/AvailabilityCalendar.tsx
+++ b/components/host/AvailabilityCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import DatePicker from 'react-datepicker';
 import "react-datepicker/dist/react-datepicker.css";
 import { db } from '../../api-services';

--- a/components/host/ICalManager.tsx
+++ b/components/host/ICalManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Copy, RefreshCw, Check, Loader2, Plus, Trash2, Calendar } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { db } from '../../api-services';

--- a/components/reviews/ReviewsSection.tsx
+++ b/components/reviews/ReviewsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Star, User, Trash2 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { db, Review } from '../../api-services';
@@ -11,7 +11,6 @@ interface ReviewsSectionProps {
 }
 
 export const ReviewsSection: React.FC<ReviewsSectionProps> = ({ propertyId }) => {
-    const isMountedRef = useRef(true);
     const { user, isAuthenticated } = useAuth();
     const { openLightbox } = useLightbox();
 

--- a/components/ui/PropertyCard.tsx
+++ b/components/ui/PropertyCard.tsx
@@ -23,7 +23,7 @@ export const PropertyCard: React.FC<PropertyCardProps> = ({ property }) => {
         >
             <div className="relative aspect-[4/3] overflow-hidden bg-slate-200 dark:bg-slate-800/80">
                 <img
-                    src={property.image}
+                    src={property.image || undefined}
                     alt={property.title}
                     className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
                     onError={(e) => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ export default tseslint.config(
       'react-refresh/only-export-components': 'off',
       // Legacy Codebase Relaxation (to be re-enabled later)
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
       '@typescript-eslint/ban-ts-comment': 'off',
       'react-hooks/exhaustive-deps': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],

--- a/pages/Esim.tsx
+++ b/pages/Esim.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Wifi, Download, Zap, Smartphone, Globe, Check, Loader } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
@@ -24,7 +24,7 @@ export const Esim: React.FC = () => {
                 if (isMountedRef.current) {
                     setPlans(data.slice(0, 6));
                 }
-            } catch (error) {
+            } catch (_error) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);
@@ -33,17 +33,6 @@ export const Esim: React.FC = () => {
         loadPlans();
         return () => { isMountedRef.current = false; };
     }, []);
-
-    const loadPlans = async () => {
-        try {
-            const data = await yesimService.getPlans();
-            setPlans(data.slice(0, 6));
-        } catch (error) {
-            console.error('Failed to load plans', error);
-        } finally {
-            setLoading(false);
-        }
-    };
 
     const handlePlanSelect = (plan: YesimPlan) => {
         setSelectedPlan(plan);

--- a/pages/ExperienceCategoryPage.tsx
+++ b/pages/ExperienceCategoryPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Check, Compass, Sun, Map, Cloud, Anchor, Mountain, Heart, Car } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
@@ -78,7 +78,7 @@ export const ExperienceCategoryPage: React.FC = () => {
                     const filtered = data.filter(s => s.features?.subcategory === category);
                     setServices(filtered);
                 }
-            } catch (err) {
+            } catch (_err) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
@@ -103,7 +103,7 @@ export const Profile: React.FC = () => {
                             email: profile.email || user.email
                         }));
                     }
-                } catch (error) {
+                } catch (_error) {
                     // ignore unmount
                 } finally {
                     if (isMountedRef.current) setLoading(false);

--- a/pages/Terms.tsx
+++ b/pages/Terms.tsx
@@ -102,11 +102,13 @@ export const Terms: React.FC = () => {
                 </div>
                 <p>
                     Alanya Holidays acts as an intermediary platform connecting guests and hosts. We verify listings for existence and basic standards, but we are not liable for:
-                    <ul>
-                        <li>Direct damages arising from the use of the property.</li>
-                        <li>Personal injuries occurring on the premises.</li>
-                        <li>Theft or loss of personal belongings.</li>
-                    </ul>
+                </p>
+                <ul>
+                    <li>Direct damages arising from the use of the property.</li>
+                    <li>Personal injuries occurring on the premises.</li>
+                    <li>Theft or loss of personal belongings.</li>
+                </ul>
+                <p>
                     However, we will actively assist in mediating disputes and hold a host guarantee fund for extreme cases.
                 </p>
             </section>

--- a/pages/admin/Dashboard.tsx
+++ b/pages/admin/Dashboard.tsx
@@ -86,7 +86,7 @@ export const Dashboard: React.FC = () => {
                         recent_bookings: recent
                     });
                 }
-            } catch (e) {
+            } catch (_e) {
                 // ignore unmount
             } finally {
                 if (isMountedRef.current) setLoading(false);

--- a/supabase/functions/yesim-proxy/index.ts
+++ b/supabase/functions/yesim-proxy/index.ts
@@ -5,17 +5,28 @@ declare const Deno: any
 
 const YESIM_API_URL = 'https://partners-api.yesim.biz'
 const YESIM_API_TOKEN = Deno.env.get('YESIM_API_TOKEN')
-const ALLOWED_ORIGIN = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
+
+const ALLOWED_ORIGINS = new Set([
+  SITE_URL,
+  'https://alanyaholidays.com',
+  'http://localhost:3000',
+  'http://localhost:5173',
+])
 
 const supabase = createClient(
   Deno.env.get('SUPABASE_URL'),
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 )
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+function getCorsHeaders(req: Request) {
+  const origin = req.headers.get('origin') || ''
+  const allowedOrigin = ALLOWED_ORIGINS.has(origin) ? origin : SITE_URL
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  }
 }
 
 const yesimHeaders = () => {
@@ -59,25 +70,41 @@ type RequestBody =
   | { action: 'createOrder'; planId: string }
 
 Deno.serve(async (req: Request) => {
+  const cors = getCorsHeaders(req)
+
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+    return new Response('ok', { headers: cors })
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 
   try {
-    // --- Auth verification ---
+    const body: RequestBody = await req.json()
+
+    if (!body?.action) {
+      return new Response(
+        JSON.stringify({ error: 'Missing action field' }),
+        { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // getPlans is public — no auth required
+    if (body.action === 'getPlans') {
+      return await handleGetPlans(cors)
+    }
+
+    // All other actions require authentication
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) {
       return new Response(
         JSON.stringify({ error: 'No authorization header' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 401, headers: { ...cors, 'Content-Type': 'application/json' } }
       )
     }
 
@@ -88,52 +115,41 @@ Deno.serve(async (req: Request) => {
       console.error('User verification failed:', userError)
       return new Response(
         JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const body: RequestBody = await req.json()
-
-    if (!body?.action) {
-      return new Response(
-        JSON.stringify({ error: 'Missing action field' }),
-        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        { status: 401, headers: { ...cors, 'Content-Type': 'application/json' } }
       )
     }
 
     // --- Route by action ---
     switch (body.action) {
-      case 'getPlans':
-        return await handleGetPlans()
       case 'createOrder':
         if (!body.planId) {
           return new Response(
             JSON.stringify({ error: 'Missing planId' }),
-            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+            { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
           )
         }
-        return await handleCreateOrder(body.planId)
+        return await handleCreateOrder(body.planId, cors)
       default:
         return new Response(
           JSON.stringify({ error: `Unknown action: ${body.action}` }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+          { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
         )
     }
   } catch (error: any) {
     console.error('yesim-proxy error:', error)
     return new Response(
       JSON.stringify({ error: error.message || 'Internal server error' }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 })
 
-async function handleGetPlans(): Promise<Response> {
+async function handleGetPlans(cors: Record<string, string>): Promise<Response> {
   if (!YESIM_API_TOKEN) {
     console.warn('YESIM_API_TOKEN not configured, returning demo plans')
     return new Response(
       JSON.stringify({ data: DEMO_PLANS }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 
@@ -149,18 +165,18 @@ async function handleGetPlans(): Promise<Response> {
     const data = await response.json()
     return new Response(
       JSON.stringify({ data }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   } catch (error: any) {
     console.error('Failed to fetch Yesim plans:', error)
     return new Response(
       JSON.stringify({ error: `Failed to fetch plans: ${error.message}` }),
-      { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 }
 
-async function handleCreateOrder(planId: string): Promise<Response> {
+async function handleCreateOrder(planId: string, cors: Record<string, string>): Promise<Response> {
   if (!YESIM_API_TOKEN) {
     console.warn('YESIM_API_TOKEN not configured, returning demo order')
     await new Promise((r) => setTimeout(r, 1500))
@@ -172,7 +188,7 @@ async function handleCreateOrder(planId: string): Promise<Response> {
     }
     return new Response(
       JSON.stringify({ data: demoOrder }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 
@@ -239,13 +255,13 @@ async function handleCreateOrder(planId: string): Promise<Response> {
 
     return new Response(
       JSON.stringify({ data: order }),
-      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   } catch (error: any) {
     console.error('Yesim Order Failed:', error)
     return new Response(
       JSON.stringify({ error: error.message || 'Order creation failed' }),
-      { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
     )
   }
 }


### PR DESCRIPTION
## Summary

- **RLS infinite recursion** on `profiles` table — removed 15 duplicate/conflicting policies, replaced with 4 clean ones using `is_admin()` (SECURITY DEFINER, no recursion possible)
- **`PropertyCard` empty `src`** — passing `undefined` instead of `""` when property has no image, preventing browser from re-fetching the page
- **`Terms` invalid HTML** — `<ul>` was nested inside `<p>` in the liability section, causing React hydration warning; split into separate elements
- **`yesim-proxy` Edge Function** — was never deployed to Supabase; fixed CORS to support localhost dev origins; made `getPlans` public (no auth needed) while `createOrder` still requires JWT

## Potential risks

- RLS policy changes are destructive (old policies dropped) — verified with a page reload that data loads correctly
- `yesim-proxy` `getPlans` is now unauthenticated — acceptable since it only returns public plan info, no user data

## Testing

- Verified `/stays` loads 5 properties with no console errors
- Verified `/terms` renders with no HTML warnings
- Verified `/services/tourist-sim-card` loads plans with no CORS or 401 errors