### PR TITLE
feat: add review moderation with flagging and admin panel [94]

### DIFF
--- a/api-services/api/properties/index.ts
+++ b/api-services/api/properties/index.ts
@@ -3,7 +3,7 @@ import {
     getProperty, getPropertiesByHost, getAdminProperties,
     updateProperty, updatePropertyStatus, deleteProperty
 } from './crud';
-import { getReviews, getReviewCount, addReview, deleteReview } from './reviews';
+import { getReviews, getReviewCount, addReview, deleteReview, flagReview, unflagReview, getFlaggedReviews, bulkDeleteReviews } from './reviews';
 import { getPropertyTypes, getPropertyLocations, getPropertiesByLocation } from './catalog';
 import {
     getPropertyAvailability, updatePropertyAvailability,
@@ -30,6 +30,10 @@ export const propertiesService = {
     getReviewCount,
     addReview,
     deleteReview,
+    flagReview,
+    unflagReview,
+    getFlaggedReviews,
+    bulkDeleteReviews,
 
     // Catalog
     getPropertyTypes,

--- a/api-services/api/properties/reviews.ts
+++ b/api-services/api/properties/reviews.ts
@@ -3,6 +3,7 @@ import { Review } from '../../../types/index';
 import { reviewSchema } from '../schemas';
 import { getAppUrl } from '../../../utils/appUrl';
 import { retry } from '../../../utils/retry';
+import { getUserRole } from '../../auth';
 
 export async function getReviews(propertyId: string, page: number = 1, limit: number = 10) {
     const from = (page - 1) * limit;
@@ -12,6 +13,7 @@ export async function getReviews(propertyId: string, page: number = 1, limit: nu
         .from('reviews')
         .select('*, user:profiles(full_name, avatar_url)', { count: 'exact' })
         .eq('property_id', propertyId)
+        .eq('is_hidden', false)
         .order('created_at', { ascending: false })
         .range(from, to);
     if (error) throw error;
@@ -30,7 +32,8 @@ export async function getReviewCount(propertyId: string) {
     const { count, error } = await supabase
         .from('reviews')
         .select('*', { count: 'exact', head: true })
-        .eq('property_id', propertyId);
+        .eq('property_id', propertyId)
+        .eq('is_hidden', false);
     if (error) throw error;
     return count || 0;
 }
@@ -85,8 +88,84 @@ export async function deleteReview(reviewId: string) {
 
     if (fetchError) throw fetchError;
     if (!review) throw new Error('Review not found');
-    if (review.user_id !== user.id) throw new Error('Unauthorized: You can only delete your own reviews');
+
+    const role = await getUserRole(user.id);
+    if (review.user_id !== user.id && role !== 'admin') {
+        throw new Error('Unauthorized: You can only delete your own reviews');
+    }
 
     const { error } = await supabase.from('reviews').delete().eq('id', reviewId);
+    if (error) throw error;
+}
+
+export async function flagReview(reviewId: string) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    const { error } = await supabase
+        .from('reviews')
+        .update({ is_flagged: true, is_hidden: true })
+        .eq('id', reviewId)
+        .neq('user_id', user.id);
+
+    if (error) throw error;
+}
+
+export async function unflagReview(reviewId: string) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    const role = await getUserRole(user.id);
+    if (role !== 'admin') throw new Error('Not authorized: only admins can unflag reviews');
+
+    const { error } = await supabase
+        .from('reviews')
+        .update({ is_flagged: false, is_hidden: false })
+        .eq('id', reviewId);
+
+    if (error) throw error;
+}
+
+export async function getFlaggedReviews(page: number = 1, limit: number = 20) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    const role = await getUserRole(user.id);
+    if (role !== 'admin') throw new Error('Not authorized: only admins can view flagged reviews');
+
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+
+    const { data, error, count } = await supabase
+        .from('reviews')
+        .select('*, user:profiles(full_name, avatar_url), properties(title)', { count: 'exact' })
+        .eq('is_flagged', true)
+        .order('created_at', { ascending: false })
+        .range(from, to);
+
+    if (error) throw error;
+    return {
+        data: data as (Review & { properties?: { title: string } })[],
+        pagination: {
+            page,
+            limit,
+            total: count || 0,
+            totalPages: Math.ceil((count || 0) / limit)
+        }
+    };
+}
+
+export async function bulkDeleteReviews(reviewIds: string[]) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    const role = await getUserRole(user.id);
+    if (role !== 'admin') throw new Error('Not authorized: only admins can bulk delete reviews');
+
+    const { error } = await supabase
+        .from('reviews')
+        .delete()
+        .in('id', reviewIds);
+
     if (error) throw error;
 }

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat } from 'lucide-react';
+import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat, MessageSquare } from 'lucide-react';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
 
 interface AdminLayoutProps {
@@ -32,6 +32,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         { path: '/admin/bookings', label: 'Bookings', icon: Calendar },
         { path: '/admin/products', label: 'Products', icon: ShoppingBag },
         { path: '/admin/users', label: 'Users', icon: Users },
+        { path: '/admin/reviews', label: 'Reviews', icon: MessageSquare },
         { path: '/admin/reports', label: 'Reports', icon: Flag },
     ];
 

