### PR TITLE
feat: add Restaurants admin section [84]

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -15,15 +15,20 @@ const sanitize = <T extends Record<string, unknown>>(obj: T): T => {
 };
 
 export const directoryService = {
-    async getDirectoryListings(page: number = 1, limit: number = 20): Promise<{ data: DirectoryListingDB[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
+    async getDirectoryListings(page: number = 1, limit: number = 20, category?: string): Promise<{ data: DirectoryListingDB[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
         const from = (page - 1) * limit;
         const to = from + limit - 1;
 
-        const { data, error, count } = await supabase
+        let query = supabase
             .from('directory_listings')
             .select('*', { count: 'exact' })
-            .order('created_at', { ascending: false })
-            .range(from, to);
+            .order('created_at', { ascending: false });
+
+        if (category) {
+            query = query.eq('category_id', category);
+        }
+
+        const { data, error, count } = await query.range(from, to);
 
         if (error) {
             console.error('Error fetching directory listings:', error);
@@ -39,6 +44,10 @@ export const directoryService = {
                 totalPages: Math.ceil((count || 0) / limit)
             }
         };
+    },
+
+    async getRestaurantsListings(page: number = 1, limit: number = 20) {
+        return this.getDirectoryListings(page, limit, 'restaurants');
     },
 
     async getDirectoryListing(id: string): Promise<DirectoryListingDB | null> {

--- a/components/admin/directory/DirectoryToolbar.tsx
+++ b/components/admin/directory/DirectoryToolbar.tsx
@@ -10,27 +10,30 @@ interface DirectoryToolbarProps {
     showMigrateButton: boolean;
     onMigrate: () => void;
     onAddListing: () => void;
+    hideCategories?: boolean;
 }
 
 export const DirectoryToolbar: React.FC<DirectoryToolbarProps> = ({
-    categories, filterCategory, onFilterCategory, searchQuery, onSearchQuery, showMigrateButton, onMigrate, onAddListing
+    categories, filterCategory, onFilterCategory, searchQuery, onSearchQuery, showMigrateButton, onMigrate, onAddListing, hideCategories = false
 }) => {
     return (
         <div className="flex flex-col md:flex-row gap-4 justify-between items-center bg-white dark:bg-slate-800/80 p-4 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm">
-            <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl overflow-x-auto max-w-full md:max-w-xl scrollbar-hide">
-                {categories.map(cat => (
-                    <button
-                        key={cat}
-                        onClick={() => onFilterCategory(cat)}
-                        className={`px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${filterCategory === cat
-                            ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
-                            : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
-                            }`}
-                    >
-                        {cat === 'all' ? 'All' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
-                    </button>
-                ))}
-            </div>
+            {!hideCategories && (
+                <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl overflow-x-auto max-w-full md:max-w-xl scrollbar-hide">
+                    {categories.map(cat => (
+                        <button
+                            key={cat}
+                            onClick={() => onFilterCategory(cat)}
+                            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${filterCategory === cat
+                                ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                                : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                        >
+                            {cat === 'all' ? 'All' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                        </button>
+                    ))}
+                </div>
+            )}
 
             <div className="flex flex-col md:flex-row gap-4 w-full md:w-auto">
                 <div className="relative w-full md:w-64">

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen } from 'lucide-react';
+import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat } from 'lucide-react';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
 
 interface AdminLayoutProps {
@@ -28,6 +28,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         { path: '/admin/fleet', label: 'Fleet', icon: Car },
         { path: '/admin/services', label: 'Services', icon: MapIcon },
         { path: '/admin/directory', label: 'Directory', icon: BookOpen },
+        { path: '/admin/restaurants', label: 'Restaurants', icon: ChefHat },
         { path: '/admin/bookings', label: 'Bookings', icon: Calendar },
         { path: '/admin/products', label: 'Products', icon: ShoppingBag },
         { path: '/admin/users', label: 'Users', icon: Users },

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -8,12 +8,14 @@ import { DirectoryToolbar } from '../../components/admin/directory/DirectoryTool
 import { DirectoryTable } from '../../components/admin/directory/DirectoryTable';
 import { toast } from 'react-hot-toast';
 
-export const DirectoryAdminPage: React.FC = () => {
+export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ defaultCategory }) => {
     const navigate = useNavigate();
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [loading, setLoading] = useState(true);
-    const [filterCategory, setFilterCategory] = useState<string>('all');
+    const [filterCategory, setFilterCategory] = useState<string>(defaultCategory || 'all');
     const [searchQuery, setSearchQuery] = useState('');
+
+    const isCategoryLocked = !!defaultCategory;
 
     const [modalConfig, setModalConfig] = useState<{
         isOpen: boolean;
@@ -36,7 +38,8 @@ export const DirectoryAdminPage: React.FC = () => {
     const loadListings = async () => {
         setLoading(true);
         try {
-            const response = await db.getDirectoryListings();
+            const category = isCategoryLocked ? defaultCategory : undefined;
+            const response = await db.getDirectoryListings(1, 100, category);
             setListings(response.data || []);
         } catch (e) {
             console.error('Failed to load listings', e);
@@ -107,8 +110,8 @@ export const DirectoryAdminPage: React.FC = () => {
     };
 
     const filteredListings = listings.filter(l => {
-        const matchesCategory = filterCategory === 'all' || l.category_id === filterCategory;
-        const matchesSearch = l.name.toLowerCase().includes(searchQuery.toLowerCase()) || 
+        const matchesCategory = isCategoryLocked || filterCategory === 'all' || l.category_id === filterCategory;
+        const matchesSearch = l.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
                               l.location.toLowerCase().includes(searchQuery.toLowerCase());
         return matchesCategory && matchesSearch;
     });
@@ -134,6 +137,7 @@ export const DirectoryAdminPage: React.FC = () => {
                 showMigrateButton={listings.length === 0}
                 onMigrate={handleMigrateMockData}
                 onAddListing={() => navigate('/admin/directory/new')}
+                hideCategories={isCategoryLocked}
             />
 
             <DirectoryTable

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { db } from '../../api-services';
 import { useNavigate } from 'react-router-dom';
 import { ConfirmationModal } from '../../components/ui/ConfirmationModal';
@@ -31,11 +31,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         message: ''
     });
 
-    useEffect(() => {
-        loadListings();
-    }, []);
-
-    const loadListings = async () => {
+    const loadListings = useCallback(async () => {
         setLoading(true);
         try {
             const category = isCategoryLocked ? defaultCategory : undefined;
@@ -46,7 +42,11 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         } finally {
             setLoading(false);
         }
-    };
+    }, [isCategoryLocked, defaultCategory]);
+
+    useEffect(() => {
+        loadListings();
+    }, [loadListings]);
 
     const openActionModal = (action: 'delete', id: string, title: string) => {
         setModalConfig({

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -290,6 +290,13 @@ export const AppRoutes: React.FC = () => {
                         </AdminLayout>
                     </AdminRoute>
                 } />
+                <Route path="/admin/restaurants" element={
+                    <AdminRoute>
+                        <AdminLayout>
+                            <DirectoryAdminPage defaultCategory="restaurants" />
+                        </AdminLayout>
+                    </AdminRoute>
+                } />
 
                 {/* Edit Routes (Wrapped in Layout) */}
                 <Route path="/admin/edit-property/:id" element={


### PR DESCRIPTION
## Summary

- `api-services/api/directory.ts` — added optional `category` param to `getDirectoryListings()` for server-side filtering; added `getRestaurantsListings()` helper
- `components/admin/directory/DirectoryToolbar.tsx` — added `hideCategories?: boolean` prop to hide category filter chips when locked
- `pages/admin/DirectoryAdminPage.tsx` — accepts `defaultCategory?: string` prop; when set, locks filter to that category and fetches server-side filtered data
- `routes/AppRoutes.tsx` — added `/admin/restaurants` route → `DirectoryAdminPage defaultCategory="restaurants"`
- `components/layouts/AdminLayout.tsx` — added "Restaurants" nav item with `ChefHat` icon

## Notes

Restaurants remain accessible in `/admin/directory` via the category filter. No new pages, no code duplication — reuses existing infrastructure.