### PR TITLE
feat: add blog DB schema, RLS, RPC and API layer [87]

### DIFF
--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -1,0 +1,424 @@
+import { supabase } from '../supabase';
+import { getUserRole } from '../auth';
+import { BlogPost, BlogTag, BlogPostStatus } from '../../types/models';
+import { blogPostSchema } from './schemas';
+import { slugify, generateUniqueSlug } from '../../utils/slugify';
+
+// ============================================================
+// Types
+// ============================================================
+
+interface BlogPostFilters {
+    category?: string;
+    status?: string;
+    is_featured?: boolean;
+    authorId?: string;
+    limit?: number;
+    offset?: number;
+}
+
+/** Raw response from Supabase with nested tag structure */
+interface BlogPostRaw {
+    id: string;
+    title: string;
+    slug: string;
+    content: string | null;
+    excerpt: string | null;
+    video_url: string | null;
+    cover_image_url: string | null;
+    author_id: string | null;
+    category: string | null;
+    status: BlogPostStatus;
+    is_featured: boolean;
+    views: number;
+    published_at: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+    author?: { full_name: string | null; avatar_url: string | null } | null;
+    tags?: Array<{ tag: BlogTag | null } | null>;
+}
+
+interface BlogPostWithTags extends BlogPost {
+    tags?: BlogTag[];
+}
+
+// ============================================================
+// Helper: auto-generate excerpt from content
+// ============================================================
+function generateExcerpt(content: string | null, maxLength: number = 200): string | null {
+    if (!content) return null;
+    const stripped = content.replace(/<[^>]*>/g, '').trim();
+    if (stripped.length <= maxLength) return stripped;
+    return stripped.slice(0, maxLength).trimEnd() + '…';
+}
+
+// ============================================================
+// Helper: resolve slug conflicts
+// ============================================================
+async function resolveSlug(baseSlug: string): Promise<string> {
+    const { data } = await supabase
+        .from('blog_posts')
+        .select('slug')
+        .eq('slug', baseSlug)
+        .or(`slug.like.${baseSlug}-%`);
+
+    const existingSlugs = (data || []).map((row: { slug: string }) => row.slug);
+    return generateUniqueSlug(baseSlug, existingSlugs);
+}
+
+// ============================================================
+// Blog Posts CRUD
+// ============================================================
+
+export const blogService = {
+    /**
+     * Fetch blog posts with optional filters.
+     * Admin users can see all statuses; others see only published.
+     */
+    async getBlogPosts(filters: BlogPostFilters = {}): Promise<{ data: BlogPostWithTags[]; total: number }> {
+        const { data: { user } } = await supabase.auth.getUser();
+        const role = user ? await getUserRole(user.id) : 'anon';
+
+        const limit = filters.limit ?? 10;
+        const offset = filters.offset ?? 0;
+
+        let query = supabase
+            .from('blog_posts')
+            .select(`
+                *,
+                author:profiles!blog_posts_author_id_fkey(full_name, avatar_url),
+                tags:blog_post_tags(tag:blog_tags(id, name, slug))
+            `, { count: 'exact' });
+
+        // Status filter
+        if (filters.status) {
+            query = query.eq('status', filters.status);
+        } else if (role !== 'admin' && !(user && filters.authorId === user.id)) {
+            // Non-admin, non-author: only published
+            query = query.eq('status', 'published');
+        }
+
+        // Category filter
+        if (filters.category) {
+            query = query.eq('category', filters.category);
+        }
+
+        // Featured filter
+        if (filters.is_featured) {
+            query = query.eq('is_featured', true);
+        }
+
+        // Author filter
+        if (filters.authorId) {
+            query = query.eq('author_id', filters.authorId);
+        }
+
+        // Order by published_at descending
+        const { data, error, count } = await query
+            .order('published_at', { ascending: false, nullsFirst: false })
+            .range(offset, offset + limit - 1);
+
+        if (error) throw error;
+
+        // Flatten the nested tags response
+        const flattened = (data || []).map((post: BlogPostRaw) => ({
+            ...post,
+            tags: (post.tags || [])
+                .map((t) => t?.tag)
+                .filter(Boolean) as BlogTag[],
+        })) as BlogPostWithTags[];
+
+        return { data: flattened, total: count || 0 };
+    },
+
+    /**
+     * Fetch a single blog post by slug. Optionally increments views.
+     */
+    async getBlogPost(slug: string, incrementViews: boolean = true): Promise<BlogPostWithTags | null> {
+        const { data, error } = await supabase
+            .from('blog_posts')
+            .select(`
+                *,
+                author:profiles!blog_posts_author_id_fkey(full_name, avatar_url),
+                tags:blog_post_tags(tag:blog_tags(id, name, slug))
+            `)
+            .eq('slug', slug)
+            .single();
+
+        if (error) {
+            if (error.code === 'PGRST116') return null;
+            throw error;
+        }
+
+        const post = data as BlogPostRaw;
+        const result: BlogPostWithTags = {
+            ...post,
+            tags: (post.tags || [])
+                .map((t) => t?.tag)
+                .filter(Boolean) as BlogTag[],
+        };
+
+        // Increment views atomically via RPC
+        if (incrementViews && result.status === 'published') {
+            try {
+                await supabase.rpc('increment_blog_views', { p_post_id: result.id });
+            } catch {
+                // Non-critical — don't fail the fetch
+            }
+        }
+
+        return result;
+    },
+
+    /**
+     * Create a new blog post. Auto-generates slug from title.
+     */
+    async createBlogPost(data: {
+        title: string;
+        slug?: string;
+        content?: string;
+        excerpt?: string;
+        video_url?: string;
+        cover_image_url?: string;
+        category?: string;
+        status?: 'draft' | 'published' | 'archived';
+        is_featured?: boolean;
+        tag_ids?: string[];
+    }): Promise<BlogPost> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        // Auto-generate slug if not provided
+        const baseSlug = data.slug || slugify(data.title);
+        const uniqueSlug = await resolveSlug(baseSlug);
+
+        // Auto-generate excerpt if not provided
+        const excerpt = data.excerpt || generateExcerpt(data.content || null);
+
+        const validatedData = blogPostSchema.parse({
+            ...data,
+            slug: uniqueSlug,
+            excerpt,
+        });
+
+        // Set published_at when publishing
+        const publishedAt = validatedData.status === 'published' ? new Date().toISOString() : null;
+
+        const { data: post, error } = await supabase
+            .from('blog_posts')
+            .insert([{
+                title: validatedData.title,
+                slug: validatedData.slug,
+                content: validatedData.content,
+                excerpt: validatedData.excerpt,
+                video_url: validatedData.video_url || null,
+                cover_image_url: validatedData.cover_image_url || null,
+                author_id: user.id,
+                category: validatedData.category || null,
+                status: validatedData.status,
+                is_featured: validatedData.is_featured && (await getUserRole(user.id)) === 'admin' ? true : false,
+                published_at: publishedAt,
+            }])
+            .select()
+            .single();
+
+        if (error) throw error;
+
+        // Attach tags if provided
+        const tagIds = data.tag_ids || validatedData.tag_ids;
+        if (tagIds && tagIds.length > 0) {
+            const tagRows = tagIds.map((tagId: string) => ({ post_id: post.id, tag_id: tagId }));
+            const { error: tagError } = await supabase
+                .from('blog_post_tags')
+                .insert(tagRows);
+            if (tagError) console.error('Failed to attach tags:', tagError);
+        }
+
+        return post as BlogPost;
+    },
+
+    /**
+     * Update a blog post. Author or admin only.
+     */
+    async updateBlogPost(id: string, updates: Partial<{
+        title: string;
+        slug: string;
+        content: string;
+        excerpt: string;
+        video_url: string;
+        cover_image_url: string;
+        category: string;
+        status: 'draft' | 'published' | 'archived';
+        is_featured: boolean;
+        tag_ids: string[];
+    }>): Promise<BlogPost> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+
+        // Verify ownership
+        const { data: existing } = await supabase
+            .from('blog_posts')
+            .select('author_id, status, slug')
+            .eq('id', id)
+            .single();
+
+        if (!existing) throw new Error('Blog post not found');
+        if (existing.author_id !== user.id && role !== 'admin') {
+            throw new Error('Not authorized');
+        }
+
+        // Build safe updates
+        const safe: Record<string, unknown> = {};
+
+        if (updates.title !== undefined) {
+            safe.title = updates.title;
+            // Re-generate slug when title changes (only if not custom-set)
+            if (!updates.slug) {
+                safe.slug = await resolveSlug(slugify(updates.title));
+            }
+        }
+
+        if (updates.content !== undefined) safe.content = updates.content;
+        if (updates.excerpt !== undefined) safe.excerpt = updates.excerpt;
+        else if (updates.content !== undefined) safe.excerpt = generateExcerpt(updates.content);
+
+        if (updates.video_url !== undefined) safe.video_url = updates.video_url || null;
+        if (updates.cover_image_url !== undefined) safe.cover_image_url = updates.cover_image_url || null;
+        if (updates.category !== undefined) safe.category = updates.category || null;
+
+        if (updates.status !== undefined) {
+            safe.status = updates.status;
+            // Set published_at when transitioning to published
+            if (updates.status === 'published' && existing.status !== 'published') {
+                safe.published_at = new Date().toISOString();
+            }
+        }
+
+        // is_featured is admin-only
+        if (updates.is_featured !== undefined && role === 'admin') {
+            safe.is_featured = updates.is_featured;
+        }
+
+        const { data: post, error } = await supabase
+            .from('blog_posts')
+            .update({ ...safe, updated_at: new Date().toISOString() })
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+
+        // Sync tags if provided
+        if (updates.tag_ids !== undefined) {
+            // Remove existing tags
+            await supabase.from('blog_post_tags').delete().eq('post_id', id);
+
+            // Insert new tags
+            if (updates.tag_ids.length > 0) {
+                const tagRows = updates.tag_ids.map((tagId: string) => ({ post_id: id, tag_id: tagId }));
+                const { error: tagError } = await supabase
+                    .from('blog_post_tags')
+                    .insert(tagRows);
+                if (tagError) console.error('Failed to sync tags:', tagError);
+            }
+        }
+
+        return post as BlogPost;
+    },
+
+    /**
+     * Delete a blog post. Admin only.
+     */
+    async deleteBlogPost(id: string): Promise<void> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can delete blog posts');
+
+        const { error } = await supabase
+            .from('blog_posts')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+    },
+
+    // ============================================================
+    // Tags
+    // ============================================================
+
+    async getBlogTags(): Promise<BlogTag[]> {
+        const { data, error } = await supabase
+            .from('blog_tags')
+            .select('*')
+            .order('name', { ascending: true });
+
+        if (error) throw error;
+        return data as BlogTag[];
+    },
+
+    async createBlogTag(name: string): Promise<BlogTag> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can create tags');
+
+        const tagSlug = slugify(name);
+
+        const { data, error } = await supabase
+            .from('blog_tags')
+            .insert([{ name, slug: tagSlug }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        return data as BlogTag;
+    },
+
+    async deleteBlogTag(id: string): Promise<void> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can delete tags');
+
+        const { error } = await supabase
+            .from('blog_tags')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+    },
+
+    // ============================================================
+    // Tag assignments
+    // ============================================================
+
+    async addTagToPost(postId: string, tagId: string): Promise<void> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { error } = await supabase
+            .from('blog_post_tags')
+            .insert([{ post_id: postId, tag_id: tagId }]);
+
+        if (error) throw error;
+    },
+
+    async removeTagFromPost(postId: string, tagId: string): Promise<void> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { error } = await supabase
+            .from('blog_post_tags')
+            .delete()
+            .eq('post_id', postId)
+            .eq('tag_id', tagId);
+
+        if (error) throw error;
+    },
+};

