### PR TITLE
fix: unblock property dates when booking is cancelled or expired [78]

### DIFF
--- a/api-services/api/bookings/mutations.ts
+++ b/api-services/api/bookings/mutations.ts
@@ -205,6 +205,22 @@ export async function updateBookingStatus(
 
     if (error) throw error;
 
+    // Unblock dates in property_availability when booking is cancelled/rejected
+    // Uses centralized RPC (DRY principle) — same logic as cancel-expired-bookings Edge Function
+    if (status === 'cancelled') {
+        try {
+            const { error: unblockError } = await supabase.rpc('unblock_dates_for_booking', {
+                p_booking_id: id
+            });
+
+            if (unblockError) {
+                console.error('Failed to unblock dates for cancelled booking:', unblockError);
+            }
+        } catch (err) {
+            console.error('Error calling unblock_dates_for_booking RPC:', err);
+        }
+    }
+
     if (currentBooking) {
         if (status === 'confirmed') {
             await createAuditLog('BOOKING_CONFIRMED', { bookingId: id }, currentBooking.user_id);

--- a/supabase/functions/cancel-expired-bookings/index.ts
+++ b/supabase/functions/cancel-expired-bookings/index.ts
@@ -66,7 +66,23 @@ Deno.serve(async (req: Request) => {
 
     if (updateError) throw updateError
 
-    // 3. Отправить email гостю и хосту по каждому бронированию
+    // 3. Unblock dates in property_availability for all cancelled bookings
+    // Uses centralized RPC (DRY principle) — delegates calendar cleanup to the database
+    const unblockResults = await Promise.allSettled(
+      ids.map((bookingId: string) =>
+        supabase.rpc('unblock_dates_for_booking', { p_booking_id: bookingId })
+      )
+    )
+
+    const unblockErrors = unblockResults
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r) => r.reason)
+
+    if (unblockErrors.length > 0) {
+      console.error('Failed to unblock some dates:', unblockErrors)
+    }
+
+    // 4. Отправить email гостю и хосту по каждому бронированию
     const emailPromises = expiredBookings.map(async (booking: any) => {
       const guestEmail = booking.guest?.email
       const guestName  = booking.guest?.full_name || 'Guest'

--- a/supabase/migrations/20260411000002_add_unblock_dates_rpc.sql
+++ b/supabase/migrations/20260411000002_add_unblock_dates_rpc.sql
@@ -1,0 +1,50 @@
+-- [78] Add RPC to unblock dates when a booking is cancelled/rejected
+-- Centralizes the responsibility of releasing property_availability rows.
+-- Both the cancel-expired-bookings Edge Function and updateBookingStatus API
+-- should call this to avoid duplicating SQL logic (DRY).
+
+CREATE OR REPLACE FUNCTION public.unblock_dates_for_booking(
+    p_booking_id UUID
+) RETURNS JSONB AS $$
+DECLARE
+    v_booking RECORD;
+    v_deleted_count INTEGER;
+BEGIN
+    -- Fetch the booking to verify it exists and is in a cancelled/rejected state
+    SELECT id, status, item_id, item_type
+    INTO v_booking
+    FROM bookings
+    WHERE id = p_booking_id;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object('error', 'Booking not found');
+    END IF;
+
+    -- Only unblock if the booking is cancelled or rejected
+    IF v_booking.status NOT IN ('cancelled', 'rejected') THEN
+        RETURN jsonb_build_object('error', 'Cannot unblock dates for a booking that is not cancelled or rejected');
+    END IF;
+
+    -- Only unblock for properties (services/products don't manage calendar dates)
+    IF v_booking.item_type != 'property' THEN
+        RETURN jsonb_build_object('data', jsonb_build_object('unblocked', 0, 'message', 'Not a property booking'));
+    END IF;
+
+    -- Delete the availability rows that were reserved by this booking
+    DELETE FROM property_availability
+    WHERE property_id = v_booking.item_id
+      AND source = 'reservation'
+      AND external_id = p_booking_id::text
+      AND status = 'booked';
+
+    GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+    RETURN jsonb_build_object(
+        'data', jsonb_build_object(
+            'unblocked', v_deleted_count,
+            'property_id', v_booking.item_id,
+            'message', format('Released %d blocked date(s)', v_deleted_count)
+        )
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;


### PR DESCRIPTION
## Summary

- **[78]** Добавлен RPC `unblock_dates_for_booking` — при отмене/истечении бронирования удаляет записи из `property_availability` с `source='reservation'` и `external_id=booking_id`.
- `updateBookingStatus` вызывает RPC при переводе в `cancelled`.
- `cancel-expired-bookings` edge function вызывает RPC для каждой истёкшей брони.

## Problem

При отмене бронирования строки в `property_availability` (status='booked') не удалялись. Даты оставались заблокированными навсегда — хост не мог принять новые бронирования на эти даты.

## Fix

Новая миграция `20260411000002_add_unblock_dates_rpc.sql`:

```sql
DELETE FROM property_availability
WHERE property_id = v_booking.item_id
  AND source = 'reservation'
  AND external_id = p_booking_id::text
  AND status = 'booked';
```

RPC проверяет что бронирование существует и находится в статусе `cancelled`/`rejected` перед разблокировкой. Только property-типы затронуты (services/products не управляют календарём).

## Risks

- Минимальный: RPC идемпотентен — повторный вызов на уже разблокированное бронирование просто вернёт `unblocked: 0`.

## Testing

- Создать бронирование → проверить что даты заблокированы в `property_availability`.
- Отменить бронирование → проверить что строки удалены из `property_availability`.