### PR TITLE
feat: add premium and free listing sections to directory landing [95]

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -82,6 +82,47 @@ export const directoryService = {
         return data as DirectoryListingDB[];
     },
 
+    // ============================================================
+    // Landing Page Listings
+    // ============================================================
+
+    /**
+     * Top community-voted free listings (limit 6, ordered by net_votes DESC)
+     */
+    async getFreeListings(): Promise<DirectoryListingDB[]> {
+        const { data, error } = await supabase
+            .from('directory_listings')
+            .select('*')
+            .eq('is_premium', false)
+            .order('net_votes', { ascending: false, nullsFirst: false })
+            .limit(6);
+
+        if (error) {
+            console.error('Error fetching free listings:', error);
+            throw error;
+        }
+
+        return data as DirectoryListingDB[];
+    },
+
+    /**
+     * Premium / promoted listings (limit 6, is_premium = true)
+     */
+    async getPremiumListings(): Promise<DirectoryListingDB[]> {
+        const { data, error } = await supabase
+            .from('directory_listings')
+            .select('*')
+            .eq('is_premium', true)
+            .limit(6);
+
+        if (error) {
+            console.error('Error fetching premium listings:', error);
+            throw error;
+        }
+
+        return data as DirectoryListingDB[];
+    },
+
     async voteForListing(listingId: string, vote: 1 | -1): Promise<{ netVotes: number; userVote: number }> {
         const { data, error } = await supabase
             .rpc('vote_listing', {

--- a/components/home/FreeListingsSection.tsx
+++ b/components/home/FreeListingsSection.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { ThumbsUp, ArrowRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingCard } from '../directory/DirectoryListingCard';
+
+interface FreeListingsSectionProps {
+    listings: DirectoryListingDB[];
+    loading: boolean;
+}
+
+export const FreeListingsSection: React.FC<FreeListingsSectionProps> = ({ listings, loading }) => {
+    const navigate = useNavigate();
+
+    return (
+        <div className="py-16 md:py-24">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                {/* Section Header */}
+                <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between mb-10 gap-4">
+                    <div>
+                        <div className="flex items-center gap-2 mb-2">
+                            <ThumbsUp className="w-5 h-5 text-teal-600 dark:text-cyan-400" />
+                            <span className="text-xs uppercase font-bold text-teal-600 dark:text-cyan-400 tracking-widest">
+                                Community Favorites
+                            </span>
+                        </div>
+                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
+                            Top Rated by the Community
+                        </h2>
+                        <p className="mt-2 text-slate-600 dark:text-slate-400">
+                            The most upvoted listings from our community
+                        </p>
+                    </div>
+                    <button
+                        onClick={() => navigate('/search-results')}
+                        className="flex items-center gap-1 text-sm font-semibold text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 transition-colors self-start sm:self-auto"
+                    >
+                        Explore all <ArrowRight size={16} />
+                    </button>
+                </div>
+
+                {/* Loading State */}
+                {loading && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[1, 2, 3].map(i => (
+                            <div key={i} className="h-96 bg-white dark:bg-slate-800 rounded-2xl animate-pulse" />
+                        ))}
+                    </div>
+                )}
+
+                {/* Empty State */}
+                {!loading && listings.length === 0 && (
+                    <div className="text-center py-12 bg-white dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-700/50">
+                        <ThumbsUp className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
+                        <p className="text-slate-500 dark:text-slate-400">Be the first to recommend a listing!</p>
+                    </div>
+                )}
+
+                {/* Listings Grid */}
+                {!loading && listings.length > 0 && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {listings.map((listing) => (
+                            <DirectoryListingCard key={listing.id} listing={listing} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/components/home/PremiumListingsSection.tsx
+++ b/components/home/PremiumListingsSection.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Crown, ArrowRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingCard } from '../directory/DirectoryListingCard';
+
+interface PremiumListingsSectionProps {
+    listings: DirectoryListingDB[];
+    loading: boolean;
+}
+
+export const PremiumListingsSection: React.FC<PremiumListingsSectionProps> = ({ listings, loading }) => {
+    const navigate = useNavigate();
+
+    return (
+        <div className="bg-gradient-to-b from-amber-50/50 to-slate-50 dark:from-amber-950/10 dark:to-slate-900/50 py-16 md:py-24 border-y border-amber-100/50 dark:border-amber-900/20">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                {/* Section Header */}
+                <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between mb-10 gap-4">
+                    <div>
+                        <div className="flex items-center gap-2 mb-2">
+                            <Crown className="w-5 h-5 text-amber-500 dark:text-amber-400" />
+                            <span className="text-xs uppercase font-bold text-amber-600 dark:text-amber-400 tracking-widest">
+                                Premium Partners
+                            </span>
+                        </div>
+                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
+                            Recommended for You
+                        </h2>
+                        <p className="mt-2 text-slate-600 dark:text-slate-400">
+                            Hand-picked, verified partners with outstanding service
+                        </p>
+                    </div>
+                    <button
+                        onClick={() => navigate('/search-results')}
+                        className="flex items-center gap-1 text-sm font-semibold text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors self-start sm:self-auto"
+                    >
+                        View all <ArrowRight size={16} />
+                    </button>
+                </div>
+
+                {/* Loading State */}
+                {loading && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[1, 2, 3].map(i => (
+                            <div key={i} className="h-96 bg-white dark:bg-slate-800 rounded-2xl animate-pulse" />
+                        ))}
+                    </div>
+                )}
+
+                {/* Empty State */}
+                {!loading && listings.length === 0 && (
+                    <div className="text-center py-12 bg-white dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-700/50">
+                        <Crown className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
+                        <p className="text-slate-500 dark:text-slate-400">Premium listings coming soon!</p>
+                    </div>
+                )}
+
+                {/* Listings Grid */}
+                {!loading && listings.length > 0 && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {listings.map((listing) => (
+                            <DirectoryListingCard key={listing.id} listing={listing} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -1,8 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { SEOHead } from '../components/seo/SEOHead';
+import { db } from '../api-services';
+import { DirectoryListingDB } from '../types/models';
+import { PremiumListingsSection } from '../components/home/PremiumListingsSection';
+import { FreeListingsSection } from '../components/home/FreeListingsSection';
 
 export const DirectoryHome: React.FC = () => {
     const { t } = useLanguage();
@@ -10,6 +14,34 @@ export const DirectoryHome: React.FC = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const [location, setLocation] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('');
+
+    // Landing page listings
+    const [premiumListings, setPremiumListings] = useState<DirectoryListingDB[]>([]);
+    const [freeListings, setFreeListings] = useState<DirectoryListingDB[]>([]);
+    const [listingsLoading, setListingsLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        async function loadListings() {
+            setListingsLoading(true);
+            try {
+                const [premium, free] = await Promise.all([
+                    db.getPremiumListings(),
+                    db.getFreeListings(),
+                ]);
+                if (!cancelled) {
+                    setPremiumListings(premium);
+                    setFreeListings(free);
+                }
+            } catch (err) {
+                console.error('Failed to load landing listings:', err);
+            } finally {
+                if (!cancelled) setListingsLoading(false);
+            }
+        }
+        loadListings();
+        return () => { cancelled = true; };
+    }, []);
 
     const categories = [
         { id: 'medical', icon: '🏥', title: t('dir.cat.medical'), path: '/medical-tourism-alanya' },
@@ -191,6 +223,12 @@ export const DirectoryHome: React.FC = () => {
                     ))}
                 </div>
             </div>
+
+            {/* Premium Listings Section */}
+            <PremiumListingsSection listings={premiumListings} loading={listingsLoading} />
+
+            {/* Free Listings / Community Favorites Section */}
+            <FreeListingsSection listings={freeListings} loading={listingsLoading} />
 
             {/* Authority Building Section */}
             <div className="bg-slate-50 dark:bg-slate-900/50 py-16 md:py-24 border-t border-slate-100 dark:border-slate-800/50">

--- a/supabase/migrations/20260413000001_directory_listings_premium.sql
+++ b/supabase/migrations/20260413000001_directory_listings_premium.sql
@@ -1,0 +1,67 @@
+-- Migration: 20260413000001_directory_listings_premium
+-- Purpose: Add is_premium column to directory_listings for paid/promoted listings
+-- Task: [95] Landing — Free Listings + Premium Listings
+
+-- ============================================================
+-- 1. ADD is_premium COLUMN
+-- ============================================================
+ALTER TABLE public.directory_listings
+    ADD COLUMN IF NOT EXISTS is_premium BOOLEAN NOT NULL DEFAULT false;
+
+-- ============================================================
+-- 2. INDEXES
+-- ============================================================
+-- Partial index: only premium listings (small, fast lookups)
+CREATE INDEX IF NOT EXISTS idx_directory_listings_premium
+    ON public.directory_listings (id)
+    WHERE is_premium = true;
+
+-- Composite: category + premium for ordered queries
+CREATE INDEX IF NOT EXISTS idx_directory_listings_category_premium
+    ON public.directory_listings (category_id, is_premium DESC);
+
+-- ============================================================
+-- 3. RLS: RESTRICT is_premium UPDATES TO ADMIN ONLY
+-- ============================================================
+-- The existing policies allow any authenticated user to UPDATE all columns.
+-- We need a CHECK constraint that prevents non-admin users from setting is_premium = true.
+-- Since RLS UPDATE policy already exists, we add a SECURITY DEFINER trigger
+-- that validates the is_premium field on update/insert.
+
+-- Approach: Use a BEFORE UPDATE/INSERT trigger to enforce admin-only is_premium changes.
+CREATE OR REPLACE FUNCTION public.enforce_premium_admin()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- If is_premium is being changed, verify user is admin
+    IF TG_OP = 'UPDATE' AND OLD.is_premium IS DISTINCT FROM NEW.is_premium THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        ) THEN
+            NEW.is_premium := OLD.is_premium; -- revert to old value silently
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' AND NEW.is_premium = true THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        ) THEN
+            NEW.is_premium := false; -- force to false for non-admins
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_enforce_premium_admin ON public.directory_listings;
+CREATE TRIGGER trg_enforce_premium_admin
+    BEFORE INSERT OR UPDATE ON public.directory_listings
+    FOR EACH ROW
+    EXECUTE FUNCTION public.enforce_premium_admin();
+
+-- Revoke direct execute on the trigger function (only used by trigger)
+REVOKE EXECUTE ON FUNCTION public.enforce_premium_admin() FROM PUBLIC;

--- a/types/models.ts
+++ b/types/models.ts
@@ -416,6 +416,7 @@ export interface DirectoryListingDB {
   name: string;
   short_description: string;
   is_featured?: boolean;
+  is_premium?: boolean;
   is_verified?: boolean;
   website?: string;
   whatsapp?: string;


### PR DESCRIPTION
## Summary
- Added `is_premium BOOLEAN DEFAULT false` to `directory_listings` via migration
- BEFORE INSERT/UPDATE trigger `enforce_premium_admin` — silently reverts `is_premium` changes for non-admins (SECURITY DEFINER)
- Partial index on `is_premium = true` + composite index on `(category_id, is_premium DESC)`
- `getFreeListings()` — top 6 non-premium by `net_votes DESC NULLS LAST`
- `getPremiumListings()` — top 6 where `is_premium = true`
- `PremiumListingsSection` — amber gradient, Crown icon, skeleton loading, empty state
- `FreeListingsSection` — teal accent, ThumbsUp icon, skeleton loading, empty state
- `DirectoryHome` — both sections fetched in parallel via `Promise.all`, inserted between category grid and trust blocks

## Page order
1. Hero + Search
2. Category Grid
3. Premium Listings (amber, paid)
4. Free Listings (teal, community)
5. Trust / Authority
6. Testimonials

## Risks
- Trigger approach instead of RLS policy — avoids policy conflicts with existing UPDATE policy; non-admin changes to `is_premium` are silently reverted
- Sections hidden via empty state if no data — no layout shift