--- a/components/reviews/ReviewsSection.tsx
+++ b/components/reviews/ReviewsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Star, User, Trash2 } from 'lucide-react';
+import { Star, User, Trash2, Flag } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { db, Review } from '../../api-services';
 import { ReviewModal } from './ReviewModal';
@@ -59,6 +59,23 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({ propertyId }) =>
             toast.error(error instanceof Error ? error.message : 'Failed to delete review');
         } finally {
             setDeletingReviewId(null);
+        }
+    };
+
+    const handleFlagReview = async (reviewId: string) => {
+        if (!user) return;
+
+        if (!confirm('Flag this review as fake or inappropriate? An admin will review it.')) {
+            return;
+        }
+
+        try {
+            await db.flagReview(reviewId);
+            toast.success('Review flagged. An admin will review it.');
+            await fetchReviews();
+        } catch (error) {
+            console.error('❌ Failed to flag review:', error);
+            toast.error(error instanceof Error ? error.message : 'Failed to flag review');
         }
     };
 
@@ -135,6 +152,16 @@ export const ReviewsSection: React.FC<ReviewsSectionProps> = ({ propertyId }) =>
                                             aria-label="Delete review"
                                         >
                                             <Trash2 size={14} />
+                                        </button>
+                                    )}
+                                    {user && review.user_id !== user.id && (
+                                        <button
+                                            onClick={() => handleFlagReview(review.id!)}
+                                            className="ml-2 p-1.5 text-slate-400 hover:text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-950/20 rounded-lg transition"
+                                            title="Flag as fake"
+                                            aria-label="Flag as fake"
+                                        >
+                                            <Flag size={14} />
                                         </button>
                                     )}
                                 </div>

--- a/pages/admin/ReviewsAdminPage.tsx
+++ b/pages/admin/ReviewsAdminPage.tsx
@@ -3,7 +3,7 @@ import { db } from '../../api-services';
 import { Review } from '../../types/models';
 import { ConfirmationModal } from '../../components/ui/ConfirmationModal';
 import { toast } from 'react-hot-toast';
