### PR TITLE
feat: rate limiting for ai-proxy and yesim-proxy edge functions [55]

### DIFF
--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -8,7 +8,11 @@ declare const Deno: any;
 const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY')
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY')
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const ALLOWED_ORIGIN = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
+
+// 10 AI requests per minute per user
+const AI_RATE_LIMIT = 10
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
@@ -31,8 +35,8 @@ Deno.serve(async (req: Request) => {
     // --- Authentication Check ---
     const authHeader = req.headers.get('Authorization')
     if (!authHeader) {
-      return new Response(JSON.stringify({ error: 'Missing Authorization header' }), { 
-        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+      return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       })
     }
 
@@ -43,15 +47,35 @@ Deno.serve(async (req: Request) => {
     const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
       global: { headers: { Authorization: authHeader } }
     })
-    
+
     // Validate the token and ensure user exists
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     if (authError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized', details: authError?.message }), { 
-        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+      return new Response(JSON.stringify({ error: 'Unauthorized', details: authError?.message }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       })
     }
     // ----------------------------
+
+    // --- Rate Limiting ---
+    if (SUPABASE_SERVICE_ROLE_KEY) {
+      const adminClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+      const { data: allowed, error: rlError } = await adminClient.rpc('check_rate_limit', {
+        p_user_id: user.id,
+        p_function_name: 'ai-proxy',
+        p_max_requests: AI_RATE_LIMIT,
+      })
+      if (rlError) {
+        console.error('Rate limit check failed:', rlError)
+        // Fail open — don't block users if DB check fails
+      } else if (!allowed) {
+        return new Response(
+          JSON.stringify({ answer: "I'm receiving too many requests from you. Please wait a moment and try again! ⏳" }),
+          { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Retry-After': '60' } }
+        )
+      }
+    }
+    // ---------------------
 
     if (!GEMINI_API_KEY) {
       throw new Error('Missing GEMINI_API_KEY in environment')
@@ -98,8 +122,8 @@ Deno.serve(async (req: Request) => {
       ${recentHistory}
 
       User Question: "${sanitizedQuestion}"
-      
-      Provide a helpful, concise answer (max 100 words). 
+
+      Provide a helpful, concise answer (max 100 words).
       If asked about services (health, transport, shopping), mention that Alanya Holidays offers verified direct bookings.
       Focus on distance, local tips, and atmosphere. Be enthusiastic about Alanya.
       IMPORTANT: Do not use markdown formatting (no bolding with asterisks, no headers). Use plain text only.

--- a/supabase/functions/yesim-proxy/index.ts
+++ b/supabase/functions/yesim-proxy/index.ts
@@ -19,6 +19,12 @@ const supabase = createClient(
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 )
 
+// Rate limits: createOrder is expensive (real money), so keep it strict
+const RATE_LIMITS: Record<string, number> = {
+  createOrder: 5,  // 5 orders per minute per user
+  getPlans:    30, // 30 plan fetches per minute per user
+}
+
 function getCorsHeaders(req: Request) {
   const origin = req.headers.get('origin') || ''
   const allowedOrigin = ALLOWED_ORIGINS.has(origin) ? origin : SITE_URL
@@ -32,6 +38,20 @@ function getCorsHeaders(req: Request) {
 const yesimHeaders = () => {
   if (!YESIM_API_TOKEN) return {}
   return { Authorization: `Bearer ${YESIM_API_TOKEN}` }
+}
+
+async function checkRateLimit(userId: string, action: string): Promise<boolean> {
+  const maxRequests = RATE_LIMITS[action] ?? 10
+  const { data, error } = await supabase.rpc('check_rate_limit', {
+    p_user_id: userId,
+    p_function_name: `yesim-proxy:${action}`,
+    p_max_requests: maxRequests,
+  })
+  if (error) {
+    console.error('Rate limit check failed:', error)
+    return true // Fail open on DB error to avoid blocking legitimate users
+  }
+  return data === true
 }
 
 interface YesimPlan {
@@ -116,6 +136,15 @@ Deno.serve(async (req: Request) => {
       return new Response(
         JSON.stringify({ error: 'Invalid token' }),
         { status: 401, headers: { ...cors, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Rate limit check
+    const allowed = await checkRateLimit(user.id, body.action)
+    if (!allowed) {
+      return new Response(
+        JSON.stringify({ error: 'Rate limit exceeded. Please wait a moment and try again.' }),
+        { status: 429, headers: { ...cors, 'Content-Type': 'application/json', 'Retry-After': '60' } }
       )
     }
 

--- a/supabase/migrations/20260410000001_add_rate_limits.sql
+++ b/supabase/migrations/20260410000001_add_rate_limits.sql
@@ -1,0 +1,46 @@
+-- Rate limiting table for edge functions
+CREATE TABLE IF NOT EXISTS rate_limits (
+    user_id       UUID        NOT NULL,
+    function_name TEXT        NOT NULL,
+    window_start  TIMESTAMPTZ NOT NULL,
+    request_count INTEGER     NOT NULL DEFAULT 1,
+    PRIMARY KEY (user_id, function_name, window_start)
+);
+
+-- Atomically check and increment rate limit counter.
+-- Returns TRUE if the request is within the allowed quota, FALSE if over limit.
+-- Uses a 1-minute fixed window per user per function.
+CREATE OR REPLACE FUNCTION check_rate_limit(
+    p_user_id       UUID,
+    p_function_name TEXT,
+    p_max_requests  INTEGER
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_count  INTEGER;
+    v_window TIMESTAMPTZ;
+BEGIN
+    v_window := date_trunc('minute', NOW());
+
+    -- Prune windows older than 1 hour to prevent table bloat
+    DELETE FROM rate_limits
+    WHERE window_start < NOW() - INTERVAL '1 hour';
+
+    -- Atomically upsert and read back the new count
+    INSERT INTO rate_limits (user_id, function_name, window_start, request_count)
+    VALUES (p_user_id, p_function_name, v_window, 1)
+    ON CONFLICT (user_id, function_name, window_start)
+    DO UPDATE SET request_count = rate_limits.request_count + 1
+    RETURNING request_count INTO v_count;
+
+    RETURN v_count <= p_max_requests;
+END;
+$$;
+
+-- Only service role (used by edge functions) can access this table directly.
+-- The check_rate_limit function itself is SECURITY DEFINER, so it bypasses RLS.
+ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Add `rate_limits` table + `check_rate_limit` RPC function (migration `20260410000001`)
- Add per-user rate limiting to `ai-proxy` (10 req/min) and `yesim-proxy` (5 orders/min, 30 plan fetches/min)

## Implementation
- Fixed 1-minute window per user per function stored in `rate_limits` table
- Atomic upsert with `ON CONFLICT DO UPDATE` — no race conditions
- `check_rate_limit` is `SECURITY DEFINER` — bypasses RLS, callable from edge functions
- Auto-prunes windows older than 1 hour to prevent table bloat
- Fail-open on DB error — legitimate users not blocked if rate limit DB call fails
- Returns `429` with `Retry-After: 60` header on limit exceeded

## Limits
| Function | Action | Limit |
|----------|--------|-------|
| ai-proxy | all requests | 10/min/user |
| yesim-proxy | createOrder | 5/min/user |
| yesim-proxy | getPlans | 30/min/user |