--- a/api-services/api/schemas.ts
+++ b/api-services/api/schemas.ts
@@ -67,3 +67,21 @@ export const reviewSchema = z.object({
     comment: z.string().min(5, "Comment must be at least 5 characters").max(1000, "Comment cannot exceed 1000 characters"),
     images: z.array(z.string()).default([]),
 });
+
+export const blogPostSchema = z.object({
+    title: z.string().min(3, "Title must be at least 3 characters"),
+    slug: z.string().min(3, "Slug must be at least 3 characters").optional(),
+    content: z.string().optional(),
+    excerpt: z.string().max(500).optional(),
+    video_url: z.string().url().optional().or(z.literal('')),
+    cover_image_url: z.string().url().optional().or(z.literal('')),
+    category: z.string().optional(),
+    status: z.enum(['draft', 'published', 'archived']).default('draft'),
+    is_featured: z.boolean().default(false),
+    tag_ids: z.array(z.string().uuid()).default([]),
+});
+
+export const blogTagSchema = z.object({
+    name: z.string().min(1, "Tag name is required"),
+    slug: z.string().min(1, "Tag slug is required"),
+});

--- a/api-services/index.ts
+++ b/api-services/index.ts
@@ -15,6 +15,7 @@ export * from './api/storage';
 export * from './api/notifications';
 export * from './api/chat';
 export * from './api/directory';