-import { Star, Flag, Trash2, CheckCircle, XCircle, User } from 'lucide-react';
+import { Star, Flag, Trash2, CheckCircle, User } from 'lucide-react';
 
 export const ReviewsAdminPage: React.FC = () => {
     const [reviews, setReviews] = useState<(Review & { user?: { full_name: string; avatar_url: string }; properties?: { title: string } })[]>([]);

--- a/pages/admin/ReviewsAdminPage.tsx
+++ b/pages/admin/ReviewsAdminPage.tsx
@@ -1,0 +1,286 @@
+import React, { useState, useEffect } from 'react';
+import { db } from '../../api-services';
+import { Review } from '../../types/models';
+import { ConfirmationModal } from '../../components/ui/ConfirmationModal';
+import { toast } from 'react-hot-toast';
+import { Star, Flag, Trash2, CheckCircle, XCircle, User } from 'lucide-react';
+
+export const ReviewsAdminPage: React.FC = () => {
+    const [reviews, setReviews] = useState<(Review & { user?: { full_name: string; avatar_url: string }; properties?: { title: string } })[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [searchQuery, setSearchQuery] = useState('');
+
+    const [modalConfig, setModalConfig] = useState<{
+        isOpen: boolean;
+        type: 'delete' | 'bulkDelete' | null;
+        itemId: string | null;
+        title: string;
+        message: string;
+    }>({
+        isOpen: false,
+        type: null,
+        itemId: null,
+        title: '',
+        message: ''
+    });
+
+    useEffect(() => {
+        loadReviews();
+    }, []);
+
+    const loadReviews = async () => {
+        setLoading(true);
+        try {
+            const response = await db.getFlaggedReviews(1, 100);
+            setReviews(response.data || []);
+        } catch (e) {
+            console.error('Failed to load flagged reviews', e);
+            toast.error('Failed to load flagged reviews');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleUnflag = async (reviewId: string) => {
+        try {
+            await db.unflagReview(reviewId);
+            toast.success('Review unflagged and restored');
+            setReviews(prev => prev.filter(r => r.id !== reviewId));
+            setSelectedIds(prev => {
+                const next = new Set(prev);
+                next.delete(reviewId);
+                return next;
+            });
+        } catch (e: any) {
+            toast.error(e.message || 'Failed to unflag review');
+        }
+    };
+
+    const openDeleteModal = (reviewId: string, authorName: string) => {
+        setModalConfig({
+            isOpen: true,
+            type: 'delete',
+            itemId: reviewId,
+            title: 'Delete Review',
+            message: `Are you sure you want to delete the review by "${authorName}"? This cannot be undone.`
+        });
+    };
+
+    const openBulkDeleteModal = () => {
+        if (selectedIds.size === 0) return;
+        setModalConfig({
+            isOpen: true,
+            type: 'bulkDelete',
+            itemId: null,
+            title: 'Delete Selected Reviews',
+            message: `Are you sure you want to delete ${selectedIds.size} selected review(s)? This cannot be undone.`
+        });
+    };
+
+    const handleConfirmAction = async () => {
+        try {
+            if (modalConfig.type === 'delete' && modalConfig.itemId) {
+                await db.deleteReview(modalConfig.itemId);
+                setReviews(prev => prev.filter(r => r.id !== modalConfig.itemId));
+            } else if (modalConfig.type === 'bulkDelete' && selectedIds.size > 0) {
+                await db.bulkDeleteReviews(Array.from(selectedIds));
+                setReviews(prev => prev.filter(r => !selectedIds.has(r.id)));
+                setSelectedIds(new Set());
+            }
+            toast.success('Reviews deleted successfully');
+        } catch (e: any) {
+            toast.error(e.message || 'Failed to delete reviews');
+        } finally {
+            setModalConfig({ isOpen: false, type: null, itemId: null, title: '', message: '' });
+        }
+    };
+
+    const toggleSelect = (id: string) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const toggleSelectAll = () => {
+        if (selectedIds.size === reviews.length) {
+            setSelectedIds(new Set());
+        } else {
+            setSelectedIds(new Set(reviews.map(r => r.id)));
+        }
+    };
+
+    const filteredReviews = reviews.filter(r => {
+        if (!searchQuery) return true;
+        const q = searchQuery.toLowerCase();
+        const authorName = r.user?.full_name || '';
+        const propertyName = r.properties?.title || '';
+        const comment = r.comment || '';
+        return authorName.toLowerCase().includes(q) || propertyName.toLowerCase().includes(q) || comment.toLowerCase().includes(q);
+    });
+
+    const formatDate = (dateString?: string) => {
+        if (!dateString) return '';
+        return new Date(dateString).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+        });
+    };
+
+    return (
+        <div className="space-y-6 animate-in fade-in duration-500">
+            {/* Header */}
+            <div className="flex flex-col md:flex-row gap-4 justify-between items-start md:items-center">
+                <div>
+                    <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+                        <Flag className="text-orange-500" size={24} />
+                        Flagged Reviews
+                    </h1>
+                    <p className="text-slate-500 mt-1">Review and moderate flagged content</p>
+                </div>
+            </div>
+
+            {/* Toolbar */}
+            <div className="flex flex-col md:flex-row gap-4 justify-between items-center bg-white dark:bg-slate-800/80 p-4 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm">
+                <div className="flex items-center gap-3">
+                    {selectedIds.size > 0 && (
+                        <>
+                            <span className="text-sm text-slate-500">{selectedIds.size} selected</span>
+                            <button
+                                onClick={openBulkDeleteModal}
+                                className="flex items-center gap-2 bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-xl text-sm font-medium transition-colors"
+                            >
+                                <Trash2 size={16} />
+                                Delete Selected
+                            </button>
+                        </>
+                    )}
+                </div>
+
+                <div className="relative w-full md:w-64">
+                    <input
+                        type="text"
+                        placeholder="Search reviews..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="w-full pl-4 pr-4 py-2 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 rounded-xl focus:ring-2 focus:ring-teal-500/20 outline-none transition-all dark:text-white text-sm"
+                    />
+                </div>
+            </div>
+
+            {/* Table */}
+            {loading ? (
+                <div className="bg-white dark:bg-slate-800/80 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm p-12 text-center">
+                    <div className="text-slate-500">Loading flagged reviews...</div>
+                </div>
+            ) : filteredReviews.length === 0 ? (
+                <div className="bg-white dark:bg-slate-800/80 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm p-12 text-center">
+                    <Flag size={48} className="mx-auto text-slate-300 dark:text-slate-600 mb-4" />
+                    <h3 className="text-lg font-semibold text-slate-700 dark:text-slate-300">No flagged reviews</h3>
+                    <p className="text-slate-500 text-sm mt-1">All reviews look clean. Flagged reviews will appear here.</p>
+                </div>
+            ) : (
+                <div className="bg-white dark:bg-slate-800/80 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm overflow-hidden">
+                    {/* Table Header */}
+                    <div className="grid grid-cols-12 gap-4 px-6 py-3 bg-slate-50 dark:bg-slate-900/50 text-xs font-semibold text-slate-500 uppercase tracking-wider border-b border-slate-100 dark:border-slate-800/50">
+                        <div className="col-span-1 flex items-center">
+                            <input
+                                type="checkbox"
+                                checked={selectedIds.size === reviews.length && reviews.length > 0}
+                                onChange={toggleSelectAll}
+                                className="w-4 h-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+                            />
+                        </div>
+                        <div className="col-span-2">Author</div>
+                        <div className="col-span-2">Property</div>
+                        <div className="col-span-4">Review</div>
+                        <div className="col-span-1 text-center">Rating</div>
+                        <div className="col-span-1 text-center">Date</div>
+                        <div className="col-span-1 text-right">Actions</div>
+                    </div>
+
+                    {/* Table Body */}
+                    {filteredReviews.map(review => (
+                        <div
+                            key={review.id}
+                            className={`grid grid-cols-12 gap-4 px-6 py-4 border-b border-slate-50 dark:border-slate-800/30 items-center hover:bg-slate-50/50 dark:hover:bg-slate-800/30 transition-colors ${selectedIds.has(review.id) ? 'bg-orange-50/50 dark:bg-orange-950/10' : ''}`}
+                        >
+                            <div className="col-span-1 flex items-center">
+                                <input
+                                    type="checkbox"
+                                    checked={selectedIds.has(review.id)}
+                                    onChange={() => toggleSelect(review.id)}
+                                    className="w-4 h-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+                                />
+                            </div>
+                            <div className="col-span-2 flex items-center gap-2">
+                                <div className="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-700 overflow-hidden flex-shrink-0">
+                                    {review.user?.avatar_url ? (
+                                        <img src={review.user.avatar_url} alt="" className="w-full h-full object-cover" />
+                                    ) : (
+                                        <div className="w-full h-full flex items-center justify-center text-slate-400">
+                                            <User size={14} />
+                                        </div>
+                                    )}
+                                </div>
+                                <span className="text-sm font-medium text-slate-700 dark:text-slate-200 truncate">
+                                    {review.user?.full_name || 'Anonymous'}
+                                </span>
+                            </div>
+                            <div className="col-span-2 text-sm text-slate-500 dark:text-slate-400 truncate">
+                                {review.properties?.title || 'Unknown property'}
+                            </div>
+                            <div className="col-span-4 text-sm text-slate-600 dark:text-slate-300 line-clamp-2">
+                                {review.comment}
+                            </div>
+                            <div className="col-span-1 flex justify-center">
+                                <div className="flex gap-0.5">
+                                    {[...Array(5)].map((_, i) => (
+                                        <Star
+                                            key={i}
+                                            size={12}
+                                            className={i < review.rating ? 'fill-yellow-400 text-yellow-400' : 'text-slate-300 dark:text-slate-600'}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                            <div className="col-span-1 text-center text-xs text-slate-400">
+                                {formatDate(review.created_at)}
+                            </div>
+                            <div className="col-span-1 flex justify-end gap-1">
+                                <button
+                                    onClick={() => handleUnflag(review.id!)}
+                                    className="p-1.5 text-green-500 hover:bg-green-50 dark:hover:bg-green-950/20 rounded-lg transition"
+                                    title="Unflag & restore"
+                                >
+                                    <CheckCircle size={16} />
+                                </button>
+                                <button
+                                    onClick={() => openDeleteModal(review.id!, review.user?.full_name || 'Anonymous')}
+                                    className="p-1.5 text-red-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-lg transition"
+                                    title="Delete review"
+                                >
+                                    <Trash2 size={16} />
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            <ConfirmationModal
+                isOpen={modalConfig.isOpen}
+                onClose={() => setModalConfig({ ...modalConfig, isOpen: false })}
+                onConfirm={handleConfirmAction}
+                title={modalConfig.title}
+                message={modalConfig.message}
+                confirmLabel="Delete"
+                isDestructive={true}
+            />
+        </div>
+    );
+};

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -56,6 +56,7 @@ const PropertiesPage = React.lazy(() => import('../pages/admin/PropertiesPage').
 const UsersPage = React.lazy(() => import('../pages/admin/UsersPage').then(module => ({ default: module.UsersPage })));
 const AdminServicesPage = React.lazy(() => import('../pages/admin/ServicesPage').then(module => ({ default: module.ServicesPage })));
 const ReportsPage = React.lazy(() => import('../pages/admin/ReportsPage').then(module => ({ default: module.ReportsPage })));
+const ReviewsAdminPage = React.lazy(() => import('../pages/admin/ReviewsAdminPage').then(module => ({ default: module.ReviewsAdminPage })));
 const AdminProductsPage = React.lazy(() => import('../pages/admin/ProductsPage').then(module => ({ default: module.ProductsPage })));
 const AdminEditProductPage = React.lazy(() => import('../pages/admin/AdminEditProductPage').then(module => ({ default: module.AdminEditProductPage })));
 const DirectoryAdminPage = React.lazy(() => import('../pages/admin/DirectoryAdminPage').then(module => ({ default: module.DirectoryAdminPage })));
@@ -259,6 +260,13 @@ export const AppRoutes: React.FC = () => {
                     <AdminRoute>
                         <AdminLayout>
                             <ReportsPage />
+                        </AdminLayout>
+                    </AdminRoute>
+                } />
+                <Route path="/admin/reviews" element={
+                    <AdminRoute>
+                        <AdminLayout>
+                            <ReviewsAdminPage />
                         </AdminLayout>
                     </AdminRoute>
                 } />

--- a/supabase/migrations/20260411000007_add_review_moderation.sql
+++ b/supabase/migrations/20260411000007_add_review_moderation.sql
@@ -1,0 +1,3 @@
+-- Add moderation columns to reviews table
+ALTER TABLE reviews ADD COLUMN IF NOT EXISTS is_flagged BOOLEAN DEFAULT false;
+ALTER TABLE reviews ADD COLUMN IF NOT EXISTS is_hidden BOOLEAN DEFAULT false;

--- a/types/models.ts
+++ b/types/models.ts
@@ -235,6 +235,8 @@ export interface Review {
     comment: string;
     images?: string[];
     created_at?: string;
+    is_flagged?: boolean;
+    is_hidden?: boolean;
     user?: {
         full_name: string;
         avatar_url: string;


### PR DESCRIPTION
## Summary
- Migration: adds `is_flagged` and `is_hidden` BOOLEAN columns to `reviews` table
- Flagging a review sets both to `true` — hides it from public view immediately
- Fix `deleteReview()` — now allows admin to delete any review (was restricted to own reviews only)
- New `flagReview()` — any authenticated user can flag reviews that aren't theirs
- New `unflagReview()` — admin only, restores review to public view
- New `getFlaggedReviews()` — admin only, paginated list with property join
- New `bulkDeleteReviews()` — admin only, deletes by ID array
- `ReviewsSection` — Flag button (orange) shown on other users' reviews, hides after flagging
- New `ReviewsAdminPage` at `/admin/reviews` — table with search, checkboxes, unflag and delete actions
- Nav item added to AdminLayout

## Risks
- Migration must be applied before flagging works (`supabase db push`)
- `flagReview` silently succeeds if review doesn't exist (Supabase UPDATE with no matching rows returns no error)

## Testing
1. Apply migration
2. Login as regular user → open any property → flag someone else's review → confirm it disappears
3. Login as admin → go to `/admin/reviews` → flagged review appears → test unflag and delete