### PR TITLE
fix: suppress exhaustive-deps ESLint warning in DirectoryCategoryPage

### DIFF
--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -60,6 +60,8 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
 
         const ids = listings.map(l => l.id);
         db.getUserVotesBatch(ids).then(setUserVotes);
+    // Intentional: user?.id and listings.length to avoid refetching on vote count updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isAuthenticated, user?.id, listings.length]);
 
     const handleVote = useCallback(async (listingId: string, vote: 1 | -1) => {


### PR DESCRIPTION
## Summary
- Added `// eslint-disable-next-line react-hooks/exhaustive-deps` comment before the `useEffect` dependency array in `DirectoryCategoryPage.tsx`

## Reasoning
The `useEffect` that fetches user votes intentionally uses `user?.id` instead of `user` and `listings.length` instead of `listings` to avoid re-fetching on every vote count update. Including the full `listings` array as a dependency would trigger a redundant network call every time `handleVote` updates net_votes locally. The optimization is intentional — comment documents this clearly.

## Risks
None — no logic changes, only ESLint suppression with explanatory comment.

## Testing
CI lint should now pass without warnings on this file.