### PR TITLE
feat: Sentry error tracking — ErrorBoundary, React Router tracing, session replay [54]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ RESEND_API_KEY=your_resend_api_key
 
 # Application settings
 SITE_URL=https://alanyaholidays.com
+
+# Error tracking (Sentry)
+VITE_SENTRY_DSN=your_sentry_dsn_here

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+import { Sentry } from '../../utils/sentry';
 
 interface Props {
   children?: ReactNode;
@@ -23,6 +24,15 @@ export class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('[ErrorBoundary] Uncaught error:', error, errorInfo);
+
+    // Report to Sentry for production monitoring
+    Sentry.captureException(error, {
+      contexts: {
+        react: {
+          componentStack: errorInfo.componentStack,
+        },
+      },
+    });
   }
 
   private handleReset = () => {

--- a/index.tsx
+++ b/index.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
+import { initSentry, Sentry } from './utils/sentry';
 import './index.css';
+
+// Initialize Sentry error tracking (no-op if VITE_SENTRY_DSN is not set)
+initSentry();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -29,8 +33,34 @@ if (import.meta.hot) {
 
 root.render(
   <React.StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
+    <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </Sentry.ErrorBoundary>
   </React.StrictMode>
 );
+
+/** Minimal fallback shown only when Sentry's own boundary catches
+ *  something our custom ErrorBoundary missed (e.g. render-time errors
+ *  inside ErrorBoundary itself). */
+function ErrorFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-950 p-4">
+      <div className="max-w-md w-full bg-white dark:bg-slate-900 rounded-3xl p-8 text-center shadow-xl">
+        <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+          Something went wrong
+        </h2>
+        <p className="text-slate-500 dark:text-slate-400 text-sm">
+          The error has been reported. Please try refreshing the page.
+        </p>
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-6 px-6 py-3 bg-teal-600 hover:bg-teal-700 text-white rounded-xl font-semibold transition-colors"
+        >
+          Refresh Page
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.2.9",
         "@iflow-mcp/maestro-mcp": "^1.0.0",
         "@react-google-maps/api": "^2.20.8",
+        "@sentry/react": "^10.48.0",
         "@supabase/supabase-js": "^2.90.1",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/vite": "^4.2.1",
@@ -2510,6 +2511,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry-internal/feedback": "10.48.0",
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry-internal/replay-canvas": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.48.0.tgz",
+      "integrity": "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.48.0",
+        "@sentry/core": "10.48.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@headlessui/react": "^2.2.9",
     "@iflow-mcp/maestro-mcp": "^1.0.0",
     "@react-google-maps/api": "^2.20.8",
+    "@sentry/react": "^10.48.0",
     "@supabase/supabase-js": "^2.90.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@tailwindcss/vite": "^4.2.1",

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -1,0 +1,63 @@
+import * as Sentry from '@sentry/react';
+import React from 'react';
+import { useLocation, useNavigationType, createRoutesFromChildren, matchRoutes } from 'react-router-dom';
+
+/**
+ * Initialize Sentry error tracking.
+ * Called once at app startup. No-op when VITE_SENTRY_DSN is not set.
+ */
+export function initSentry(): void {
+    const dsn = import.meta.env.VITE_SENTRY_DSN;
+
+    if (!dsn) {
+        // Silently skip — local/dev environments don't need Sentry
+        return;
+    }
+
+    Sentry.init({
+        dsn,
+        environment: import.meta.env.PROD ? 'production' : 'development',
+        integrations: [
+            // React Router v7 integration for automatic navigation tracing
+            Sentry.reactRouterV7BrowserTracingIntegration({
+                useEffect: React.useEffect,
+                useLocation,
+                useNavigationType,
+                createRoutesFromChildren,
+                matchRoutes,
+            }),
+            Sentry.replayIntegration({
+                maskAllText: false,
+                blockAllMedia: false,
+            }),
+        ],
+
+        // Performance traces — sample 20% in production
+        tracesSampleRate: import.meta.env.PROD ? 0.2 : 1.0,
+
+        // Session replays — sample 10% in production
+        replaysSessionSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+        replaysOnErrorSampleRate: import.meta.env.PROD ? 1.0 : 1.0,
+
+        // Ignore noisy / unactionable errors
+        ignoreErrors: [
+            // Browser extensions
+            'chrome-extension://',
+            'moz-extension://',
+            'safari-extension://',
+            // Common third-party script errors
+            'Script error.',
+            'RandomlyChangeHash',
+            // Network / offline issues
+            'NetworkError',
+            'Failed to fetch',
+            'Load failed',
+            'network error',
+        ],
+
+        // Deny URLs we don't want traces from (third-party iframes, etc.)
+        denyUrls: [/chrome-extension:\/\//, /moz-extension:\/\//],
+    });
+}
+
+export { Sentry };


### PR DESCRIPTION
## Summary
- Add `@sentry/react` package
- Add `utils/sentry.ts` — init with React Router v7 tracing + session replay, no-op when `VITE_SENTRY_DSN` is unset
- Update `ErrorBoundary.tsx` — `Sentry.captureException()` in `componentDidCatch`
- Update `index.tsx` — `initSentry()` on startup, wrap app in `Sentry.ErrorBoundary`
- Add `VITE_SENTRY_DSN` to `.env.example`

## Configuration
- No-op in local/dev if `VITE_SENTRY_DSN` is not set — zero overhead
- Production: 20% performance traces, 10% session replays, 100% error replays
- Ignores browser extension noise, network errors, Script error

## Deployment note
Set `VITE_SENTRY_DSN` in your hosting env vars (Vercel/Netlify) to activate.