### PR TITLE
feat: add blog submissions with $5 Stripe payment and admin moderation [88]

### DIFF
--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -1,7 +1,7 @@
 import { supabase } from '../supabase';
 import { getUserRole } from '../auth';
-import { BlogPost, BlogTag, BlogPostStatus } from '../../types/models';
-import { blogPostSchema } from './schemas';
+import { BlogPost, BlogTag, BlogPostStatus, BlogSubmission } from '../../types/models';
+import { blogPostSchema, blogSubmissionSchema } from './schemas';
 import { slugify, generateUniqueSlug } from '../../utils/slugify';
 
 // ============================================================
@@ -420,5 +420,266 @@ export const blogService = {
             .eq('tag_id', tagId);
 
         if (error) throw error;
+    },
+
+    // ============================================================
+    // Blog Submissions (User-submitted posts requiring payment + moderation)
+    // ============================================================
+
+    /**
+     * Create a blog submission and return Stripe checkout URL.
+     * Creates submission with status='pending_payment', then invokes Stripe edge function.
+     */
+    async createBlogSubmission(data: {
+        title: string;
+        content: string;
+        video_url?: string;
+        media_urls?: string[];
+    }): Promise<{ submissionId: string; checkoutUrl: string }> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const validatedData = blogSubmissionSchema.parse(data);
+
+        // Create submission record
+        const { data: submission, error: subError } = await supabase
+            .from('blog_submissions')
+            .insert([{
+                user_id: user.id,
+                title: validatedData.title,
+                content: validatedData.content,
+                video_url: validatedData.video_url || null,
+                media_urls: validatedData.media_urls || [],
+                status: 'pending_payment',
+                payment_status: 'unpaid',
+            }])
+            .select()
+            .single();
+
+        if (subError || !submission) throw subError || new Error('Failed to create submission');
+
+        // Get user email for Stripe
+        const { data: profile } = await supabase
+            .from('profiles')
+            .select('email')
+            .eq('id', user.id)
+            .single();
+
+        // Invoke Stripe edge function for blog submission checkout
+        const { data: stripeData, error: stripeError } = await supabase.functions.invoke('create-checkout-session', {
+            body: {
+                mode: 'blog_submission',
+                email: profile?.email,
+                origin: window.location.origin,
+                blogSubmission: {
+                    submissionId: submission.id,
+                    title: submission.title,
+                    authorEmail: profile?.email,
+                },
+            },
+        });
+
+        if (stripeError || !stripeData?.url) {
+            // Clean up the submission if Stripe checkout failed
+            await supabase.from('blog_submissions').delete().eq('id', submission.id);
+            throw stripeError || new Error('Failed to create Stripe checkout session');
+        }
+
+        return { submissionId: submission.id, checkoutUrl: stripeData.url };
+    },
+
+    /**
+     * Get all blog submissions. Admin only.
+     */
+    async getBlogSubmissions(filters?: { status?: string; userId?: string }): Promise<BlogSubmission[]> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can view all submissions');
+
+        let query = supabase
+            .from('blog_submissions')
+            .select(`
+                *,
+                user:profiles!blog_submissions_user_id_fkey(full_name, email)
+            `)
+            .order('created_at', { ascending: false });
+
+        if (filters?.status) query = query.eq('status', filters.status);
+        if (filters?.userId) query = query.eq('user_id', filters.userId);
+
+        const { data, error } = await query;
+        if (error) throw error;
+        return data as BlogSubmission[];
+    },
+
+    /**
+     * Get current user's own blog submissions.
+     */
+    async getUserBlogSubmissions(): Promise<BlogSubmission[]> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { data, error } = await supabase
+            .from('blog_submissions')
+            .select('*')
+            .eq('user_id', user.id)
+            .order('created_at', { ascending: false });
+
+        if (error) throw error;
+        return data as BlogSubmission[];
+    },
+
+    /**
+     * Approve a blog submission: creates a blog_post from the submission data.
+     * Admin only. Sends email to author.
+     */
+    async approveBlogSubmission(submissionId: string): Promise<BlogPost> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can approve submissions');
+
+        // Get submission
+        const { data: submission, error: subError } = await supabase
+            .from('blog_submissions')
+            .select('*')
+            .eq('id', submissionId)
+            .single();
+
+        if (subError || !submission) throw subError || new Error('Submission not found');
+        if (submission.payment_status !== 'paid') throw new Error('Submission payment not confirmed');
+        if (submission.status !== 'pending_review') throw new Error('Submission is not pending review');
+
+        // Create blog post from submission
+        const baseSlug = slugify(submission.title);
+        const uniqueSlug = await resolveSlug(baseSlug);
+
+        const { data: post, error: postError } = await supabase
+            .from('blog_posts')
+            .insert([{
+                title: submission.title,
+                slug: uniqueSlug,
+                content: submission.content,
+                excerpt: generateExcerpt(submission.content),
+                video_url: submission.video_url,
+                cover_image_url: submission.media_urls?.[0] || null,
+                author_id: submission.user_id,
+                status: 'published',
+                is_featured: false,
+                published_at: new Date().toISOString(),
+            }])
+            .select()
+            .single();
+
+        if (postError || !post) throw postError || new Error('Failed to create blog post');
+
+        // Update submission status
+        await supabase
+            .from('blog_submissions')
+            .update({ status: 'approved' })
+            .eq('id', submissionId);
+
+        // Notify author
+        const { data: authorProfile } = await supabase
+            .from('profiles')
+            .select('email, full_name')
+            .eq('id', submission.user_id)
+            .single();
+
+        await supabase.from('notifications').insert({
+            user_id: submission.user_id,
+            title: 'Blog Post Published!',
+            message: `Your submission "${submission.title}" has been approved and published.`,
+            type: 'success',
+            link: `/blog/${uniqueSlug}`,
+        });
+
+        // Send approval email
+        if (authorProfile?.email) {
+            try {
+                await supabase.functions.invoke('send-email', {
+                    body: {
+                        to: authorProfile.email,
+                        type: 'blog_submission_approved',
+                        data: {
+                            postTitle: submission.title,
+                            postUrl: `${window.location.origin}/blog/${uniqueSlug}`,
+                            authorName: authorProfile.full_name || 'Author',
+                        },
+                    },
+                });
+            } catch (e) {
+                console.error('Failed to send approval email:', e);
+            }
+        }
+
+        return post as BlogPost;
+    },
+
+    /**
+     * Reject a blog submission. Admin only. Sends email to author with reason.
+     */
+    async rejectBlogSubmission(submissionId: string, reason: string): Promise<void> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const role = await getUserRole(user.id);
+        if (role !== 'admin') throw new Error('Only admins can reject submissions');
+        if (!reason || reason.trim().length < 10) throw new Error('Rejection reason must be at least 10 characters');
+
+        // Get submission
+        const { data: submission, error: subError } = await supabase
+            .from('blog_submissions')
+            .select('*')
+            .eq('id', submissionId)
+            .single();
+
+        if (subError || !submission) throw subError || new Error('Submission not found');
+
+        // Update submission
+        await supabase
+            .from('blog_submissions')
+            .update({
+                status: 'rejected',
+                rejection_reason: reason,
+            })
+            .eq('id', submissionId);
+
+        // Notify author
+        await supabase.from('notifications').insert({
+            user_id: submission.user_id,
+            title: 'Blog Submission Rejected',
+            message: `Your submission "${submission.title}" was not approved. Reason: ${reason}`,
+            type: 'warning',
+            link: '/blog/submit',
+        });
+
+        // Send rejection email
+        const { data: authorProfile } = await supabase
+            .from('profiles')
+            .select('email, full_name')
+            .eq('id', submission.user_id)
+            .single();
+
+        if (authorProfile?.email) {
+            try {
+                await supabase.functions.invoke('send-email', {
+                    body: {
+                        to: authorProfile.email,
+                        type: 'blog_submission_rejected',
+                        data: {
+                            postTitle: submission.title,
+                            reason,
+                            authorName: authorProfile.full_name || 'Author',
+                        },
+                    },
+                });
+            } catch (e) {
+                console.error('Failed to send rejection email:', e);
+            }
+        }
     },
 };

