### PR TITLE
feat: add listing votes (👍/👎) with batch RPC and toggle fix

### DIFF
--- a/api-services/api/directory.test.ts
+++ b/api-services/api/directory.test.ts
@@ -104,8 +104,9 @@ describe('directoryService', () => {
     describe('getDirectoryListingsByCategory', () => {
         it('returns listings filtered by category', async () => {
             const chain = makeChain();
-            // Second order call resolves with data
+            // Three order calls: is_featured, net_votes, name — last one resolves
             chain.order
+                .mockReturnValueOnce(chain)
                 .mockReturnValueOnce(chain)
                 .mockResolvedValueOnce({ data: [mockListing], error: null });
             mockSupabase.from.mockReturnValue(chain);
@@ -117,6 +118,7 @@ describe('directoryService', () => {
         it('throws on error', async () => {
             const chain = makeChain();
             chain.order
+                .mockReturnValueOnce(chain)
                 .mockReturnValueOnce(chain)
                 .mockResolvedValueOnce({ data: null, error: { message: 'fail' } });
             mockSupabase.from.mockReturnValue(chain);

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -71,6 +71,7 @@ export const directoryService = {
             .select('*')
             .eq('category_id', categoryId)
             .order('is_featured', { ascending: false })
+            .order('net_votes', { ascending: false, nullsFirst: false })
             .order('name', { ascending: true });
 
         if (error) {
@@ -79,6 +80,59 @@ export const directoryService = {
         }
 
         return data as DirectoryListingDB[];
+    },
+
+    async voteForListing(listingId: string, vote: 1 | -1): Promise<{ netVotes: number; userVote: number }> {
+        const { data, error } = await supabase
+            .rpc('vote_listing', {
+                p_listing_id: listingId,
+                p_listing_type: 'directory',
+                p_vote: vote
+            });
+
+        if (error) {
+            console.error('Error voting for listing:', error);
+            throw error;
+        }
+
+        return {
+            netVotes: data[0].net_votes,
+            userVote: data[0].user_vote
+        };
+    },
+
+    async getUserVotesBatch(listingIds: string[]): Promise<Record<string, 1 | -1>> {
+        const { data, error } = await supabase
+            .rpc('get_user_votes_batch', {
+                p_listing_ids: listingIds,
+                p_listing_type: 'directory'
+            });
+
+        if (error) {
+            console.error('Error getting user votes batch:', error);
+            return {};
+        }
+
+        const votes: Record<string, 1 | -1> = {};
+        for (const row of (data as { listing_id: string; vote: 1 | -1 }[])) {
+            votes[row.listing_id] = row.vote;
+        }
+        return votes;
+    },
+
+    async removeListingVote(listingId: string): Promise<{ netVotes: number }> {
+        const { data, error } = await supabase
+            .rpc('remove_listing_vote', {
+                p_listing_id: listingId,
+                p_listing_type: 'directory'
+            });
+
+        if (error) {
+            console.error('Error removing vote:', error);
+            throw error;
+        }
+
+        return { netVotes: data[0].net_votes };
     },
 
     async createDirectoryListing(listing: Omit<DirectoryListingDB, 'id' | 'created_at' | 'updated_at'>): Promise<DirectoryListingDB> {

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
-import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check } from 'lucide-react';
+import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, ThumbsUp, ThumbsDown } from 'lucide-react';
 import { DirectoryListingDB } from '../../types/models';
 
 interface DirectoryListingCardProps {
     listing: DirectoryListingDB;
     onClick?: (listing: DirectoryListingDB) => void;
+    userVote?: 1 | -1 | null;
+    onVote?: (listingId: string, vote: 1 | -1) => void;
+    isAuthenticated?: boolean;
+    isVoting?: boolean;
 }
 
-export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({ listing, onClick }) => {
+export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
+    listing, onClick, userVote, onVote, isAuthenticated, isVoting
+}) => {
+    const netVotes = listing.net_votes || 0;
+
+    const handleVote = (e: React.MouseEvent, vote: 1 | -1) => {
+        e.stopPropagation();
+        if (!isAuthenticated || isVoting) return;
+        onVote?.(listing.id, vote);
+    };
+
     return (
         <div 
             className={`group flex flex-col bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 border border-slate-200 dark:border-slate-700 h-full ${onClick ? 'cursor-pointer' : ''}`}
@@ -57,6 +71,41 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({ list
                 <p className="text-slate-600 dark:text-slate-400 text-sm leading-relaxed mb-4 line-clamp-2">
                     {listing.short_description}
                 </p>
+
+                {/* Vote Buttons */}
+                <div className="flex items-center gap-3 mb-4">
+                    <button
+                        onClick={(e) => handleVote(e, 1)}
+                        className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                            userVote === 1
+                                ? 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400'
+                                : isAuthenticated && !isVoting
+                                    ? 'bg-slate-100 dark:bg-slate-700 text-slate-500 hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 dark:hover:text-green-400'
+                                    : 'bg-slate-100 dark:bg-slate-700 text-slate-400 cursor-not-allowed'
+                        }`}
+                        title={isAuthenticated ? 'Helpful' : 'Login to vote'}
+                        disabled={!isAuthenticated || isVoting}
+                    >
+                        <ThumbsUp size={14} className={userVote === 1 ? 'fill-green-600 dark:fill-green-400' : ''} />
+                    </button>
+                    <button
+                        onClick={(e) => handleVote(e, -1)}
+                        className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                            userVote === -1
+                                ? 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'
+                                : isAuthenticated && !isVoting
+                                    ? 'bg-slate-100 dark:bg-slate-700 text-slate-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 dark:hover:text-red-400'
+                                    : 'bg-slate-100 dark:bg-slate-700 text-slate-400 cursor-not-allowed'
+                        }`}
+                        title={isAuthenticated ? 'Not helpful' : 'Login to vote'}
+                        disabled={!isAuthenticated || isVoting}
+                    >
+                        <ThumbsDown size={14} className={userVote === -1 ? 'fill-red-600 dark:fill-red-400' : ''} />
+                    </button>
+                    <span className={`text-xs font-medium ${netVotes > 0 ? 'text-green-600 dark:text-green-400' : netVotes < 0 ? 'text-red-600 dark:text-red-400' : 'text-slate-400'}`}>
+                        {netVotes > 0 ? `+${netVotes}` : netVotes}
+                    </span>
+                </div>
 
                 {/* Tags */}
                 <div className="flex flex-wrap gap-2 mb-4">

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -1,12 +1,14 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { useParams, Navigate } from 'react-router-dom';
 import { Filter, Star, Info, ChevronDown, ChevronUp } from 'lucide-react';
 import { Helmet } from 'react-helmet-async';
+import { useAuth } from '../context/AuthContext';
 import { directoryCategoryIntros } from '../data/directoryData';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { db } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
+import { toast } from 'react-hot-toast';
 
 export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categoryId: propCategoryId }) => {
     const params = useParams<{ categoryId: string }>();
@@ -30,6 +32,11 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [_loading, setLoading] = useState(true);
 
+    // Auth & Voting State
+    const { isAuthenticated, user } = useAuth();
+    const [userVotes, setUserVotes] = useState<Record<string, 1 | -1>>({});
+    const [votingId, setVotingId] = useState<string | null>(null);
+
     // Fetch from Supabase
     React.useEffect(() => {
         if (!categoryId) return;
@@ -46,6 +53,48 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
         };
         fetchListings();
     }, [categoryId]);
+
+    // Fetch user's votes for current listings — single batch call
+    useEffect(() => {
+        if (!isAuthenticated || !user || listings.length === 0) return;
+
+        const ids = listings.map(l => l.id);
+        db.getUserVotesBatch(ids).then(setUserVotes);
+    }, [isAuthenticated, user?.id, listings.length]);
+
+    const handleVote = useCallback(async (listingId: string, vote: 1 | -1) => {
+        if (!isAuthenticated || votingId) return;
+
+        const currentVote = userVotes[listingId];
+        const isToggleOff = currentVote === vote;
+
+        setVotingId(listingId);
+        try {
+            if (isToggleOff) {
+                // Remove vote via dedicated RPC
+                const result = await db.removeListingVote(listingId);
+                setUserVotes(prev => {
+                    const next = { ...prev };
+                    delete next[listingId];
+                    return next;
+                });
+                setListings(prev => prev.map(l =>
+                    l.id === listingId ? { ...l, net_votes: result.netVotes } : l
+                ));
+            } else {
+                const result = await db.voteForListing(listingId, vote);
+                setUserVotes(prev => ({ ...prev, [listingId]: result.userVote as 1 | -1 }));
+                setListings(prev => prev.map(l =>
+                    l.id === listingId ? { ...l, net_votes: result.netVotes } : l
+                ));
+            }
+        } catch (e: any) {
+            console.error('Failed to vote:', e);
+            toast.error(e.message || 'Failed to vote');
+        } finally {
+            setVotingId(null);
+        }
+    }, [isAuthenticated, userVotes, votingId]);
 
     // Extract unique locations and languages for this category to populate filter
     const availableLocations = useMemo(() => {
@@ -274,7 +323,15 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                         </h2>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                             {featuredListings.map(listing => (
-                                <DirectoryListingCard key={listing.id} listing={listing} onClick={setSelectedListing} />
+                                <DirectoryListingCard
+                                    key={listing.id}
+                                    listing={listing}
+                                    onClick={setSelectedListing}
+                                    userVote={userVotes[listing.id] ?? null}
+                                    onVote={handleVote}
+                                    isAuthenticated={isAuthenticated}
+                                    isVoting={votingId === listing.id}
+                                />
                             ))}
                         </div>
                     </div>
@@ -288,7 +345,15 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                     {standardListings.length > 0 ? (
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                             {standardListings.map(listing => (
-                                <DirectoryListingCard key={listing.id} listing={listing} onClick={setSelectedListing} />
+                                <DirectoryListingCard
+                                    key={listing.id}
+                                    listing={listing}
+                                    onClick={setSelectedListing}
+                                    userVote={userVotes[listing.id] ?? null}
+                                    onVote={handleVote}
+                                    isAuthenticated={isAuthenticated}
+                                    isVoting={votingId === listing.id}
+                                />
                             ))}
                         </div>
                     ) : (

--- a/supabase/migrations/20260411000008_listing_votes.sql
+++ b/supabase/migrations/20260411000008_listing_votes.sql
@@ -1,0 +1,234 @@
+-- ============================================================
+-- Migration: Directory Listing Votes (👍/👎)
+-- Date: 2026-04-11
+-- ============================================================
+
+-- 1. Add net_votes column to directory_listings
+ALTER TABLE directory_listings ADD COLUMN IF NOT EXISTS net_votes INT DEFAULT 0;
+
+-- 2. Index for sorting by net_votes
+CREATE INDEX IF NOT EXISTS idx_directory_listings_net_votes ON directory_listings (category_id, net_votes DESC) WHERE net_votes != 0;
+
+-- 3. Create listing_votes table
+CREATE TABLE IF NOT EXISTS listing_votes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    listing_id UUID NOT NULL REFERENCES directory_listings(id) ON DELETE CASCADE,
+    listing_type TEXT NOT NULL DEFAULT 'directory',
+    vote SMALLINT NOT NULL CHECK (vote IN (1, -1)),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT unique_user_listing_vote UNIQUE (user_id, listing_id, listing_type)
+);
+
+-- 4. Indexes on listing_votes
+CREATE INDEX IF NOT EXISTS idx_listing_votes_listing ON listing_votes (listing_id, listing_type);
+CREATE INDEX IF NOT EXISTS idx_listing_votes_user ON listing_votes (user_id);
+
+-- 5. Enable RLS on listing_votes
+ALTER TABLE listing_votes ENABLE ROW LEVEL SECURITY;
+
+-- 6. RLS Policies for listing_votes
+
+-- Public can read votes (transparent)
+CREATE POLICY "listing_votes_select" ON listing_votes
+    FOR SELECT
+    USING (true);
+
+-- Authenticated users can insert their own vote
+CREATE POLICY "listing_votes_insert" ON listing_votes
+    FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+-- Authenticated users can update their own vote only
+CREATE POLICY "listing_votes_update" ON listing_votes
+    FOR UPDATE
+    USING (auth.uid() = user_id);
+
+-- Authenticated users can delete their own vote only
+CREATE POLICY "listing_votes_delete" ON listing_votes
+    FOR DELETE
+    USING (auth.uid() = user_id);
+
+-- 7. RPC Function: vote_listing
+-- UPSERTs the vote and returns the new state
+CREATE OR REPLACE FUNCTION vote_listing(
+    p_listing_id UUID,
+    p_listing_type TEXT DEFAULT 'directory',
+    p_vote SMALLINT
+)
+RETURNS TABLE (
+    net_votes INT,
+    user_vote SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_user_id UUID;
+BEGIN
+    v_user_id := auth.uid();
+
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+
+    IF p_vote NOT IN (1, -1) THEN
+        RAISE EXCEPTION 'Vote must be 1 (upvote) or -1 (downvote)';
+    END IF;
+
+    -- UPSERT the vote
+    INSERT INTO listing_votes (user_id, listing_id, listing_type, vote)
+    VALUES (v_user_id, p_listing_id, p_listing_type, p_vote)
+    ON CONFLICT (user_id, listing_id, listing_type) DO UPDATE
+    SET vote = EXCLUDED.vote, created_at = now();
+
+    -- Return the current state
+    RETURN QUERY
+    SELECT
+        COALESCE((SELECT SUM(vote)::INT FROM listing_votes WHERE listing_id = p_listing_id AND listing_type = p_listing_type), 0),
+        (SELECT vote FROM listing_votes WHERE user_id = v_user_id AND listing_id = p_listing_id AND listing_type = p_listing_type);
+END;
+$$;
+
+-- 8. RPC Function: get_user_vote
+-- Returns the current user's vote for a listing (or null)
+CREATE OR REPLACE FUNCTION get_user_vote(
+    p_listing_id UUID,
+    p_listing_type TEXT DEFAULT 'directory'
+)
+RETURNS SMALLINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_user_id UUID;
+    v_vote SMALLINT;
+BEGIN
+    v_user_id := auth.uid();
+
+    IF v_user_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT vote INTO v_vote
+    FROM listing_votes
+    WHERE user_id = v_user_id
+      AND listing_id = p_listing_id
+      AND listing_type = p_listing_type;
+
+    RETURN v_vote;
+END;
+$$;
+
+-- 9. Trigger function: recalculate net_votes
+CREATE OR REPLACE FUNCTION recalculate_net_votes()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_listing_id UUID;
+    v_listing_type TEXT;
+BEGIN
+    -- Determine which listing was affected
+    IF TG_OP = 'DELETE' THEN
+        v_listing_id := OLD.listing_id;
+        v_listing_type := OLD.listing_type;
+    ELSE
+        v_listing_id := NEW.listing_id;
+        v_listing_type := NEW.listing_type;
+    END IF;
+
+    -- Recalculate net_votes for the listing
+    UPDATE directory_listings
+    SET net_votes = COALESCE(
+        (SELECT SUM(vote)::INT FROM listing_votes WHERE listing_id = v_listing_id AND listing_type = v_listing_type),
+        0
+    )
+    WHERE id = v_listing_id;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$$;
+
+-- 10. Trigger: fire on INSERT, UPDATE, DELETE of listing_votes
+DROP TRIGGER IF EXISTS trg_listing_votes_net ON listing_votes;
+CREATE TRIGGER trg_listing_votes_net
+    AFTER INSERT OR UPDATE OR DELETE ON listing_votes
+    FOR EACH ROW
+    EXECUTE FUNCTION recalculate_net_votes();
+
+-- 11. RPC Function: remove_vote
+-- Deletes the user's vote and returns updated state
+CREATE OR REPLACE FUNCTION remove_listing_vote(
+    p_listing_id UUID,
+    p_listing_type TEXT DEFAULT 'directory'
+)
+RETURNS TABLE (
+    net_votes INT,
+    user_vote SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_user_id UUID;
+BEGIN
+    v_user_id := auth.uid();
+
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+
+    DELETE FROM listing_votes
+    WHERE user_id = v_user_id
+      AND listing_id = p_listing_id
+      AND listing_type = p_listing_type;
+
+    RETURN QUERY
+    SELECT
+        COALESCE((SELECT SUM(vote)::INT FROM listing_votes WHERE listing_id = p_listing_id AND listing_type = p_listing_type), 0),
+        NULL::SMALLINT;
+END;
+$$;
+
+-- 12. RPC Function: get_user_votes_batch
+-- Returns votes for multiple listings in a single call
+CREATE OR REPLACE FUNCTION get_user_votes_batch(
+    p_listing_ids UUID[],
+    p_listing_type TEXT DEFAULT 'directory'
+)
+RETURNS TABLE (
+    listing_id UUID,
+    vote SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_user_id UUID;
+BEGIN
+    v_user_id := auth.uid();
+
+    IF v_user_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT lv.listing_id, lv.vote
+    FROM listing_votes lv
+    WHERE lv.user_id = v_user_id
+      AND lv.listing_id = ANY(p_listing_ids)
+      AND lv.listing_type = p_listing_type;
+END;
+$$;
+
+-- 13. Backfill net_votes for any existing listings (should be 0, but safety net)
+UPDATE directory_listings
+SET net_votes = COALESCE(
+    (SELECT SUM(vote)::INT FROM listing_votes WHERE listing_id = directory_listings.id AND listing_type = 'directory'),
+    0
+);

--- a/types/models.ts
+++ b/types/models.ts
@@ -413,6 +413,7 @@ export interface DirectoryListingDB {
   location: string;
   google_map_url?: string;
   price_level?: 1 | 2 | 3 | 4;
+  net_votes?: number;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary

- Add `listing_votes` table with RLS policies, unique constraint per user/listing, and trigger-maintained `net_votes` column on `directory_listings`
- Add three Supabase RPCs: `vote_listing` (upsert), `remove_listing_vote` (delete), `get_user_votes_batch` (batch fetch)
- Sort directory listings by `net_votes DESC` after featured/name ordering
- Wire up vote UI in `DirectoryListingCard` with `ThumbsUp`/`ThumbsDown` buttons and colored net vote counter

## Bug Fixes

- **Toggle-off bug (critical)**: clicking the same vote again was casting the opposite vote instead of removing it — fixed via dedicated `remove_listing_vote` RPC
- **N+1 queries**: replaced per-listing `getUserVote()` calls with a single `getUserVotesBatch()` RPC
- **Stale `net_votes`**: counter now updates in both vote and unvote branches
- **Double-click race**: buttons are disabled while a request is in-flight via `votingId` state

## Risks

- Migration must be applied to Supabase before deploying frontend — RPCs are required at runtime
- `SECURITY DEFINER` on RPC functions bypasses RLS, but auth check via `auth.uid()` is enforced manually inside each function

## Testing

- [ ] Vote on a listing as authenticated user — counter increments, button highlights
- [ ] Click same vote again — vote is removed, counter decrements
- [ ] Switch vote from 👍 to 👎 — counter updates correctly
- [ ] Rapid-click protection — buttons disabled during request
- [ ] Unauthenticated user — buttons are greyed out and disabled