+export * from './api/blog';
 export * from './supabase';
 export * from './auth';
 export * from './aiService';
@@ -30,6 +31,7 @@ import { notificationsService } from './api/notifications';
 import { chatService } from './api/chat';
 import { yesimService } from './api/yesim';
 import { directoryService } from './api/directory';
+import { blogService } from './api/blog';
 
 export const db = {
     ...propertiesService,
@@ -43,5 +45,6 @@ export const db = {
     ...notificationsService,
     ...chatService,
     ...directoryService,
+    ...blogService,
     yesimService
 };

--- a/supabase/migrations/20260413000002_blog_system.sql
+++ b/supabase/migrations/20260413000002_blog_system.sql
@@ -1,0 +1,222 @@
+-- Migration: 20260413000002_blog_system
+-- Purpose: Create blog_posts, blog_tags, blog_post_tags tables with RLS
+-- Task: [87] Блог — БД схема + API
+
+-- ============================================================
+-- 1. CREATE blog_posts table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.blog_posts (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    title TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    content TEXT,
+    excerpt TEXT,
+    video_url TEXT,
+    cover_image_url TEXT,
+    author_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+    category TEXT,
+    status TEXT DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'archived')),
+    is_featured BOOLEAN NOT NULL DEFAULT false,
+    views INT NOT NULL DEFAULT 0,
+    published_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- ============================================================
+-- 2. CREATE blog_tags + blog_post_tags tables
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.blog_tags (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL
+);
+
+-- Enforce unique tag names and slugs
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blog_tags_name ON public.blog_tags (name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blog_tags_slug ON public.blog_tags (slug);
+
+CREATE TABLE IF NOT EXISTS public.blog_post_tags (
+    post_id UUID NOT NULL REFERENCES public.blog_posts(id) ON DELETE CASCADE,
+    tag_id UUID NOT NULL REFERENCES public.blog_tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+
+-- ============================================================
+-- 3. INDEXES
+-- ============================================================
+-- Unique slug
+CREATE UNIQUE INDEX IF NOT EXISTS idx_blog_posts_slug ON public.blog_posts (slug);
+
+-- Status-based queries
+CREATE INDEX IF NOT EXISTS idx_blog_posts_status ON public.blog_posts (status);
+
+-- Author-based queries
+CREATE INDEX IF NOT EXISTS idx_blog_posts_author_id ON public.blog_posts (author_id);
+
+-- Featured published posts (small, fast partial index)
+CREATE INDEX IF NOT EXISTS idx_blog_posts_featured
+    ON public.blog_posts (id, title, slug, cover_image_url, published_at)
+    WHERE is_featured = true AND status = 'published';
+
+-- Category + status composite
+CREATE INDEX IF NOT EXISTS idx_blog_posts_category_status
+    ON public.blog_posts (category, status, published_at DESC);
+
+-- Published posts ordered by date (for listing pages)
+CREATE INDEX IF NOT EXISTS idx_blog_posts_published
+    ON public.blog_posts (published_at DESC)
+    WHERE status = 'published';
+
+-- Junction table index (tag → posts direction, FK already creates post_id index)
+CREATE INDEX IF NOT EXISTS idx_blog_post_tags_tag_id ON public.blog_post_tags (tag_id);
+
+-- ============================================================
+-- 4. TRIGGER: updated_at
+-- ============================================================
+-- Uses the existing global update_updated_at_column() function
+DROP TRIGGER IF EXISTS trg_blog_posts_updated_at ON public.blog_posts;
+CREATE TRIGGER trg_blog_posts_updated_at
+    BEFORE UPDATE ON public.blog_posts
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_updated_at_column();
+
+-- ============================================================
+-- 5. ROW LEVEL SECURITY — blog_posts
+-- ============================================================
+ALTER TABLE public.blog_posts ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: public can read published posts only
+CREATE POLICY "blog_posts_select_published" ON public.blog_posts
+    FOR SELECT
+    USING (status = 'published');
+
+-- SELECT: authors can read their own posts (any status)
+CREATE POLICY "blog_posts_select_own" ON public.blog_posts
+    FOR SELECT
+    USING (author_id = (SELECT auth.uid()));
+
+-- SELECT: admin can read all posts
+CREATE POLICY "blog_posts_select_admin" ON public.blog_posts
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- INSERT: authenticated users can create posts (author_id forced in API layer)
+CREATE POLICY "blog_posts_insert" ON public.blog_posts
+    FOR INSERT
+    WITH CHECK ((SELECT auth.role()) = 'authenticated');
+
+-- UPDATE: authors can update their own posts
+CREATE POLICY "blog_posts_update" ON public.blog_posts
+    FOR UPDATE
+    USING (
+        author_id = (SELECT auth.uid())
+        OR EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- DELETE: admin only
+CREATE POLICY "blog_posts_delete" ON public.blog_posts
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- ============================================================
+-- 6. ROW LEVEL SECURITY — blog_tags
+-- ============================================================
+ALTER TABLE public.blog_tags ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: public read
+CREATE POLICY "blog_tags_select" ON public.blog_tags
+    FOR SELECT
+    USING (true);
+
+-- INSERT/UPDATE/DELETE: admin only
+CREATE POLICY "blog_tags_insert" ON public.blog_tags
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+CREATE POLICY "blog_tags_update" ON public.blog_tags
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+CREATE POLICY "blog_tags_delete" ON public.blog_tags
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- ============================================================
+-- 7. ROW LEVEL SECURITY — blog_post_tags
+-- ============================================================
+ALTER TABLE public.blog_post_tags ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: public read
+CREATE POLICY "blog_post_tags_select" ON public.blog_post_tags
+    FOR SELECT
+    USING (true);
+
+-- INSERT/DELETE: post author or admin
+CREATE POLICY "blog_post_tags_insert" ON public.blog_post_tags
+    FOR INSERT
+    WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM public.blog_posts bp
+            WHERE bp.id = blog_post_tags.post_id
+            AND (
+                bp.author_id = (SELECT auth.uid())
+                OR EXISTS (
+                    SELECT 1 FROM public.profiles
+                    WHERE id = (SELECT auth.uid())
+                    AND role = 'admin'
+                )
+            )
+        )
+    );
+
+CREATE POLICY "blog_post_tags_delete" ON public.blog_post_tags
+    FOR DELETE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.blog_posts bp
+            WHERE bp.id = blog_post_tags.post_id
+            AND (
+                bp.author_id = (SELECT auth.uid())
+                OR EXISTS (
+                    SELECT 1 FROM public.profiles
+                    WHERE id = (SELECT auth.uid())
+                    AND role = 'admin'
+                )
+            )
+        )
+    );