--- a/api-services/api/schemas.ts
+++ b/api-services/api/schemas.ts
@@ -85,3 +85,10 @@ export const blogTagSchema = z.object({
     name: z.string().min(1, "Tag name is required"),
     slug: z.string().min(1, "Tag slug is required"),
 });
+
+export const blogSubmissionSchema = z.object({
+    title: z.string().min(3, "Title must be at least 3 characters"),
+    content: z.string().min(100, "Content must be at least 100 characters"),
+    video_url: z.string().url().optional().or(z.literal('')),
+    media_urls: z.array(z.string()).default([]),
+});

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -29,6 +29,13 @@ interface CartItem {
   listingId: string
   title: string
 }
+
+interface BlogSubmissionPayload {
+  submissionId: string
+  title: string
+  authorEmail?: string
+}
+
 interface SupabaseEmptyResponse {
   data: unknown[]
   error: null
@@ -59,9 +66,9 @@ Deno.serve(async (req: Request) => {
       )
     }
 
-    const { items, email, origin } = await req.json()
+    const { items, email, origin, mode, blogSubmission } = await req.json()
 
-    if (!items?.length || !origin) {
+    if (!origin) {
       return new Response(
         JSON.stringify({ error: 'Missing required fields' }),
         { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -76,6 +83,93 @@ Deno.serve(async (req: Request) => {
     }
 
     const verifiedUserId = user.id
+
+    // --- Blog submission checkout ---
+    if (mode === 'blog_submission') {
+      const payload = blogSubmission as BlogSubmissionPayload | undefined
+      if (!payload?.submissionId) {
+        return new Response(
+          JSON.stringify({ error: 'submissionId is required for blog_submission mode' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+
+      // Verify ownership
+      const { data: submission, error: subError } = await supabase
+        .from('blog_submissions')
+        .select('id, title, user_id, status')
+        .eq('id', payload.submissionId)
+        .single()
+
+      if (subError || !submission) {
+        return new Response(
+          JSON.stringify({ error: 'Submission not found' }),
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+
+      if (submission.user_id !== verifiedUserId) {
+        return new Response(
+          JSON.stringify({ error: 'Not authorized' }),
+          { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+
+      if (submission.status !== 'pending_payment') {
+        return new Response(
+          JSON.stringify({ error: 'Submission is not in pending_payment status' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        )
+      }
+
+      const expiresAt = Math.floor(Date.now() / 1000) + 30 * 60
+      const paymentExpiresAt = new Date(Date.now() + PAYMENT_WINDOW_MINUTES * 60 * 1000).toISOString()
+
+      const session = await stripe.checkout.sessions.create({
+        mode: 'payment',
+        customer_email: email,
+        expires_at: expiresAt,
+        line_items: [{
+          price_data: {
+            currency: 'eur',
+            product_data: {
+              name: 'Blog Post Submission Fee',
+              description: `Publication fee for: ${submission.title}`,
+            },
+            unit_amount: 500, // $5.00
+          },
+          quantity: 1,
+        }],
+        success_url: `${origin}/blog/submission-success?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${origin}/blog/submit`,
+        metadata: {
+          userId: verifiedUserId,
+          type: 'blog_submission',
+          submissionId: payload.submissionId,
+        },
+      })
+
+      await supabase
+        .from('blog_submissions')
+        .update({
+          stripe_session_id: session.id,
+          payment_expires_at: paymentExpiresAt,
+        })
+        .eq('id', payload.submissionId)
+
+      return new Response(
+        JSON.stringify({ url: session.url }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // --- Standard cart/booking checkout ---
+    if (!items?.length) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required fields: items' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
 
     // --- Server-side price verification ---
     const propertyIds: string[] = []

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -44,6 +44,9 @@ const emailDataSchemas = {
   refund_processed:      z.object({ amount: z.coerce.string(), itemTitle: s, link: sOpt }),
   new_review:            z.object({ itemTitle: s, guestName: s, rating: z.coerce.number().min(1).max(5), comment: s, link: sOpt }),
   admin_contact_message: z.object({ subject: s, name: s, email: s, message: s }),
+  blog_submission_received: z.object({ postTitle: s, link: sOpt }),
+  blog_submission_approved: z.object({ postTitle: s, postUrl: s, authorName: s }),
+  blog_submission_rejected: z.object({ postTitle: s, reason: s, authorName: s }),
 } as const
 
 type EmailType = keyof typeof emailDataSchemas
@@ -633,6 +636,66 @@ function generateEmailContent(type: string, data: any): { subject: string, html:
                     `,
                     `mailto:${encodeURIComponent(data.email || '')}`,
                     'Reply via Email'
+                )
+            };
+
+        // --- Blog Submissions ---
+        case 'blog_submission_received':
+            return {
+                subject: `📝 Blog Submission Received: ${escapeHtml(data.postTitle)}`,
+                html: getHtmlTemplate(
+                    'Submission Received',
+                    `
+                    <p style="font-size: 16px;">Thank you! Your blog post <strong>${escapeHtml(data.postTitle)}</strong> has been received.</p>
+                    <div class="card">
+                        <p style="text-align: center; margin: 0;">Your submission is awaiting payment confirmation. Once payment is processed, our editorial team will review your content within 3-5 business days.</p>
+                    </div>
+                    <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">You will receive an email once your post is reviewed and published.</p>
+                    `,
+                    data.link,
+                    'View Blog'
+                )
+            };
+
+        case 'blog_submission_approved':
+            return {
+                subject: `🎉 Your blog post is Live: ${escapeHtml(data.postTitle)}!`,
+                html: getHtmlTemplate(
+                    'Blog Post Published!',
+                    `
+                    <p style="font-size: 16px;">Hi ${escapeHtml(data.authorName)},</p>
+                    <p>Great news! Your blog post <strong>${escapeHtml(data.postTitle)}</strong> has been approved and is now live on our website.</p>
+                    <div class="card">
+                         <div style="text-align: center; margin-bottom: 16px;">
+                            <div style="background: #d1fae5; color: #059669; width: 64px; height: 64px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto;">
+                                <span style="font-size: 32px;">✓</span>
+                            </div>
+                         </div>
+                         <p style="text-align: center; font-weight: 600; color: ${HEADING_COLOR}; margin: 0;">${escapeHtml(data.postTitle)}</p>
+                         <p style="text-align: center; font-size: 14px; color: #64748b; margin-top: 8px;">Now visible to all readers</p>
+                    </div>
+                    `,
+                    data.postUrl,
+                    'Read Your Post'
+                )
+            };
+
+        case 'blog_submission_rejected':
+            return {
+                subject: `⚠️ Blog Submission Update: ${escapeHtml(data.postTitle)}`,
+                html: getHtmlTemplate(
+                    'Submission Review Complete',
+                    `
+                    <p style="font-size: 16px;">Hi ${escapeHtml(data.authorName)},</p>
+                    <p>Thank you for your submission <strong>${escapeHtml(data.postTitle)}</strong>. After careful review, we are unable to publish it at this time.</p>
+                     <div class="card">
+                         <div class="info-row"><span class="label">Reason</span><span class="value" style="color:#ef4444">${escapeHtml(data.reason)}</span></div>
+                    </div>
+                    <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">You can revise your content and submit again.</p>
+                    `,
+                    undefined,
+                    undefined,
+                    true
                 )
             };
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -54,7 +54,87 @@ Deno.serve(async (req: Request) => {
     }
 
     if (session.payment_status === 'paid') {
-      if (bookingIds.length > 0) {
+      // --- Handle blog submission payment ---
+      if (session.metadata?.type === 'blog_submission') {
+        const submissionId = session.metadata.submissionId
+        if (submissionId) {
+          const { data: submission, error: subError } = await supabase
+            .from('blog_submissions')
+            .select('id, user_id, title, status, payment_status')
+            .eq('id', submissionId)
+            .maybeSingle()
+
+          if (subError) {
+            console.error('Blog submission lookup error:', subError)
+          } else if (submission && submission.payment_status !== 'paid') {
+            // Idempotency: skip if already paid
+            const { error: updateError } = await supabase
+              .from('blog_submissions')
+              .update({
+                payment_status: 'paid',
+                status: 'pending_review',
+              })
+              .eq('id', submissionId)
+
+            if (updateError) {
+              console.error('Failed to confirm blog submission payment:', updateError)
+              return new Response('DB update failed', { status: 500 })
+            }
+
+            console.log(`Confirmed blog submission payment: ${submissionId}`)
+
+            // Notify all admins about new submission awaiting review
+            const { data: admins } = await supabase
+              .from('profiles')
+              .select('id')
+              .eq('role', 'admin')
+
+            if (admins && admins.length > 0) {
+              await supabase.from('notifications').insert(
+                admins.map((admin: { id: string }) => ({
+                  user_id: admin.id,
+                  title: 'New Blog Submission',
+                  message: `A new blog submission "${submission.title}" is ready for review.`,
+                  type: 'info',
+                  link: `/admin/blog-submissions/${submissionId}`,
+                }))
+              )
+            }
+
+            // Send email to author: submission received, awaiting moderation
+            const { data: authorProfile } = await supabase
+              .from('profiles')
+              .select('email, full_name')
+              .eq('id', submission.user_id)
+              .maybeSingle()
+
+            const authorEmail = authorProfile?.email
+            if (authorEmail) {
+              const siteUrl = Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'
+              try {
+                await supabase.functions.invoke('send-email', {
+                  body: {
+                    to: authorEmail,
+                    type: 'blog_submission_received',
+                    data: {
+                      postTitle: submission.title,
+                      link: `${siteUrl}/blog`,
+                    },
+                  },
+                })
+                console.log(`Sent received email to ${authorEmail}`)
+              } catch (e) {
+                console.error('Failed to send received email:', e)
+              }
+            }
+          } else {
+            console.warn(`Skipping duplicate webhook for submission ${submissionId}`)
+          }
+        }
+      }
+
+      // --- Handle booking payments (existing logic) ---
+      else if (bookingIds.length > 0) {
         const updatePayload: Record<string, unknown> = {
           status: 'confirmed',
           payment_status: 'paid',

--- a/supabase/migrations/20260413000004_blog_submissions.sql
+++ b/supabase/migrations/20260413000004_blog_submissions.sql
@@ -1,0 +1,78 @@
+-- Migration: 20260413000004_blog_submissions
+-- Purpose: Create blog_submissions table for user-submitted blog posts awaiting payment + moderation
+-- Task: [88] Блог — заявки от пользователей + оплата $5
+
+-- ============================================================
+-- 1. CREATE blog_submissions table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.blog_submissions (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    video_url TEXT,
+    media_urls TEXT[] DEFAULT '{}',
+    status TEXT DEFAULT 'pending_payment' CHECK (status IN ('pending_payment', 'pending_review', 'approved', 'rejected')),
+    stripe_session_id TEXT UNIQUE,
+    payment_expires_at TIMESTAMPTZ,
+    payment_status TEXT DEFAULT 'unpaid',
+    rejection_reason TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- ============================================================
+-- 2. INDEXES
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_blog_submissions_user_id ON public.blog_submissions (user_id);
+CREATE INDEX IF NOT EXISTS idx_blog_submissions_status ON public.blog_submissions (status);
+CREATE INDEX IF NOT EXISTS idx_blog_submissions_stripe_session ON public.blog_submissions (stripe_session_id) WHERE stripe_session_id IS NOT NULL;
+
+-- ============================================================
+-- 3. ROW LEVEL SECURITY
+-- ============================================================
+ALTER TABLE public.blog_submissions ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: users can see their own submissions
+CREATE POLICY "blog_submissions_select_own" ON public.blog_submissions
+    FOR SELECT
+    USING (user_id = (SELECT auth.uid()));
+
+-- SELECT: admin can see all submissions
+CREATE POLICY "blog_submissions_select_admin" ON public.blog_submissions
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- INSERT: authenticated users can create submissions (user_id forced in API layer)
+CREATE POLICY "blog_submissions_insert" ON public.blog_submissions
+    FOR INSERT
+    WITH CHECK ((SELECT auth.role()) = 'authenticated');
+
+-- UPDATE: users can update their own submissions only while pending_payment
+CREATE POLICY "blog_submissions_update" ON public.blog_submissions
+    FOR UPDATE
+    USING (
+        user_id = (SELECT auth.uid())
+        OR EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- DELETE: users can delete their own submissions; admin can delete any
+CREATE POLICY "blog_submissions_delete" ON public.blog_submissions
+    FOR DELETE
+    USING (
+        user_id = (SELECT auth.uid())
+        OR EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );

--- a/types/models.ts
+++ b/types/models.ts
@@ -471,3 +471,23 @@ export interface BlogPostTag {
   post_id: string;
   tag_id: string;
 }
+
+export type BlogSubmissionStatus = 'pending_payment' | 'pending_review' | 'approved' | 'rejected';
+
+export interface BlogSubmission {
+  id: string;
+  user_id: string;
+  title: string;
+  content: string;
+  video_url: string | null;
+  media_urls: string[];
+  status: BlogSubmissionStatus;
+  stripe_session_id: string | null;
+  payment_expires_at: string | null;
+  payment_status: string;
+  rejection_reason: string | null;
+  created_at: string | null;
+
+  // Virtual / joined
+  user?: { full_name: string | null; email: string | null };
+}


### PR DESCRIPTION
## Summary
- Migration: `blog_submissions` table with RLS (user sees own, admin sees all)
- Extended `create-checkout-session` — new `mode: 'blog_submission'` branch before `items` validation
- Extended `stripe-webhook` — `checkout.session.completed` dispatches on `metadata.type === 'blog_submission'`: sets `payment_status='paid'`, `status='pending_review'`, notifies admins, emails author
- API: `createBlogSubmission`, `getBlogSubmissions`, `getUserBlogSubmissions`, `approveBlogSubmission`, `rejectBlogSubmission`
- Email templates: `blog_submission_received`, `blog_submission_approved`, `blog_submission_rejected`
- Types: `BlogSubmission`, `BlogSubmissionStatus`; Zod: `blogSubmissionSchema`

## Flow
1. User submits → INSERT `blog_submissions` (pending_payment) → Stripe Checkout $5
2. Webhook → paid → pending_review → admin notified + author emailed
3. Admin approves → blog_post created (published) + author notified
4. Admin rejects → rejection_reason saved + author notified

## Notes
- Webhook idempotency: skips if `payment_status === 'paid'` already
- Frontend (submit form, admin panel, success page) — not in scope for this task
- Stripe testing requires test mode keys from account owner