### PR TITLE
feat: handle charge.refunded webhook — update payment_status, audit log, notify guest [80]

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -209,6 +209,121 @@ Deno.serve(async (req: Request) => {
     }
   }
 
+  if (event.type === 'charge.refunded') {
+    const charge = event.data.object as Stripe.Charge
+    const paymentIntentId = charge.payment_intent as string | undefined
+    const amountRefundedCents = charge.amount_refunded ?? 0
+    const amountRefunded = (amountRefundedCents / 100).toFixed(2)
+
+    if (!paymentIntentId) {
+      console.warn('charge.refunded event received without payment_intent — cannot lookup booking')
+      return new Response(JSON.stringify({ received: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Look up booking by payment_intent_id (set by checkout.session.completed handler)
+    const { data: booking, error: fetchError } = await supabase
+      .from('bookings')
+      .select(`
+        id, user_id, payment_status,
+        property:properties(title),
+        service:services(title),
+        profile:profiles!bookings_user_id_fkey(email)
+      `)
+      .eq('payment_intent_id', paymentIntentId)
+      .limit(1)
+      .maybeSingle()
+
+    if (fetchError) {
+      console.error('Failed to fetch booking for refund:', fetchError)
+      return new Response('DB lookup failed', { status: 500 })
+    }
+
+    if (!booking) {
+      console.warn(`No booking found for payment_intent ${paymentIntentId} — refund not applied`)
+      return new Response(JSON.stringify({ received: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Idempotency: skip if already refunded
+    if (booking.payment_status === 'refunded') {
+      console.warn(`Booking ${booking.id} already refunded — skipping`)
+      return new Response(JSON.stringify({ received: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    // Update payment_status
+    const { error: updateError } = await supabase
+      .from('bookings')
+      .update({ payment_status: 'refunded' })
+      .eq('id', booking.id)
+
+    if (updateError) {
+      console.error('Failed to update booking payment_status to refunded:', updateError)
+      return new Response('DB update failed', { status: 500 })
+    }
+
+    // Create audit log
+    const itemTitle = (booking.property as any)?.title ?? (booking.service as any)?.title ?? 'Booking'
+    await supabase.from('audit_logs').insert({
+      event_type: 'REFUND',
+      details: {
+        bookingId: booking.id,
+        amountRefunded,
+        currency: charge.currency ?? 'eur',
+        chargeId: charge.id,
+        previousPaymentStatus: booking.payment_status,
+      },
+      user_id: booking.user_id,
+      created_at: new Date().toISOString(),
+    })
+
+    // In-app notification to guest
+    await supabase.from('notifications').insert({
+      user_id: booking.user_id,
+      title: 'Refund Processed',
+      message: `A refund of €${amountRefunded} has been processed for "${itemTitle}". It may take 5-10 business days for the credit to appear on your statement.`,
+      type: 'info',
+      link: '/profile',
+    })
+
+    // Email to guest (uses existing 'refund_processed' template)
+    const guestEmail = (booking.profile as any)?.email
+    if (guestEmail) {
+      const siteUrl = Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'
+      const maxRetries = 3
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          await supabase.functions.invoke('send-email', {
+            body: {
+              to: guestEmail,
+              type: 'refund_processed',
+              data: {
+                amount: amountRefunded,
+                itemTitle,
+                link: `${siteUrl}/profile`,
+              },
+            },
+          })
+          break
+        } catch (e: any) {
+          if (attempt < maxRetries) {
+            const delayMs = Math.pow(2, attempt) * 1000
+            console.warn(`Refund email send failed for booking ${booking.id}, attempt ${attempt}/${maxRetries}. Retrying in ${delayMs}ms...`)
+            await new Promise(resolve => setTimeout(resolve, delayMs))
+          } else {
+            console.error(`Refund email send failed for booking ${booking.id} after ${maxRetries} attempts:`, e)
+          }
+        }
+      }
+    }
+
+    console.warn(`Refund processed: booking ${booking.id}, amount €${amountRefunded}, charge ${charge.id}`)
+  }
+
   return new Response(JSON.stringify({ received: true }), {
     headers: { 'Content-Type': 'application/json' },
   })


### PR DESCRIPTION
## Summary

- **[80]** Добавлен обработчик `charge.refunded` в `stripe-webhook` edge function.

## Problem

При возврате средств через Stripe Dashboard приложение не реагировало: `payment_status` не менялся, гость не получал уведомление, audit log не создавался.

## Solution

Паттерн Command + Idempotency:

1. Lookup booking по `payment_intent_id`
2. Idempotency check — пропуск если `payment_status === 'refunded'`
3. `payment_status = 'refunded'`
4. Audit log `REFUND` (сумма, валюта, chargeId)
5. In-app уведомление гостю
6. Email гостю через шаблон `refund_processed` (retry 3×, exponential backoff)

## Risks

- Зависит от `payment_intent_id` из [79] — старые бронирования без него не получат автоматический refund-статус (нужно обновить вручную).

## Testing

- Эмулировать `charge.refunded` через Stripe CLI: `stripe trigger charge.refunded`
- Убедиться что `payment_status='refunded'` в `bookings` и уведомление появилось у гостя.