--- a/supabase/migrations/20260413000003_blog_rpc.sql
+++ b/supabase/migrations/20260413000003_blog_rpc.sql
@@ -1,0 +1,34 @@
+-- Migration: 20260413000003_blog_rpc
+-- Purpose: RPC functions for blog system
+-- Task: [87] Блог — БД схема + API
+
+-- ============================================================
+-- 1. increment_blog_views — atomic view counter
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.increment_blog_views(p_post_id UUID)
+RETURNS TABLE (views INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF p_post_id IS NULL THEN
+        RAISE EXCEPTION 'post_id is required';
+    END IF;
+
+    UPDATE public.blog_posts
+    SET views = views + 1
+    WHERE id = p_post_id
+    RETURNING blog_posts.views INTO views;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Blog post not found: %', p_post_id;
+    END IF;
+
+    RETURN NEXT;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.increment_blog_views(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_blog_views(UUID) TO anon;
+GRANT EXECUTE ON FUNCTION public.increment_blog_views(UUID) TO authenticated;

--- a/types/models.ts
+++ b/types/models.ts
@@ -432,3 +432,42 @@ export interface DirectoryListingDB {
   created_at?: string;
   updated_at?: string;
 }
+
+// ============================================================
+// Blog
+// ============================================================
+
+export type BlogPostStatus = 'draft' | 'published' | 'archived';
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  slug: string;
+  content: string | null;
+  excerpt: string | null;
+  video_url: string | null;
+  cover_image_url: string | null;
+  author_id: string | null;
+  category: string | null;
+  status: BlogPostStatus;
+  is_featured: boolean;
+  views: number;
+  published_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+
+  // Virtual / joined fields
+  author?: { full_name: string | null; avatar_url: string | null };
+  tags?: BlogTag[];
+}
+
+export interface BlogTag {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface BlogPostTag {
+  post_id: string;
+  tag_id: string;
+}

--- a/utils/slugify.ts
+++ b/utils/slugify.ts
@@ -1,0 +1,56 @@
+/**
+ * Converts a string into a URL-safe slug.
+ *
+ * - Lowercases the input
+ * - Replaces non-ASCII chars with ASCII approximations (Turkish-aware)
+ * - Replaces spaces/special chars with hyphens
+ * - Collapses multiple hyphens into one
+ * - Trims leading/trailing hyphens
+ */
+export function slugify(input: string): string {
+    if (!input) return '';
+
+    const turkishMap: Record<string, string> = {
+        'ç': 'c', 'Ç': 'C',
+        'ğ': 'g', 'Ğ': 'G',
+        'ı': 'i', 'İ': 'I',
+        'ö': 'o', 'Ö': 'O',
+        'ş': 's', 'Ş': 'S',
+        'ü': 'u', 'Ü': 'U',
+    };
+
+    let result = input.toLowerCase();
+
+    // Replace Turkish characters
+    for (const [from, to] of Object.entries(turkishMap)) {
+        result = result.replace(new RegExp(from, 'g'), to);
+    }
+
+    // Replace apostrophes and quotes (remove them)
+    result = result.replace(/['"""]/g, '');
+
+    // Replace spaces and non-alphanumeric chars with hyphens
+    result = result.replace(/[^a-z0-9]+/g, '-');
+
+    // Collapse multiple hyphens and trim
+    result = result.replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+    return result;
+}
+
+/**
+ * Generates a unique slug by appending a numeric suffix if the base slug exists.
+ */
+export function generateUniqueSlug(baseSlug: string, existingSlugs: string[]): string {
+    if (!existingSlugs.includes(baseSlug)) {
+        return baseSlug;
+    }
+
+    let suffix = 1;
+    let candidate = `${baseSlug}-${suffix}`;
+    while (existingSlugs.includes(candidate)) {
+        suffix++;
+        candidate = `${baseSlug}-${suffix}`;
+    }
+    return candidate;
+}


### PR DESCRIPTION
## Summary
- 2 migrations: `blog_posts` + `blog_tags` + `blog_post_tags` tables, indexes, RLS, `updated_at` trigger; `increment_blog_views` RPC
- Full CRUD API in `api-services/api/blog.ts`: `getBlogPosts`, `getBlogPost`, `createBlogPost`, `updateBlogPost`, `deleteBlogPost`, `getBlogTags`, `createBlogTag`, `deleteBlogTag`, `addTagToPost`, `removeTagFromPost`
- `utils/slugify.ts` — Turkish-aware slugifier + unique slug conflict resolution
- Types: `BlogPost`, `BlogTag`, `BlogPostTag`, `BlogPostStatus` in `types/models.ts`
- Zod schemas: `blogPostSchema`, `blogTagSchema`

## Key decisions
- `is_featured` is admin-only (enforced in API layer, not just RLS)
- `published_at` auto-set on status transition to `published`
- `increment_blog_views` fires only for published posts, failure is non-fatal
- Tag sync on update uses delete+insert pattern (simple, atomic enough for blog use case)
- `resolveSlug` handles slug conflicts via suffix: `my-post`, `my-post-1`, `my-post-2`

## Testing notes
- Run migrations: `supabase db push`
- No frontend yet — task 96 (Travel Guide section) depends on this