### PR TITLE
feat: add social links to user profile [93]

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -15,15 +15,20 @@ const sanitize = <T extends Record<string, unknown>>(obj: T): T => {
 };
 
 export const directoryService = {
-    async getDirectoryListings(page: number = 1, limit: number = 20): Promise<{ data: DirectoryListingDB[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
+    async getDirectoryListings(page: number = 1, limit: number = 20, category?: string): Promise<{ data: DirectoryListingDB[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
         const from = (page - 1) * limit;
         const to = from + limit - 1;
 
-        const { data, error, count } = await supabase
+        let query = supabase
             .from('directory_listings')
             .select('*', { count: 'exact' })
-            .order('created_at', { ascending: false })
-            .range(from, to);
+            .order('created_at', { ascending: false });
+
+        if (category) {
+            query = query.eq('category_id', category);
+        }
+
+        const { data, error, count } = await query.range(from, to);
 
         if (error) {
             console.error('Error fetching directory listings:', error);
@@ -39,6 +44,10 @@ export const directoryService = {
                 totalPages: Math.ceil((count || 0) / limit)
             }
         };
+    },
+
+    async getRestaurantsListings(page: number = 1, limit: number = 20) {
+        return this.getDirectoryListings(page, limit, 'restaurants');
     },
 
     async getDirectoryListing(id: string): Promise<DirectoryListingDB | null> {

--- a/components/admin/directory/DirectoryToolbar.tsx
+++ b/components/admin/directory/DirectoryToolbar.tsx
@@ -10,27 +10,30 @@ interface DirectoryToolbarProps {
     showMigrateButton: boolean;
     onMigrate: () => void;
     onAddListing: () => void;
+    hideCategories?: boolean;
 }
 
 export const DirectoryToolbar: React.FC<DirectoryToolbarProps> = ({
-    categories, filterCategory, onFilterCategory, searchQuery, onSearchQuery, showMigrateButton, onMigrate, onAddListing
+    categories, filterCategory, onFilterCategory, searchQuery, onSearchQuery, showMigrateButton, onMigrate, onAddListing, hideCategories = false
 }) => {
     return (
         <div className="flex flex-col md:flex-row gap-4 justify-between items-center bg-white dark:bg-slate-800/80 p-4 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm">
-            <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl overflow-x-auto max-w-full md:max-w-xl scrollbar-hide">
-                {categories.map(cat => (
-                    <button
-                        key={cat}
-                        onClick={() => onFilterCategory(cat)}
-                        className={`px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${filterCategory === cat
-                            ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
-                            : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
-                            }`}
-                    >
-                        {cat === 'all' ? 'All' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
-                    </button>
-                ))}
-            </div>
+            {!hideCategories && (
+                <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl overflow-x-auto max-w-full md:max-w-xl scrollbar-hide">
+                    {categories.map(cat => (
+                        <button
+                            key={cat}
+                            onClick={() => onFilterCategory(cat)}
+                            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${filterCategory === cat
+                                ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                                : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                        >
+                            {cat === 'all' ? 'All' : cat.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                        </button>
+                    ))}
+                </div>
+            )}
 
             <div className="flex flex-col md:flex-row gap-4 w-full md:w-auto">
                 <div className="relative w-full md:w-64">

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen } from 'lucide-react';
+import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat } from 'lucide-react';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
 
 interface AdminLayoutProps {
@@ -28,6 +28,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         { path: '/admin/fleet', label: 'Fleet', icon: Car },
         { path: '/admin/services', label: 'Services', icon: MapIcon },
         { path: '/admin/directory', label: 'Directory', icon: BookOpen },
+        { path: '/admin/restaurants', label: 'Restaurants', icon: ChefHat },
         { path: '/admin/bookings', label: 'Bookings', icon: Calendar },
         { path: '/admin/products', label: 'Products', icon: ShoppingBag },
         { path: '/admin/users', label: 'Users', icon: Users },

--- a/components/user/profile/ProfileSettingsTab.test.tsx
+++ b/components/user/profile/ProfileSettingsTab.test.tsx
@@ -11,10 +11,15 @@ vi.mock('lucide-react', () => ({
     Phone: () => <div data-testid="phone-icon" />,
     Home: () => <div data-testid="home-icon" />,
     Save: () => <div data-testid="save-icon" />,
+    Globe: () => <div data-testid="globe-icon" />,
+    Instagram: () => <div data-testid="instagram-icon" />,
+    Facebook: () => <div data-testid="facebook-icon" />,
+    Video: () => <div data-testid="video-icon" />,
+    Music: () => <div data-testid="music-icon" />,
 }));
 
 const defaultProps = {
-    profileForm: { name: 'John Doe', phone: '+90555000', companyName: '' },
+    profileForm: { name: 'John Doe', phone: '+90555000', companyName: '', socialLinks: {} },
     setProfileForm: vi.fn(),
     savingProfile: false,
     handleUpdateProfile: vi.fn(),

--- a/components/user/profile/ProfileSettingsTab.tsx
+++ b/components/user/profile/ProfileSettingsTab.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
-import { UserCircle, Phone, Home, Save } from 'lucide-react';
+import { UserCircle, Phone, Home, Save, Globe, Instagram, Facebook, Video, Music } from 'lucide-react';
 import { useLanguage } from '../../../context/LanguageContext';
+import { SocialLinks } from '../../../types/models';
 
 interface ProfileSettingsTabProps {
-    profileForm: { name: string; phone: string; companyName: string };
+    profileForm: { name: string; phone: string; companyName: string; socialLinks: SocialLinks };
     setProfileForm: React.Dispatch<React.SetStateAction<any>>;
     savingProfile: boolean;
     handleUpdateProfile: (e: React.FormEvent) => void;
     isHostOrAdmin: boolean;
 }
+
+const socialFields: { key: keyof SocialLinks; label: string; placeholder: string; icon: React.FC<{ size: number; className?: string }> }[] = [
+    { key: 'website', label: 'Website', placeholder: 'https://example.com', icon: Globe },
+    { key: 'instagram', label: 'Instagram', placeholder: 'https://instagram.com/...', icon: Instagram },
+    { key: 'facebook', label: 'Facebook', placeholder: 'https://facebook.com/...', icon: Facebook },
+    { key: 'tiktok', label: 'TikTok', placeholder: 'https://tiktok.com/@...', icon: Music },
+    { key: 'youtube', label: 'YouTube', placeholder: 'https://youtube.com/@...', icon: Video },
+];
 
 export const ProfileSettingsTab: React.FC<ProfileSettingsTabProps> = ({
     profileForm,
@@ -73,6 +82,33 @@ export const ProfileSettingsTab: React.FC<ProfileSettingsTabProps> = ({
                         </div>
                     </div>
                 )}
+
+                {/* Social Links Section */}
+                <div className="pt-6 border-t border-slate-100 dark:border-slate-800/50">
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Social Links</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        {socialFields.map(({ key, label, placeholder, icon: Icon }) => (
+                            <div key={key}>
+                                <label className="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-1.5">
+                                    {label}
+                                </label>
+                                <div className="relative">
+                                    <input
+                                        type="url"
+                                        value={profileForm.socialLinks[key] || ''}
+                                        onChange={(e) => setProfileForm({
+                                            ...profileForm,
+                                            socialLinks: { ...profileForm.socialLinks, [key]: e.target.value }
+                                        })}
+                                        placeholder={placeholder}
+                                        className="w-full pl-10 pr-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 rounded-xl focus:ring-2 focus:ring-primary outline-none transition-all dark:text-white text-sm"
+                                    />
+                                    <Icon size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
 
                 <div className="flex justify-end pt-4 border-t border-slate-100 dark:border-slate-800/50">
                     <button

--- a/components/user/profile/ProfileSidebar.tsx
+++ b/components/user/profile/ProfileSidebar.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Camera, Grid, Home, Car, Banknote, Settings, Shield, LogOut } from 'lucide-react';
+import { Camera, Grid, Home, Car, Banknote, Settings, Shield, LogOut, Globe, Instagram, Facebook, Video, Music } from 'lucide-react';
 import { useLanguage } from '../../../context/LanguageContext';
+import { SocialLinks } from '../../../types/models';
 
 interface ProfileSidebarProps {
     user: any;
+    socialLinks?: SocialLinks;
     activeTab: string;
     setActiveTab: (tab: any) => void;
     fileInputRef: React.RefObject<HTMLInputElement>;
@@ -14,8 +16,17 @@ interface ProfileSidebarProps {
     loading: boolean;
 }
 
+const socialIcons: { key: keyof SocialLinks; icon: React.FC<{ size: number; className?: string }>; color: string }[] = [
+    { key: 'website', icon: Globe, color: 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-200' },
+    { key: 'instagram', icon: Instagram, color: 'text-pink-500 hover:text-pink-600' },
+    { key: 'facebook', icon: Facebook, color: 'text-blue-600 hover:text-blue-700' },
+    { key: 'tiktok', icon: Music, color: 'text-slate-700 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white' },
+    { key: 'youtube', icon: Video, color: 'text-red-500 hover:text-red-600' },
+];
+
 export const ProfileSidebar: React.FC<ProfileSidebarProps> = ({
     user,
+    socialLinks,
     activeTab,
     setActiveTab,
     fileInputRef,
@@ -61,6 +72,28 @@ export const ProfileSidebar: React.FC<ProfileSidebarProps> = ({
                     <span className={`w-2 h-2 rounded-full ${user.role === 'admin' ? 'bg-purple-500' : 'bg-green-500'}`}></span>
                     {user.role === 'host' ? t('profile.role.host') : user.role === 'admin' ? t('profile.role.admin') : t('profile.role.guest')}
                 </div>
+
+                {/* Social Links Icons */}
+                {socialLinks && Object.values(socialLinks).some(Boolean) && (
+                    <div className="flex items-center justify-center gap-3 mt-4 pt-4 border-t border-slate-100 dark:border-slate-800/50">
+                        {socialIcons.map(({ key, icon: Icon, color }) => {
+                            const url = socialLinks[key];
+                            if (!url) return null;
+                            return (
+                                <a
+                                    key={key}
+                                    href={url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className={`transition-colors ${color}`}
+                                    title={key}
+                                >
+                                    <Icon size={18} />
+                                </a>
+                            );
+                        })}
+                    </div>
+                )}
             </div>
 
             {/* Navigation Tabs */}

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../context/LanguageContext';
+import { SocialLinks } from '../types/models';
 import { toast } from 'react-hot-toast';
 import { BecomeHostModal } from '../components/modals/BecomeHostModal';
 import { ProfileSidebar } from '../components/user/profile/ProfileSidebar';
@@ -34,7 +35,8 @@ export const Profile: React.FC = () => {
     const [profileForm, setProfileForm] = useState({
         name: user?.name || '',
         phone: '',
-        companyName: user?.company_name || ''
+        companyName: user?.company_name || '',
+        socialLinks: {} as SocialLinks
     });
 
     const [emailForm, setEmailForm] = useState({
@@ -90,7 +92,8 @@ export const Profile: React.FC = () => {
                             ...prev,
                             name: profile.full_name || user.name,
                             phone: profile.phone || '',
-                            companyName: profile.company_name || user.company_name || ''
+                            companyName: profile.company_name || user.company_name || '',
+                            socialLinks: profile.social_links || {}
                         }));
                         setPayoutForm({
                             iban: profile.iban || '',
@@ -150,7 +153,8 @@ export const Profile: React.FC = () => {
             await db.updateUserProfile(user.id, {
                 full_name: profileForm.name,
                 phone: profileForm.phone,
-                company_name: profileForm.companyName
+                company_name: profileForm.companyName,
+                social_links: profileForm.socialLinks
             });
             await updateUser({
                 name: profileForm.name,
@@ -272,6 +276,7 @@ export const Profile: React.FC = () => {
                     {/* Sidebar Navigation */}
                     <ProfileSidebar
                         user={user}
+                        socialLinks={profileForm.socialLinks}
                         activeTab={activeTab}
                         setActiveTab={setActiveTab}
                         fileInputRef={fileInputRef}

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -8,12 +8,14 @@ import { DirectoryToolbar } from '../../components/admin/directory/DirectoryTool
 import { DirectoryTable } from '../../components/admin/directory/DirectoryTable';
 import { toast } from 'react-hot-toast';
 
-export const DirectoryAdminPage: React.FC = () => {
+export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ defaultCategory }) => {
     const navigate = useNavigate();
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [loading, setLoading] = useState(true);
-    const [filterCategory, setFilterCategory] = useState<string>('all');
+    const [filterCategory, setFilterCategory] = useState<string>(defaultCategory || 'all');
     const [searchQuery, setSearchQuery] = useState('');
+
+    const isCategoryLocked = !!defaultCategory;
 
     const [modalConfig, setModalConfig] = useState<{
         isOpen: boolean;
@@ -36,7 +38,8 @@ export const DirectoryAdminPage: React.FC = () => {
     const loadListings = async () => {
         setLoading(true);
         try {
-            const response = await db.getDirectoryListings();
+            const category = isCategoryLocked ? defaultCategory : undefined;
+            const response = await db.getDirectoryListings(1, 100, category);
             setListings(response.data || []);
         } catch (e) {
             console.error('Failed to load listings', e);
@@ -107,8 +110,8 @@ export const DirectoryAdminPage: React.FC = () => {
     };
 
     const filteredListings = listings.filter(l => {
-        const matchesCategory = filterCategory === 'all' || l.category_id === filterCategory;
-        const matchesSearch = l.name.toLowerCase().includes(searchQuery.toLowerCase()) || 
+        const matchesCategory = isCategoryLocked || filterCategory === 'all' || l.category_id === filterCategory;
+        const matchesSearch = l.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
                               l.location.toLowerCase().includes(searchQuery.toLowerCase());
         return matchesCategory && matchesSearch;
     });
@@ -134,6 +137,7 @@ export const DirectoryAdminPage: React.FC = () => {
                 showMigrateButton={listings.length === 0}
                 onMigrate={handleMigrateMockData}
                 onAddListing={() => navigate('/admin/directory/new')}
+                hideCategories={isCategoryLocked}
             />
 
             <DirectoryTable

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { db } from '../../api-services';
 import { useNavigate } from 'react-router-dom';
 import { ConfirmationModal } from '../../components/ui/ConfirmationModal';
@@ -31,11 +31,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         message: ''
     });
 
-    useEffect(() => {
-        loadListings();
-    }, []);
-
-    const loadListings = async () => {
+    const loadListings = useCallback(async () => {
         setLoading(true);
         try {
             const category = isCategoryLocked ? defaultCategory : undefined;
@@ -46,7 +42,11 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         } finally {
             setLoading(false);
         }
-    };
+    }, [isCategoryLocked, defaultCategory]);
+
+    useEffect(() => {
+        loadListings();
+    }, [loadListings]);
 
     const openActionModal = (action: 'delete', id: string, title: string) => {
         setModalConfig({

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -290,6 +290,13 @@ export const AppRoutes: React.FC = () => {
                         </AdminLayout>
                     </AdminRoute>
                 } />
+                <Route path="/admin/restaurants" element={
+                    <AdminRoute>
+                        <AdminLayout>
+                            <DirectoryAdminPage defaultCategory="restaurants" />
+                        </AdminLayout>
+                    </AdminRoute>
+                } />
 
                 {/* Edit Routes (Wrapped in Layout) */}
                 <Route path="/admin/edit-property/:id" element={

--- a/supabase/migrations/20260411000006_add_social_links_to_profiles.sql
+++ b/supabase/migrations/20260411000006_add_social_links_to_profiles.sql
@@ -1,0 +1,2 @@
+-- Add social_links JSONB column to profiles table
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS social_links JSONB DEFAULT '{}';

--- a/types/models.ts
+++ b/types/models.ts
@@ -5,6 +5,14 @@ export interface Amenity {
     label: string;
 }
 
+export interface SocialLinks {
+    website?: string;
+    instagram?: string;
+    facebook?: string;
+    tiktok?: string;
+    youtube?: string;
+}
+
 export interface UserProfile {
   id: string;
   full_name: string;
@@ -18,6 +26,9 @@ export interface UserProfile {
   bank_name?: string;
   bank_account_holder_name?: string;
   crypto_wallet?: string;
+
+  // Social Links
+  social_links?: SocialLinks;
 
   created_at?: string;
   role?: 'guest' | 'user' | 'host' | 'admin';


### PR DESCRIPTION
## Summary
- Add `social_links JSONB DEFAULT '{}'` column to `profiles` table via migration
- New `SocialLinks` interface in `types/models.ts` with `instagram, facebook, tiktok, youtube, website`
- Settings tab extended with Social Links section (5 URL inputs with platform icons)
- ProfileSidebar displays clickable brand-colored icons below role badge when links are set

## Reasoning
Social links are stored as JSONB for flexibility — no schema changes needed to add/remove platforms in the future. Icons are rendered only when at least one link is populated.

## Risks
- Migration must be applied before the feature works (`supabase db push`)
- No URL validation beyond browser-native `type="url"` — intentionally kept simple

## Testing
1. Apply migration
2. Go to Profile → Settings → fill any social link → Save
3. Check sidebar for icons