### PR TITLE
feat: add Spa & Hammams and Hair & Beauty categories [83]

### DIFF
--- a/data/services.ts
+++ b/data/services.ts
@@ -1,4 +1,4 @@
-import { Car, Anchor, Heart, Stethoscope, Cloud, Mountain, Bike, Camera, Video } from 'lucide-react';
+import { Car, Anchor, Heart, Stethoscope, Cloud, Mountain, Bike, Camera, Video, Sparkles, Scissors } from 'lucide-react';
 
 export const SERVICES_DATA = [
     // Transport
@@ -236,6 +236,74 @@ export const SERVICES_DATA = [
         description: 'services.health.cave_desc',
         icon: Heart,
         price: 10,
+        route: '/contact',
+        actionLabel: 'book_button'
+    },
+    // Spa & Wellness
+    {
+        id: 'turkish-hamam',
+        category: 'spa-wellness',
+        title: 'services.spa.turkish_hamam',
+        description: 'services.spa.turkish_hamam_desc',
+        icon: Sparkles,
+        price: 40,
+        priceLabel: '/person',
+        route: '/experiences/wellness',
+        actionLabel: 'book_button'
+    },
+    {
+        id: 'spa-massage',
+        category: 'spa-wellness',
+        title: 'services.spa.massage',
+        description: 'services.spa.massage_desc',
+        icon: Heart,
+        price: 50,
+        priceLabel: '/session',
+        route: '/experiences/wellness',
+        actionLabel: 'book_button'
+    },
+    {
+        id: 'spa-wellness-package',
+        category: 'spa-wellness',
+        title: 'services.spa.wellness_package',
+        description: 'services.spa.wellness_package_desc',
+        icon: Sparkles,
+        price: 80,
+        priceLabel: '/person',
+        route: '/experiences/wellness',
+        actionLabel: 'book_button'
+    },
+    // Hair & Beauty
+    {
+        id: 'hair-styling',
+        category: 'hair-beauty',
+        title: 'services.hair.styling',
+        description: 'services.hair.styling_desc',
+        icon: Scissors,
+        price: 30,
+        priceLabel: '/session',
+        route: '/contact',
+        actionLabel: 'book_button'
+    },
+    {
+        id: 'nail-salon',
+        category: 'hair-beauty',
+        title: 'services.hair.nails',
+        description: 'services.hair.nails_desc',
+        icon: Sparkles,
+        price: 25,
+        priceLabel: '/session',
+        route: '/contact',
+        actionLabel: 'book_button'
+    },
+    {
+        id: 'beauty-makeover',
+        category: 'hair-beauty',
+        title: 'services.hair.makeover',
+        description: 'services.hair.makeover_desc',
+        icon: Scissors,
+        price: 60,
+        priceLabel: '/session',
         route: '/contact',
         actionLabel: 'book_button'
     }

--- a/db_scripts/verify_state_machine_trigger.sql
+++ b/db_scripts/verify_state_machine_trigger.sql
@@ -1,0 +1,17 @@
+-- Verify the state machine trigger is working
+DO $$
+DECLARE
+    v_trigger_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'trg_validate_booking_status_transition'
+          AND tgrelid = 'bookings'::regclass
+    ) INTO v_trigger_exists;
+
+    IF v_trigger_exists THEN
+        RAISE NOTICE '✅ Trigger trg_validate_booking_status_transition exists on bookings table';
+    ELSE
+        RAISE NOTICE '❌ Trigger NOT found on bookings table';
+    END IF;
+END $$;

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -204,6 +204,26 @@ export const ar = {
     'services.connectivity.esim': 'باقات eSIM',
     'services.connectivity.esim_desc': 'اتصال بيانات فوري لرحلتك.',
 
+    // سبا والعافية
+    'services.spa.title': 'سبا والعافية',
+    'services.spa.subtitle': 'استرخِ وجدد نشاطك مع تجارب السبا والحمام التركي الأصيل.',
+    'services.spa.turkish_hamam': 'الحمام التركي التقليدي',
+    'services.spa.turkish_hamam_desc': 'تجربة الحمام التركي العريقة مع تدليك رغوي وتقشير.',
+    'services.spa.massage': 'تدليك استرخائي',
+    'services.spa.massage_desc': 'جلسات تدليك عميق للأنسجة، بالعطور العلاجية والحجارة الساخنة.',
+    'services.spa.wellness_package': 'باقة يوم سبا كامل',
+    'services.spa.wellness_package_desc': 'تجربة عافية شاملة: حمام، تدليك، عناية بالوجه، وعلاج عطري.',
+
+    // الشعر والتجميل
+    'services.hair.title': 'الشعر والتجميل',
+    'services.hair.subtitle': 'أفضل صالونات التجميل لإطلالة مثالية أثناء إقامتك.',
+    'services.hair.styling': 'تصفيف الشعر وتلوينه',
+    'services.hair.styling_desc': 'قصات احترافية، تلوين، بالياج، وتصفيف من مصففين خبراء.',
+    'services.hair.nails': 'صالون الأظافر',
+    'services.hair.nails_desc': 'مانيكير، باديكير، أظافر جل، وتصاميم في أجواء مريحة.',
+    'services.hair.makeover': 'تحول تجميل شامل',
+    'services.hair.makeover_desc': 'باقة تجميل متكاملة: شعر، مكياج، أظافر، وعناية بالبشرة في جلسة واحدة.',
+
     'book_button': 'احجز الآن',
     'consult_button': 'استشارة مجانية',
     'view_shop': 'زيارة المتجر',

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -754,6 +754,8 @@ export const ar = {
     'dir.cat.visa': 'التأشيرة والإقامة',
     'dir.cat.shopping': 'التسوق والهدايا التذكارية',
     'dir.cat.nature': 'المعالم الطبيعية',
+    'dir.cat.spa_hamam': 'سبا والحمامات',
+    'dir.cat.hair_beauty': 'الشعر والجمال',
     'dir.cat.title': 'تصفح حسب الفئة',
     'dir.cat.subtitle': 'اعثر على كل ما تحتاجه لإقامة مثالية.',
     'dir.trust.title': 'لماذا تثق بمركز عطلات ألانيا؟',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -763,6 +763,8 @@ export const en = {
   'dir.cat.visa': 'Visa & Residency',
   'dir.cat.shopping': 'Shopping & Souvenirs',
   'dir.cat.nature': 'Natural Attractions',
+  'dir.cat.spa_hamam': 'Spa & Hammams',
+  'dir.cat.hair_beauty': 'Hair & Beauty',
   'dir.cat.title': 'Explore by Category',
   'dir.cat.subtitle': 'Find everything you need for your perfect stay.',
   'dir.trust.title': 'Why Trust Alanya Holidays Hub?',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -210,6 +210,26 @@ export const en = {
   'services.connectivity.esim': 'eSIM',
   'services.connectivity.esim_desc': 'Instant data connectivity for your trip.',
 
+  // Spa & Wellness
+  'services.spa.title': 'Spa & Wellness',
+  'services.spa.subtitle': 'Relax and rejuvenate with authentic Turkish spa experiences.',
+  'services.spa.turkish_hamam': 'Traditional Turkish Hamam',
+  'services.spa.turkish_hamam_desc': 'Experience the centuries-old Turkish bath ritual with foam massage and scrub.',
+  'services.spa.massage': 'Relaxing Massage',
+  'services.spa.massage_desc': 'Deep tissue, aromatherapy, and hot stone massage sessions.',
+  'services.spa.wellness_package': 'Full Spa Day Package',
+  'services.spa.wellness_package_desc': 'Complete wellness experience: hamam, massage, facial, and aromatherapy.',
+
+  // Hair & Beauty
+  'services.hair.title': 'Hair & Beauty',
+  'services.hair.subtitle': 'Top-rated salons for a perfect makeover during your stay.',
+  'services.hair.styling': 'Hair Styling & Coloring',
+  'services.hair.styling_desc': 'Professional cuts, coloring, balayage, and styling by expert hairdressers.',
+  'services.hair.nails': 'Nail Salon',
+  'services.hair.nails_desc': 'Manicure, pedicure, gel nails, and nail art in a relaxing atmosphere.',
+  'services.hair.makeover': 'Full Beauty Makeover',
+  'services.hair.makeover_desc': 'Complete beauty package: hair, makeup, nails, and skincare in one session.',
+
   'request_details': 'Request details',
   'book_button': 'Book Now',
   'buy_button': 'Buy',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -754,6 +754,8 @@ export const ru = {
   'dir.cat.visa': 'Виза и ВНЖ',
   'dir.cat.shopping': 'Шопинг и сувениры',
   'dir.cat.nature': 'Природные достопримечательности',
+  'dir.cat.spa_hamam': 'Спа и хаммамы',
+  'dir.cat.hair_beauty': 'Волосы и красота',
   'dir.cat.title': 'Выберите Категорию',
   'dir.cat.subtitle': 'Найдите все необходимое для идеального пребывания.',
   'dir.trust.title': 'Почему выбирают Alanya Holidays Hub?',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -203,6 +203,26 @@ export const ru = {
   'services.connectivity.esim': 'eSIM Пакеты',
   'services.connectivity.esim_desc': 'Мгновенная мобильная связь для вашей поездки.',
 
+  // Спа и Велнес
+  'services.spa.title': 'Спа и Велнес',
+  'services.spa.subtitle': 'Расслабьтесь и восстановите силы в autentичных турецких спа-салонах.',
+  'services.spa.turkish_hamam': 'Традиционный турецкий хамам',
+  'services.spa.turkish_hamam_desc': 'Вековые ритуалы турецкой бани с пенным массажем и скрабом.',
+  'services.spa.massage': 'Расслабляющий массаж',
+  'services.spa.massage_desc': 'Глубокий массаж тканей, ароматерапия и массаж горячими камнями.',
+  'services.spa.wellness_package': 'Полный спа-день',
+  'services.spa.wellness_package_desc': 'Комплексный велнес: хамам, массаж, уход за лицом и ароматерапия.',
+
+  // Волосы и Красота
+  'services.hair.title': 'Волосы и Красота',
+  'services.hair.subtitle': 'Лучшие салоны для идеального преображения во время вашего отдыха.',
+  'services.hair.styling': 'Укладка и окрашивание',
+  'services.hair.styling_desc': 'Профессиональные стрижки, окрашивание, балаяж и укладка от опытных мастеров.',
+  'services.hair.nails': 'Маникюр и педикюр',
+  'services.hair.nails_desc': 'Маникюр, педикюр, гель-лак и нейл-арт в расслабляющей атмосфере.',
+  'services.hair.makeover': 'Полное преображение',
+  'services.hair.makeover_desc': 'Комплексный бьюти-пакет: волосы, макияж, ногти и уход за кожей за один сеанс.',
+
   'book_button': 'Забронировать сейчас',
   'buy_button': 'Купить',
   'consult_button': 'Консультация',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -754,6 +754,8 @@ export const tr = {
     'dir.cat.visa': 'Vize ve İkamet',
     'dir.cat.shopping': 'Alışveriş ve Hediyelik',
     'dir.cat.nature': 'Doğal Güzellikler',
+    'dir.cat.spa_hamam': 'Spa ve Hamamlar',
+    'dir.cat.hair_beauty': 'Saç ve Güzellik',
     'dir.cat.title': 'Kategorileri Keşfedin',
     'dir.cat.subtitle': 'Kusursuz bir konaklama için ihtiyacınız olan her şeyi bulun.',
     'dir.trust.title': 'Neden Alanya Holidays Hub?',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -204,6 +204,26 @@ export const tr = {
     'services.connectivity.esim': 'eSIM Paketleri',
     'services.connectivity.esim_desc': 'Seyahatiniz için anında veri bağlantısı.',
 
+    // Spa & Wellness
+    'services.spa.title': 'Spa & Sağlık',
+    'services.spa.subtitle': 'Otantik Türk hamamı ve spa deneyimleriyle rahatlayın ve yenilenin.',
+    'services.spa.turkish_hamam': 'Geleneksel Türk Hamamı',
+    'services.spa.turkish_hamam_desc': 'Köpük masajı ve kese ile yüzyıllık Türk banyosu ritüeli.',
+    'services.spa.massage': 'Rahatlatıcı Masaj',
+    'services.spa.massage_desc': 'Dokusu derin doku, aromaterapi ve sıcak taş masaj seansları.',
+    'services.spa.wellness_package': 'Tam Spa Günü Paketi',
+    'services.spa.wellness_package_desc': 'Tam wellness deneyimi: hamam, masaj, yüz bakımı ve aromaterapi.',
+
+    // Saç & Güzellik
+    'services.hair.title': 'Saç & Güzellik',
+    'services.hair.subtitle': 'Kalışınızda mükemmel bir görünüm için en iyi kuaförler.',
+    'services.hair.styling': 'Saç Tasarımı ve Boyama',
+    'services.hair.styling_desc': 'Uzman kuaförlerden profesyonel kesim, boyama, balyaj ve styling.',
+    'services.hair.nails': 'Tırnak Salonu',
+    'services.hair.nails_desc': 'Manikür, pedikür, jel tırnak ve nail art rahatlatıcı bir atmosferde.',
+    'services.hair.makeover': 'Tam Güzellik Dönüşümü',
+    'services.hair.makeover_desc': 'Tam güzellik paketi: saç, makyaj, tırnak ve cilt bakımı tek seansta.',
+
     'book_button': 'Hemen Rezervasyon Yap',
     'consult_button': 'Ücretsiz Danışma',
     'view_shop': 'Mağazayı Gez',

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -21,8 +21,8 @@ export const DirectoryHome: React.FC = () => {
         { id: 'visa', icon: '🛂', title: t('dir.cat.visa'), path: '/alanya-residency-guide' },
         { id: 'shopping', icon: '🛍️', title: t('dir.cat.shopping'), path: '/alanya-shopping-guide' },
         { id: 'nature', icon: '🌿', title: t('dir.cat.nature'), path: '/alanya-nature-attractions' },
-        { id: 'spa-hamam', icon: '🧖', title: t('dir.cat.spa_hamam') || 'Spa & Hamams', path: '/alanya-spa-hamam' },
-        { id: 'hair-beauty', icon: '💇', title: t('dir.cat.hair_beauty') || 'Hair & Beauty', path: '/alanya-hair-beauty' },
+        { id: 'spa-hamam', icon: '🧖', title: t('dir.cat.spa_hamam'), path: '/alanya-spa-hamam' },
+        { id: 'hair-beauty', icon: '💇', title: t('dir.cat.hair_beauty'), path: '/alanya-hair-beauty' },
     ];
 
     return (

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -21,6 +21,8 @@ export const DirectoryHome: React.FC = () => {
         { id: 'visa', icon: '🛂', title: t('dir.cat.visa'), path: '/alanya-residency-guide' },
         { id: 'shopping', icon: '🛍️', title: t('dir.cat.shopping'), path: '/alanya-shopping-guide' },
         { id: 'nature', icon: '🌿', title: t('dir.cat.nature'), path: '/alanya-nature-attractions' },
+        { id: 'spa-hamam', icon: '🧖', title: t('dir.cat.spa_hamam') || 'Spa & Hamams', path: '/alanya-spa-hamam' },
+        { id: 'hair-beauty', icon: '💇', title: t('dir.cat.hair_beauty') || 'Hair & Beauty', path: '/alanya-hair-beauty' },
     ];
 
     return (

--- a/pages/ExperienceCategoryPage.tsx
+++ b/pages/ExperienceCategoryPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Check, Compass, Sun, Map, Cloud, Anchor, Mountain, Heart, Car } from 'lucide-react';
+import { Check, Compass, Sun, Map, Cloud, Anchor, Mountain, Heart, Car, Sparkles, Scissors } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
 import { db, ServiceData } from '../api-services';
@@ -63,6 +63,20 @@ export const ExperienceCategoryPage: React.FC = () => {
             heroImage: '/images/experiences/atv_buggy_hero.png',
             features: ['Hourly Rentals', 'Safety Briefing', 'Helmet Included'],
             icon: Car
+        },
+        'spa-wellness': {
+            title: t('services.spa.title'),
+            subtitle: t('services.spa.subtitle'),
+            heroImage: '/images/experiences/wellness_hero.png',
+            features: ['Certified Therapists', 'Premium Products', 'Relaxing Ambiance'],
+            icon: Sparkles
+        },
+        'hair-beauty': {
+            title: t('services.hair.title'),
+            subtitle: t('services.hair.subtitle'),
+            heroImage: '/images/experiences/hair_beauty_hero.png',
+            features: ['Expert Stylists', 'Modern Techniques', 'Luxury Products'],
+            icon: Scissors
         }
     };
 

--- a/pages/ServicesPage.tsx
+++ b/pages/ServicesPage.tsx
@@ -42,6 +42,8 @@ export const ServicesPage: React.FC = () => {
         { id: 'transport', label: t('services.transport.title') },
         { id: 'experiences', label: t('footer.experiences') },
         { id: 'health', label: t('services.health.title') },
+        { id: 'spa-wellness', label: t('services.spa.title') },
+        { id: 'hair-beauty', label: t('services.hair.title') },
         { id: 'visa', label: t('services.visa.title') },
         { id: 'creative', label: t('services.creative.title') },
         { id: 'connectivity', label: t('services.connectivity.title') },

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -93,6 +93,8 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/alanya-shopping-guide" element={<DirectoryCategoryPage categoryId="shopping" />} />
                 <Route path="/alanya-nature-attractions" element={<DirectoryCategoryPage categoryId="nature" />} />
                 <Route path="/nightlife" element={<DirectoryCategoryPage categoryId="nightlife" />} />
+                <Route path="/alanya-spa-hamam" element={<DirectoryCategoryPage categoryId="spa-hamam" />} />
+                <Route path="/alanya-hair-beauty" element={<DirectoryCategoryPage categoryId="hair-beauty" />} />
 
                 <Route path="/list-property" element={<ListProperty />} />
 

--- a/supabase/migrations/20260411000005_unique_stripe_session_id.sql
+++ b/supabase/migrations/20260411000005_unique_stripe_session_id.sql
@@ -1,0 +1,13 @@
+-- [82] Add UNIQUE constraint on bookings.stripe_session_id
+-- Idempotency for Stripe webhooks was only application-level.
+-- A DB-level unique constraint ensures no two bookings share the same
+-- stripe_session_id even under concurrent webhook retries.
+
+-- Drop the plain index added in migration 20260401000000 first
+-- (a UNIQUE constraint creates its own index)
+DROP INDEX IF EXISTS bookings_stripe_session_id_idx;
+
+-- Add unique constraint (partial — only where stripe_session_id is set)
+ALTER TABLE bookings
+ADD CONSTRAINT bookings_stripe_session_id_unique
+UNIQUE (stripe_session_id);


### PR DESCRIPTION
## Summary

- **[83]** Добавлены две новые категории: **Spa & Hammams** и **Hair & Beauty Salons**

## Changes

| Файл | Изменение |
|------|-----------|
| `routes/AppRoutes.tsx` | +2 SEO-маршрута: `/alanya-spa-hamam`, `/alanya-hair-beauty` |
| `pages/DirectoryHome.tsx` | +2 карточки категорий (🧖 Spa & Hamams, 💇 Hair & Beauty) |
| `pages/ServicesPage.tsx` | +2 вкладки: spa-wellness, hair-beauty |
| `pages/ExperienceCategoryPage.tsx` | +2 конфига categoryConfig |
| `data/services.ts` | +6 сервисов: 3 spa-wellness + 3 hair-beauty |
| `locales/en|ru|tr|ar.ts` | +12 ключей локализации на 4 языках |

## Routes

- `/alanya-spa-hamam` → DirectoryCategoryPage (spa-hamam)
- `/alanya-hair-beauty` → DirectoryCategoryPage (hair-beauty)
- `/services/spa-wellness` → ServicesPage tab
- `/services/hair-beauty` → ServicesPage tab
- `/experiences/spa-wellness` → ExperienceCategoryPage
- `/experiences/hair-beauty` → ExperienceCategoryPage

## Risks

Нет. Новые маршруты и данные, существующий код не затронут.