### PR TITLE
fix: add payment_intent_id to bookings, wire payment_failed and dispute handlers [79]

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -181,6 +181,9 @@ Deno.serve(async (req: Request) => {
         .update({
           stripe_session_id: session.id,
           payment_expires_at: paymentExpiresAt,
+          // payment_intent_id is NOT saved here — Stripe only provides it
+          // after the session is completed. It's saved by stripe-webhook
+          // on the 'checkout.session.completed' event.
         })
         .in('id', verifiedIds)
     }

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -31,6 +31,10 @@ Deno.serve(async (req: Request) => {
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
 
+    const paymentIntentId = typeof session.payment_intent === 'string'
+      ? session.payment_intent
+      : (session.payment_intent as any)?.id ?? null
+
     // Idempotency: skip if already processed (payment_status already 'paid')
     const bookingIds = session.metadata?.bookingIds?.split(',').filter(Boolean) ?? []
     if (bookingIds.length > 0) {
@@ -51,12 +55,18 @@ Deno.serve(async (req: Request) => {
 
     if (session.payment_status === 'paid') {
       if (bookingIds.length > 0) {
+        const updatePayload: Record<string, unknown> = {
+          status: 'confirmed',
+          payment_status: 'paid',
+        }
+
+        if (paymentIntentId) {
+          updatePayload.payment_intent_id = paymentIntentId
+        }
+
         const { error } = await supabase
           .from('bookings')
-          .update({
-            status: 'confirmed',
-            payment_status: 'paid',
-          })
+          .update(updatePayload)
           .in('id', bookingIds)
 
         if (error) {

--- a/supabase/migrations/20260411000003_add_booking_payment_intent_id.sql
+++ b/supabase/migrations/20260411000003_add_booking_payment_intent_id.sql
@@ -1,0 +1,11 @@
+-- [79] Add payment_intent_id column to bookings table
+-- Required by stripe-webhook to look up bookings when handling
+-- payment_intent.payment_failed and charge.dispute.created events.
+-- Without this column, both handlers silently return null and never update bookings.
+
+ALTER TABLE bookings
+ADD COLUMN IF NOT EXISTS payment_intent_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_bookings_payment_intent_id
+ON bookings (payment_intent_id)
+WHERE payment_intent_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- **[79]** Добавлена колонка `payment_intent_id TEXT` в таблицу `bookings` + partial index.
- `checkout.session.completed` теперь сохраняет `payment_intent_id` при подтверждении оплаты (поддержка обоих форматов — string и объект).
- Обработчики `payment_intent.payment_failed` и `charge.dispute.created` теперь корректно находят бронирование по `payment_intent_id`.

## Problem

Колонка `payment_intent_id` отсутствовала в таблице `bookings`. Stripe webhook обращался к несуществующей колонке — оба обработчика молча возвращали `null` и не обновляли статус бронирования.

## Fix

Паттерн Observer: единый поток данных через webhook события:
1. `checkout.session.completed` → сохраняет `payment_intent_id`
2. `payment_intent.payment_failed` → находит booking по `payment_intent_id` → `payment_status='failed'`
3. `charge.dispute.created` → находит booking по `payment_intent_id` → уведомляет админов

## Risks

- Старые бронирования (до деплоя) не будут иметь `payment_intent_id` — это нормально, колонка nullable.

## Testing

- Создать тестовый платёж в Stripe → убедиться что `payment_intent_id` сохраняется в `bookings`.
- Эмулировать `payment_intent.payment_failed` через Stripe CLI → убедиться что `payment_status='failed'`.