### PR TITLE
feat: add product variants with size selector [86]

### DIFF
--- a/api-services/api/products.ts
+++ b/api-services/api/products.ts
@@ -1,7 +1,17 @@
 import { supabase } from '../supabase';
 import { getUserRole } from '../auth';
 import { Product } from '../../types/index';
-import { productSchema } from './schemas';
+import { productSchema, productVariantSchema } from './schemas';
+
+export interface ProductVariant {
+    id: string;
+    product_id: string;
+    size_label: string;
+    price: number;
+    stock: number;
+    sku: string | null;
+    created_at: string;
+}
 
 export const productsService = {
     async createProduct(data: Product) {
@@ -111,6 +121,113 @@ export const productsService = {
             .from('products')
             .delete()
             .eq('id', id);
+
+        if (error) throw error;
+    },
+
+    // ============================================================
+    // Product Variants CRUD
+    // ============================================================
+
+    async getProductVariants(productId: string) {
+        const { data, error } = await supabase
+            .from('product_variants')
+            .select('*')
+            .eq('product_id', productId)
+            .order('created_at', { ascending: true });
+
+        if (error) throw error;
+        return data as ProductVariant[];
+    },
+
+    async createProductVariant(productId: string, data: Omit<ProductVariant, 'id' | 'product_id' | 'created_at'>) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        // Verify user owns the product
+        const role = await getUserRole(user.id);
+        const { data: product } = await supabase
+            .from('products')
+            .select('seller_id, artisan_id')
+            .eq('id', productId)
+            .single();
+
+        if (!product || (product.seller_id !== user.id && product.artisan_id !== user.id && role !== 'admin')) {
+            throw new Error('Not authorized');
+        }
+
+        const validatedData = productVariantSchema.parse(data);
+
+        const { data: variant, error } = await supabase
+            .from('product_variants')
+            .insert([{ ...validatedData, product_id: productId }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        return variant as ProductVariant;
+    },
+
+    async updateProductVariant(variantId: string, updates: Partial<Omit<ProductVariant, 'id' | 'product_id' | 'created_at'>>) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        // Verify user owns the parent product
+        const role = await getUserRole(user.id);
+        const { data: existingVariant } = await supabase
+            .from('product_variants')
+            .select('product_id')
+            .eq('id', variantId)
+            .single();
+
+        if (!existingVariant) throw new Error('Variant not found');
+
+        const { data: product } = await supabase
+            .from('products')
+            .select('seller_id, artisan_id')
+            .eq('id', existingVariant.product_id)
+            .single();
+
+        if (!product || (product.seller_id !== user.id && product.artisan_id !== user.id && role !== 'admin')) {
+            throw new Error('Not authorized');
+        }
+
+        const { error } = await supabase
+            .from('product_variants')
+            .update(updates)
+            .eq('id', variantId);
+
+        if (error) throw error;
+    },
+
+    async deleteProductVariant(variantId: string) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        // Verify user owns the parent product
+        const role = await getUserRole(user.id);
+        const { data: existingVariant } = await supabase
+            .from('product_variants')
+            .select('product_id')
+            .eq('id', variantId)
+            .single();
+
+        if (!existingVariant) throw new Error('Variant not found');
+
+        const { data: product } = await supabase
+            .from('products')
+            .select('seller_id, artisan_id')
+            .eq('id', existingVariant.product_id)
+            .single();
+
+        if (!product || (product.seller_id !== user.id && product.artisan_id !== user.id && role !== 'admin')) {
+            throw new Error('Not authorized');
+        }
+
+        const { error } = await supabase
+            .from('product_variants')
+            .delete()
+            .eq('id', variantId);
 
         if (error) throw error;
     }

--- a/api-services/api/schemas.ts
+++ b/api-services/api/schemas.ts
@@ -26,7 +26,8 @@ export const bookingSchema = z.object({
     guests: z.number().int().min(1),
     message: z.string().max(500).optional(),
     payment_method: z.enum(['card', 'cash', 'bank', 'crypto', 'swift']).default('card'),
-    item_type: z.enum(['property', 'service', 'product'])
+    item_type: z.enum(['property', 'service', 'product']),
+    variant_id: z.string().uuid().optional(),
 }).refine(data => new Date(data.check_out) > new Date(data.check_in), {
     message: "Check-out date must be after check-in date",
     path: ["check_out"]
@@ -50,6 +51,13 @@ export const productSchema = z.object({
     category: z.string().min(1, "Category is required"),
     images: z.array(z.string()).min(1, "At least one image is required"),
     seller_id: z.string().uuid("Invalid seller ID"),
+});
+
+export const productVariantSchema = z.object({
+    size_label: z.string().min(1, "Size label is required"),
+    price: z.number().positive("Price must be positive"),
+    stock: z.number().int().nonnegative("Stock cannot be negative"),
+    sku: z.string().optional(),
 });
 
 export const reviewSchema = z.object({

--- a/components/admin/products/ProductVariantsForm.tsx
+++ b/components/admin/products/ProductVariantsForm.tsx
@@ -1,0 +1,319 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Trash2, Edit2, Check, X } from 'lucide-react';
+import { ProductVariant } from '../../../types/models';
+import { productsService } from '../../../api-services/api/products';
+import toast from 'react-hot-toast';
+
+interface ProductVariantsFormProps {
+    productId: string | undefined;
+}
+
+export const ProductVariantsForm: React.FC<ProductVariantsFormProps> = ({ productId }) => {
+    const [variants, setVariants] = useState<ProductVariant[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editForm, setEditForm] = useState<{ size_label: string; price: string; stock: string; sku: string }>({
+        size_label: '',
+        price: '',
+        stock: '',
+        sku: '',
+    });
+    const [adding, setAdding] = useState(false);
+    const [newForm, setNewForm] = useState<{ size_label: string; price: string; stock: string; sku: string }>({
+        size_label: '',
+        price: '',
+        stock: '',
+        sku: '',
+    });
+
+    // Load variants when productId is available
+    useEffect(() => {
+        if (!productId) return;
+        let cancelled = false;
+        async function load() {
+            setLoading(true);
+            try {
+                const data = await productsService.getProductVariants(productId);
+                if (!cancelled) setVariants(data);
+            } catch {
+                // Silently fail
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        load();
+        return () => { cancelled = true; };
+    }, [productId]);
+
+    const startEdit = (variant: ProductVariant) => {
+        setEditingId(variant.id);
+        setEditForm({
+            size_label: variant.size_label,
+            price: String(variant.price),
+            stock: String(variant.stock),
+            sku: variant.sku ?? '',
+        });
+    };
+
+    const cancelEdit = () => {
+        setEditingId(null);
+    };
+
+    const saveEdit = async () => {
+        if (!editingId) return;
+        try {
+            await productsService.updateProductVariant(editingId, {
+                size_label: editForm.size_label,
+                price: parseFloat(editForm.price),
+                stock: parseInt(editForm.stock),
+                sku: editForm.sku || undefined,
+            });
+            setVariants(prev =>
+                prev.map(v =>
+                    v.id === editingId
+                        ? { ...v, size_label: editForm.size_label, price: parseFloat(editForm.price), stock: parseInt(editForm.stock), sku: editForm.sku || null }
+                        : v
+                )
+            );
+            setEditingId(null);
+            toast.success('Variant updated');
+        } catch (err: any) {
+            toast.error(err.message || 'Failed to update variant');
+        }
+    };
+
+    const handleDelete = async (variantId: string) => {
+        if (!confirm('Delete this variant?')) return;
+        try {
+            await productsService.deleteProductVariant(variantId);
+            setVariants(prev => prev.filter(v => v.id !== variantId));
+            toast.success('Variant deleted');
+        } catch (err: any) {
+            toast.error(err.message || 'Failed to delete variant');
+        }
+    };
+
+    const handleAdd = async () => {
+        if (!productId || !newForm.size_label || !newForm.price) {
+            toast.error('Size and price are required');
+            return;
+        }
+        try {
+            const variant = await productsService.createProductVariant(productId, {
+                size_label: newForm.size_label,
+                price: parseFloat(newForm.price),
+                stock: parseInt(newForm.stock) || 0,
+                sku: newForm.sku || undefined,
+            });
+            setVariants(prev => [...prev, variant]);
+            setNewForm({ size_label: '', price: '', stock: '', sku: '' });
+            setAdding(false);
+            toast.success('Variant added');
+        } catch (err: any) {
+            toast.error(err.message || 'Failed to add variant');
+        }
+    };
+
+    if (!productId) {
+        return (
+            <div className="bg-white dark:bg-slate-800/50 rounded-2xl p-6 border border-slate-200 dark:border-slate-700/50">
+                <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-2">Product Variants</h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                    Save the product first, then you can add size variants here.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="bg-white dark:bg-slate-800/50 rounded-2xl p-6 border border-slate-200 dark:border-slate-700/50">
+            <div className="flex items-center justify-between mb-4">
+                <div>
+                    <h3 className="text-lg font-bold text-slate-900 dark:text-white">Product Variants</h3>
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
+                        Manage size options and variant-specific pricing
+                    </p>
+                </div>
+                {!adding && (
+                    <button
+                        onClick={() => setAdding(true)}
+                        className="flex items-center gap-1.5 text-sm bg-teal-600 dark:bg-cyan-600 hover:bg-teal-700 dark:hover:bg-cyan-700 text-white px-3 py-1.5 rounded-lg font-medium transition-colors"
+                    >
+                        <Plus size={16} />
+                        Add Variant
+                    </button>
+                )}
+            </div>
+
+            {/* Loading state */}
+            {loading && (
+                <div className="space-y-2">
+                    {[1, 2, 3].map(i => (
+                        <div key={i} className="h-12 bg-slate-100 dark:bg-slate-700/50 rounded-lg animate-pulse" />
+                    ))}
+                </div>
+            )}
+
+            {/* Empty state */}
+            {!loading && variants.length === 0 && !adding && (
+                <div className="text-center py-8 text-slate-400 dark:text-slate-500">
+                    <p className="text-sm">No variants yet. Click "Add Variant" to create one.</p>
+                </div>
+            )}
+
+            {/* Variant list */}
+            {!loading && variants.length > 0 && (
+                <div className="space-y-2 mb-4">
+                    {variants.map(variant => (
+                        <div
+                            key={variant.id}
+                            className="flex items-center gap-3 p-3 rounded-lg border border-slate-100 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-800/30"
+                        >
+                            {editingId === variant.id ? (
+                                // Inline edit mode
+                                <div className="flex-1 grid grid-cols-4 gap-2">
+                                    <input
+                                        type="text"
+                                        value={editForm.size_label}
+                                        onChange={e => setEditForm(prev => ({ ...prev, size_label: e.target.value }))}
+                                        placeholder="Size"
+                                        className="px-2 py-1.5 text-sm rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                                    />
+                                    <input
+                                        type="number"
+                                        value={editForm.price}
+                                        onChange={e => setEditForm(prev => ({ ...prev, price: e.target.value }))}
+                                        placeholder="Price"
+                                        step="0.01"
+                                        min="0"
+                                        className="px-2 py-1.5 text-sm rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                                    />
+                                    <input
+                                        type="number"
+                                        value={editForm.stock}
+                                        onChange={e => setEditForm(prev => ({ ...prev, stock: e.target.value }))}
+                                        placeholder="Stock"
+                                        min="0"
+                                        className="px-2 py-1.5 text-sm rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                                    />
+                                    <input
+                                        type="text"
+                                        value={editForm.sku}
+                                        onChange={e => setEditForm(prev => ({ ...prev, sku: e.target.value }))}
+                                        placeholder="SKU (optional)"
+                                        className="px-2 py-1.5 text-sm rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                                    />
+                                    <div className="col-span-4 flex justify-end gap-2 mt-1">
+                                        <button
+                                            onClick={cancelEdit}
+                                            className="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                                        >
+                                            <X size={16} />
+                                        </button>
+                                        <button
+                                            onClick={saveEdit}
+                                            className="p-1.5 text-teal-600 hover:text-teal-700 transition-colors"
+                                        >
+                                            <Check size={16} />
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                // Display mode
+                                <>
+                                    <div className="flex-1 flex items-center gap-4">
+                                        <span className="inline-block w-10 text-center font-bold text-sm bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded py-0.5">
+                                            {variant.size_label}
+                                        </span>
+                                        <span className="text-sm font-semibold text-slate-900 dark:text-white">
+                                            €{variant.price.toFixed(2)}
+                                        </span>
+                                        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${variant.stock > 0 ? 'bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400' : 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400'}`}>
+                                            {variant.stock} in stock
+                                        </span>
+                                        {variant.sku && (
+                                            <span className="text-xs text-slate-400 font-mono">
+                                                {variant.sku}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-1">
+                                        <button
+                                            onClick={() => startEdit(variant)}
+                                            className="p-1.5 text-slate-400 hover:text-teal-600 transition-colors"
+                                            title="Edit variant"
+                                        >
+                                            <Edit2 size={14} />
+                                        </button>
+                                        <button
+                                            onClick={() => handleDelete(variant.id)}
+                                            className="p-1.5 text-slate-400 hover:text-red-500 transition-colors"
+                                            title="Delete variant"
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Add new form */}
+            {adding && (
+                <div className="mb-4 p-4 rounded-lg border-2 border-dashed border-teal-200 dark:border-cyan-700/50 bg-teal-50/50 dark:bg-cyan-900/10">
+                    <div className="grid grid-cols-4 gap-2 mb-3">
+                        <input
+                            type="text"
+                            value={newForm.size_label}
+                            onChange={e => setNewForm(prev => ({ ...prev, size_label: e.target.value }))}
+                            placeholder="Size (e.g., S, M, L)"
+                            className="px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                        />
+                        <input
+                            type="number"
+                            value={newForm.price}
+                            onChange={e => setNewForm(prev => ({ ...prev, price: e.target.value }))}
+                            placeholder="Price"
+                            step="0.01"
+                            min="0"
+                            className="px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                        />
+                        <input
+                            type="number"
+                            value={newForm.stock}
+                            onChange={e => setNewForm(prev => ({ ...prev, stock: e.target.value }))}
+                            placeholder="Stock"
+                            min="0"
+                            className="px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                        />
+                        <input
+                            type="text"
+                            value={newForm.sku}
+                            onChange={e => setNewForm(prev => ({ ...prev, sku: e.target.value }))}
+                            placeholder="SKU (optional)"
+                            className="px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-white"
+                        />
+                    </div>
+                    <div className="flex justify-end gap-2">
+                        <button
+                            onClick={() => { setAdding(false); setNewForm({ size_label: '', price: '', stock: '', sku: '' }); }}
+                            className="flex items-center gap-1.5 text-sm px-3 py-1.5 text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors"
+                        >
+                            <X size={14} />
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleAdd}
+                            className="flex items-center gap-1.5 text-sm bg-teal-600 dark:bg-cyan-600 hover:bg-teal-700 dark:hover:bg-cyan-700 text-white px-3 py-1.5 rounded-lg font-medium transition-colors"
+                        >
+                            <Check size={14} />
+                            Add
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/components/shop/ProductCard.tsx
+++ b/components/shop/ProductCard.tsx
@@ -1,16 +1,54 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ShoppingBag, Star, User } from 'lucide-react';
-import { Product } from '../../types/models';
+import { Product, ProductVariant } from '../../types/models';
+import { VariantSelector } from './VariantSelector';
+import { productsService } from '../../api-services/api/products';
 
 interface ProductCardProps {
     product: Product;
     index: number;
-    onAddToCart: (product: Product) => void;
+    onAddToCart: (product: Product, variant?: ProductVariant) => void;
     formatPrice: (price: string | number) => string;
     convertPrice: (price: number, from: 'USD' | 'EUR') => number;
 }
 
-export const ProductCard: React.FC<ProductCardProps> = ({ product, index, onAddToCart, formatPrice, convertPrice }) => {
+export const ProductCard: React.FC<ProductCardProps> = ({
+    product,
+    index,
+    onAddToCart,
+    formatPrice,
+    convertPrice,
+}) => {
+    const [variants, setVariants] = useState<ProductVariant[]>([]);
+    const [selectedVariant, setSelectedVariant] = useState<ProductVariant | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        async function fetchVariants() {
+            if (!product.id) return;
+            setLoading(true);
+            try {
+                const data = await productsService.getProductVariants(product.id!);
+                if (!cancelled && data.length > 0) {
+                    setVariants(data);
+                }
+            } catch {
+                // Silently fail — fall back to base price
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        fetchVariants();
+        return () => { cancelled = true; };
+    }, [product.id]);
+
+    const displayPrice = selectedVariant ? selectedVariant.price : product.price;
+
+    const handleAddToCart = () => {
+        onAddToCart(product, selectedVariant ?? undefined);
+    };
+
     return (
         <div
             className="group bg-white dark:bg-slate-800/80 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-800/50 animate-stagger-enter flex flex-col"
@@ -29,7 +67,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, index, onAddT
                     </div>
                 )}
                 <button
-                    onClick={() => onAddToCart(product)}
+                    onClick={handleAddToCart}
                     className="absolute bottom-4 right-4 bg-white text-slate-900 p-3 rounded-full shadow-lg opacity-0 group-hover:opacity-100 transform translate-y-4 group-hover:translate-y-0 transition-all duration-300 hover:bg-amber-500 hover:text-white"
                     title="Add to Basket"
                 >
@@ -52,6 +90,16 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, index, onAddT
                 <p className="text-sm text-slate-500 dark:text-slate-400 mb-4 line-clamp-2 min-h-[40px] flex-grow">
                     {product.description}
                 </p>
+
+                {/* Variant Selector */}
+                {variants.length > 0 && (
+                    <VariantSelector
+                        variants={variants}
+                        selectedVariant={selectedVariant}
+                        onSelect={setSelectedVariant}
+                    />
+                )}
+
                 <div className="flex justify-between items-center border-t border-slate-100 dark:border-slate-800/50 pt-4 mt-auto">
                     <div className="flex items-center gap-2">
                         <div className="w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800/50 flex items-center justify-center text-slate-400">
@@ -62,16 +110,23 @@ export const ProductCard: React.FC<ProductCardProps> = ({ product, index, onAddT
                         </span>
                     </div>
                     <div className="flex items-center gap-3">
-                        <span className="text-xl font-bold text-slate-900 dark:text-white">
-                            {formatPrice(convertPrice(product.price, 'EUR'))}
-                        </span>
+                        {loading ? (
+                            <div className="h-6 w-20 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                        ) : (
+                            <span className="text-xl font-bold text-slate-900 dark:text-white">
+                                {formatPrice(convertPrice(displayPrice, 'EUR'))}
+                            </span>
+                        )}
                     </div>
                 </div>
                 <button
-                    onClick={() => onAddToCart(product)}
-                    className="w-full mt-4 bg-slate-100 dark:bg-slate-800/50 hover:bg-amber-600 hover:text-white dark:hover:bg-amber-600 text-slate-900 dark:text-white py-2 rounded-lg font-medium transition-colors text-sm"
+                    onClick={handleAddToCart}
+                    disabled={selectedVariant !== null && selectedVariant.stock <= 0}
+                    className="w-full mt-4 bg-slate-100 dark:bg-slate-800/50 hover:bg-amber-600 hover:text-white dark:hover:bg-amber-600 text-slate-900 dark:text-white py-2 rounded-lg font-medium transition-colors text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                    Add to Basket
+                    {selectedVariant !== null && selectedVariant.stock <= 0
+                        ? 'Out of Stock'
+                        : 'Add to Basket'}
                 </button>
             </div>
         </div>

--- a/components/shop/VariantSelector.tsx
+++ b/components/shop/VariantSelector.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { ProductVariant } from '../../types/models';
+
+interface VariantSelectorProps {
+    variants: ProductVariant[];
+    selectedVariant: ProductVariant | null;
+    onSelect: (variant: ProductVariant) => void;
+}
+
+export const VariantSelector: React.FC<VariantSelectorProps> = ({
+    variants,
+    selectedVariant,
+    onSelect,
+}) => {
+    if (variants.length === 0) return null;
+
+    return (
+        <div className="mt-3">
+            <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400 uppercase tracking-wider mb-2">
+                Size
+            </label>
+            <div className="flex flex-wrap gap-2">
+                {variants.map((variant) => {
+                    const isSelected = selectedVariant?.id === variant.id;
+                    const isOutOfStock = variant.stock <= 0;
+
+                    return (
+                        <button
+                            key={variant.id}
+                            disabled={isOutOfStock}
+                            onClick={() => onSelect(variant)}
+                            className={`
+                                relative px-4 py-2 rounded-lg text-sm font-medium border-2 transition-all duration-200
+                                ${isOutOfStock
+                                    ? 'border-slate-200 dark:border-slate-700 text-slate-300 dark:text-slate-600 cursor-not-allowed line-through'
+                                    : isSelected
+                                        ? 'border-amber-500 bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 shadow-sm'
+                                        : 'border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-amber-300 dark:hover:border-amber-600 hover:bg-amber-50/50 dark:hover:bg-amber-500/5'
+                                }
+                            `}
+                        >
+                            {variant.size_label}
+                            {isOutOfStock && (
+                                <span className="absolute -top-1 -right-1 w-2 h-2 bg-red-400 rounded-full" />
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/components/ui/CartDrawer.tsx
+++ b/components/ui/CartDrawer.tsx
@@ -105,6 +105,9 @@ export const CartDrawer: React.FC = () => {
                                     <div className="flex-1 min-w-0 flex flex-col justify-between">
                                         <div>
                                             <h3 className="font-bold text-slate-900 dark:text-white text-sm line-clamp-2">{item.title}</h3>
+                                            {item.variant_label && (
+                                                <p className="text-xs text-amber-600 dark:text-amber-400 font-medium mt-0.5">Size: {item.variant_label}</p>
+                                            )}
                                             <p className="text-xs text-slate-500 mt-1">
                                                 {item.startDate ? `${new Date(item.startDate).toLocaleDateString()} - ${new Date(item.endDate!).toLocaleDateString()}` : (item.date ? new Date(item.date).toLocaleDateString() : 'Date: Flexible')}
                                             </p>

--- a/pages/Shop.tsx
+++ b/pages/Shop.tsx
@@ -10,7 +10,7 @@ import { ServiceType } from '../types/index';
 // Modular Components
 import { ProductCard } from '../components/shop/ProductCard';
 import { ShopHero } from '../components/shop/ShopHero';
-import { Product as DBProduct } from '../types/models';
+import { Product as DBProduct, ProductVariant } from '../types/models';
 
 // Mock Data
 const mockProducts: DBProduct[] = [
@@ -105,15 +105,18 @@ export const Shop: React.FC = () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-    const handleAddToCart = (product: DBProduct) => {
+    const handleAddToCart = (product: DBProduct, variant?: ProductVariant) => {
         contextAddToCart({
             id: product.id,
             title: product.title,
-            price: product.price,
+            price: variant ? variant.price : product.price,
             image: product.images[0],
-            type: ServiceType.PRODUCT
+            type: ServiceType.PRODUCT,
+            variant_id: variant?.id,
+            variant_label: variant?.size_label,
         });
-        setCartToast(`Added ${product.title} to basket`);
+        const label = variant ? `${product.title} (${variant.size_label})` : product.title;
+        setCartToast(`Added ${label} to basket`);
         setTimeout(() => setCartToast(null), 3000);
     };
 

--- a/pages/admin/AdminEditProductPage.tsx
+++ b/pages/admin/AdminEditProductPage.tsx
@@ -9,6 +9,7 @@ import toast from 'react-hot-toast';
 import { ProductBasicDetailsForm } from '../../components/admin/products/ProductBasicDetailsForm';
 import { ProductSettingsSidebar } from '../../components/admin/products/ProductSettingsSidebar';
 import { ProductMediaForm } from '../../components/admin/products/ProductMediaForm';
+import { ProductVariantsForm } from '../../components/admin/products/ProductVariantsForm';
 
 export const AdminEditProductPage: React.FC = () => {
     const { id } = useParams();
@@ -149,13 +150,15 @@ export const AdminEditProductPage: React.FC = () => {
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-8 animate-in fade-in duration-500">
                     <div className="md:col-span-2 space-y-6">
                         <ProductBasicDetailsForm formData={formData} handleChange={handleChange} />
-                        
-                        <ProductMediaForm 
-                            existingImages={existingImages} 
-                            removeExistingImage={removeExistingImage} 
-                            files={files} 
-                            setFiles={setFiles} 
+
+                        <ProductMediaForm
+                            existingImages={existingImages}
+                            removeExistingImage={removeExistingImage}
+                            files={files}
+                            setFiles={setFiles}
                         />
+
+                        {isEditing && <ProductVariantsForm productId={id} />}
                     </div>
 
                     <div className="space-y-6">

--- a/supabase/migrations/20260413000000_product_variants.sql
+++ b/supabase/migrations/20260413000000_product_variants.sql
@@ -1,0 +1,93 @@
+-- Migration: 20260413000000_product_variants
+-- Purpose: Add product_variants table for size-based variants with pricing and stock
+-- Task: [86] Shop — варианты размеров с ценами
+
+-- ============================================================
+-- 1. CREATE product_variants table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.product_variants (
+    id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    product_id UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+    size_label TEXT NOT NULL,
+    price DECIMAL(10, 2) NOT NULL,
+    stock INTEGER DEFAULT 0,
+    sku TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. INDEXES
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_product_variants_product_id
+    ON public.product_variants (product_id);
+
+CREATE INDEX IF NOT EXISTS idx_product_variants_sku
+    ON public.product_variants (sku)
+    WHERE sku IS NOT NULL;
+
+-- ============================================================
+-- 3. ROW LEVEL SECURITY
+-- ============================================================
+ALTER TABLE public.product_variants ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: public read (anyone can view variants)
+CREATE POLICY "product_variants_select" ON public.product_variants
+    FOR SELECT
+    USING (true);
+
+-- INSERT: product owner (seller_id or artisan_id) or admin
+CREATE POLICY "product_variants_insert" ON public.product_variants
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.products p
+            WHERE p.id = product_variants.product_id
+            AND (
+                p.seller_id = (SELECT auth.uid())
+                OR p.artisan_id = (SELECT auth.uid())
+                OR EXISTS (
+                    SELECT 1 FROM public.profiles
+                    WHERE profiles.id = (SELECT auth.uid())
+                    AND profiles.role = 'admin'
+                )
+            )
+        )
+    );
+
+-- UPDATE: product owner or admin
+CREATE POLICY "product_variants_update" ON public.product_variants
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.products p
+            WHERE p.id = product_variants.product_id
+            AND (
+                p.seller_id = (SELECT auth.uid())
+                OR p.artisan_id = (SELECT auth.uid())
+                OR EXISTS (
+                    SELECT 1 FROM public.profiles
+                    WHERE profiles.id = (SELECT auth.uid())
+                    AND profiles.role = 'admin'
+                )
+            )
+        )
+    );
+
+-- DELETE: product owner or admin
+CREATE POLICY "product_variants_delete" ON public.product_variants
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.products p
+            WHERE p.id = product_variants.product_id
+            AND (
+                p.seller_id = (SELECT auth.uid())
+                OR p.artisan_id = (SELECT auth.uid())
+                OR EXISTS (
+                    SELECT 1 FROM public.profiles
+                    WHERE profiles.id = (SELECT auth.uid())
+                    AND profiles.role = 'admin'
+                )
+            )
+        )
+    );

--- a/types/models.ts
+++ b/types/models.ts
@@ -213,6 +213,16 @@ export interface ServiceModel {
     image_url: string;
 }
 
+export interface ProductVariant {
+    id: string;
+    product_id: string;
+    size_label: string;
+    price: number;
+    stock: number;
+    sku: string | null;
+    created_at: string;
+}
+
 export interface Product {
     id?: string;
     title: string;
@@ -222,7 +232,8 @@ export interface Product {
     stock: number;
     seller_id: string;
     images: string[];
-    
+    variants?: ProductVariant[];
+
     seller?: Partial<UserProfile>;
     created_at?: string;
 }
@@ -260,6 +271,7 @@ export interface Booking {
     user_id: string;
     item_id: string;
     item_type: 'property' | 'service' | 'product';
+    variant_id?: string;
     check_in?: string;
     check_out?: string;
     status: 'pending' | 'confirmed' | 'cancelled' | 'completed';
@@ -387,6 +399,8 @@ export interface CartItem {
   cleaningFee?: number;
   pricePerNight?: number;
   nights?: number;
+  variant_id?: string;
+  variant_label?: string;
 }
 
 export interface SearchFilters {


### PR DESCRIPTION
## Summary
- New `product_variants` table (migration `20260413000000_product_variants.sql`) with `product_id FK CASCADE`, `size_label`, `price`, `stock`, `sku`
- RLS: public SELECT, seller/artisan/admin INSERT/UPDATE/DELETE
- `productVariantSchema` added to schemas.ts, `variant_id` optional added to `bookingSchema`
- `ProductVariant` interface in `types/models.ts`, `variants?: ProductVariant[]` on `Product`
- 4 API methods in `products.ts`: `getProductVariants`, `createProductVariant`, `updateProductVariant`, `deleteProductVariant`
- `VariantSelector` component — size button group with out-of-stock state
- `ProductCard` — fetches variants on mount, dynamic price display, passes variant to cart
- `ProductVariantsForm` — inline CRUD in admin product edit (add/edit/delete rows)
- `AdminEditProductPage` — integrated `ProductVariantsForm`
- `CartDrawer` — shows variant size label when present

## Design decisions
- Base `price` kept on products table as fallback (backwards compatible)
- Size-only variants (`size_label TEXT`) — no multi-attribute complexity
- Inline admin UI — no separate page/route needed

## Risks
- `artisan_id` referenced in RLS — confirmed field exists in existing migrations
- Variant stock and product stock are independent — no auto-sync (intentional for simplicity)

## Testing notes
- Run migration: `supabase db push`
- Checkout flow: `variant_id` is optional in `bookingSchema`, existing bookings unaffected