### PR TITLE
feat: add CSP and security headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,29 @@
 {
-    "rewrites": [
-        {
-            "source": "/calendar/:id.ics",
-            "destination": "https://mdmizeyiyebvhkujjyjg.supabase.co/functions/v1/export-ical?id=:id"
-        },
-        {
-            "source": "/calendar/:id",
-            "destination": "https://mdmizeyiyebvhkujjyjg.supabase.co/functions/v1/export-ical?id=:id"
-        },
-        {
-            "source": "/(.*)",
-            "destination": "/index.html"
-        }
-    ]
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": {
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.supabase.co https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://checkout.stripe.com https://cdn.mapbox.com https://api.mapbox.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.mapbox.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.supabase.co; connect-src 'self' wss://*.supabase.co https://*.supabase.co https://api.mapbox.com https://maps.googleapis.com https://api.stripe.com; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; worker-src 'self';",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains"
+      }
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/calendar/:id.ics",
+      "destination": "https://mdmizeyiyebvhkujjyjg.supabase.co/functions/v1/export-ical?id=:id"
+    },
+    {
+      "source": "/calendar/:id",
+      "destination": "https://mdmizeyiyebvhkujjyjg.supabase.co/functions/v1/export-ical?id=:id"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Add comprehensive security headers to the application via vercel.json:

- Content Security Policy (CSP) configured for all necessary domains (Supabase, Stripe, Google Maps, Mapbox, CDNs)
- X-Frame-Options: SAMEORIGIN (clickjacking protection)
- X-Content-Type-Options: nosniff (MIME sniffing protection)
- Referrer-Policy: strict-origin-when-cross-origin
- Permissions-Policy: disable geolocation, microphone, camera
- Strict-Transport-Security: enforce HTTPS for 1 year

## Testing
- Deploy to Vercel preview environment
- Verify headers are present in network response
- Test that CSP does not break any functionality (Supabase, Stripe Checkout, Maps)
- Check securityheaders.com rating

## Related
Closes #44 (leaked password protection note - manual step required in Supabase Dashboard)
Part of Security & Quality Audit (task [34])