### PR TITLE
fix: add missing UPDATE policy on chat_conversations

### DIFF
--- a/supabase/migrations/20260407150842_fix_chat_conversations_update_policy.sql
+++ b/supabase/migrations/20260407150842_fix_chat_conversations_update_policy.sql
@@ -1,0 +1,9 @@
+-- Fix missing UPDATE policy on chat_conversations
+-- sendMessage() calls .update({ updated_at }) on chat_conversations,
+-- which was broken after RLS cleanup removed the old admin ALL policy.
+CREATE POLICY "chat_conversations_update" ON chat_conversations
+  FOR UPDATE USING (
+    (SELECT auth.uid()) = guest_id
+    OR (SELECT auth.uid()) = host_id
+    OR (SELECT auth.uid()) IN (SELECT id FROM profiles WHERE role = 'admin')
+  );


### PR DESCRIPTION
## Summary

- During the RLS cleanup (PR #50), the `chat_conversations` UPDATE policy was accidentally dropped
- `sendMessage()` in `api-services/api/chat.ts:118` calls `.update({ updated_at })` on `chat_conversations` after each message send — this was silently failing
- Added `chat_conversations_update` policy: participants (guest/host) and admins can update

## Testing notes
- Verified via code audit of `api-services/api/chat.ts`
- Policy matches the same condition as `chat_conversations_select`