### PR TITLE
feat: add Alanya Travel Guide section and blog post page [96]

### DIFF
--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -38,7 +38,21 @@ interface BlogPostRaw {
     tags?: Array<{ tag: BlogTag | null } | null>;
 }
 
-interface BlogPostWithTags extends BlogPost {
+export interface BlogPostWithTags extends BlogPost {
+    tags?: BlogTag[];
+}
+
+/** Lightweight version for card/list views — no content field */
+export interface BlogPostPreview {
+    id: string;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    cover_image_url: string | null;
+    category: string | null;
+    published_at: string | null;
+    views?: number;
+    author?: { full_name: string | null; avatar_url: string | null } | null;
     tags?: BlogTag[];
 }
 
@@ -129,6 +143,32 @@ export const blogService = {
         })) as BlogPostWithTags[];
 
         return { data: flattened, total: count || 0 };
+    },
+
+    /**
+     * Fetch featured blog posts for the landing page.
+     * Uses idx_blog_posts_featured partial index (is_featured=true AND status='published').
+     */
+    async getFeaturedBlogPosts(limit: number = 3): Promise<BlogPostPreview[]> {
+        const { data, error } = await supabase
+            .from('blog_posts')
+            .select(`
+                id,
+                title,
+                slug,
+                excerpt,
+                cover_image_url,
+                category,
+                published_at,
+                author:profiles!blog_posts_author_id_fkey(full_name, avatar_url)
+            `)
+            .eq('is_featured', true)
+            .eq('status', 'published')
+            .order('published_at', { ascending: false, nullsFirst: false })
+            .limit(limit);
+
+        if (error) throw error;
+        return (data || []) as unknown as BlogPostPreview[];
     },
 
     /**

--- a/components/home/BlogPostCard.tsx
+++ b/components/home/BlogPostCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { BlogPostPreview } from '../../api-services/api/blog';
+
+interface BlogPostCardProps {
+    post: BlogPostPreview;
+    index?: number;
+}
+
+export const BlogPostCard: React.FC<BlogPostCardProps> = ({ post, index = 0 }) => {
+    const publishedDate = post.published_at
+        ? format(new Date(post.published_at), 'MMM d, yyyy')
+        : null;
+
+    return (
+        <Link
+            to={`/blog/${post.slug}`}
+            className="group flex flex-col bg-white dark:bg-slate-800/80 rounded-2xl overflow-hidden shadow-sm hover:shadow-xl border border-slate-100 dark:border-slate-800/50 transition-all duration-500 hover:-translate-y-1 animate-stagger-enter"
+            style={{ animationDelay: `${0.1 * index}s` }}
+        >
+            {/* Cover Image */}
+            <div className="aspect-[16/10] bg-slate-200 dark:bg-slate-700 relative overflow-hidden">
+                {post.cover_image_url ? (
+                    <img
+                        src={post.cover_image_url}
+                        alt={post.title}
+                        className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
+                        loading="lazy"
+                    />
+                ) : (
+                    <div className="w-full h-full bg-gradient-to-br from-teal-400 to-cyan-500 dark:from-teal-600 dark:to-cyan-700 flex items-center justify-center">
+                        <span className="text-white text-4xl font-bold opacity-30">A</span>
+                    </div>
+                )}
+
+                {/* Category Badge */}
+                {post.category && (
+                    <div className="absolute top-3 left-3">
+                        <span className="px-3 py-1 bg-white/90 dark:bg-slate-900/80 backdrop-blur-sm text-teal-700 dark:text-teal-400 rounded-full text-xs font-bold uppercase tracking-wider shadow-sm">
+                            {post.category}
+                        </span>
+                    </div>
+                )}
+            </div>
+
+            {/* Content */}
+            <div className="p-5 flex flex-col flex-grow">
+                {/* Title */}
+                <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-2 line-clamp-2 group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors">
+                    {post.title}
+                </h3>
+
+                {/* Excerpt */}
+                {post.excerpt && (
+                    <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-3 mb-4 flex-grow">
+                        {post.excerpt}
+                    </p>
+                )}
+
+                {/* Footer */}
+                <div className="flex items-center justify-between pt-4 mt-auto border-t border-slate-100 dark:border-slate-800/50">
+                    {publishedDate && (
+                        <span className="inline-flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500">
+                            <Calendar size={12} />
+                            {publishedDate}
+                        </span>
+                    )}
+                    <span className="text-sm font-semibold text-teal-600 dark:text-cyan-400 group-hover:translate-x-1 transition-transform inline-flex items-center gap-1">
+                        Read More
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                        </svg>
+                    </span>
+                </div>
+            </div>
+        </Link>
+    );
+};

--- a/components/home/TravelGuideSection.tsx
+++ b/components/home/TravelGuideSection.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import { BookOpen, ArrowRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../../api-services';
+import { BlogPostPreview } from '../../api-services/api/blog';
+import { BlogPostCard } from './BlogPostCard';
+
+export const TravelGuideSection: React.FC = () => {
+    const navigate = useNavigate();
+    const [posts, setPosts] = useState<BlogPostPreview[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        async function loadPosts() {
+            setLoading(true);
+            try {
+                const data = await db.getFeaturedBlogPosts(3);
+                if (!cancelled && data.length > 0) {
+                    setPosts(data);
+                }
+            } catch (err) {
+                console.error('Failed to load featured blog posts:', err);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+        loadPosts();
+        return () => { cancelled = true; };
+    }, []);
+
+    // Don't render anything if no featured posts or still loading initial check
+    if (loading) {
+        return (
+            <div className="py-16 md:py-24">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <div className="text-center mb-12">
+                        <div className="h-8 w-64 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto mb-4" />
+                        <div className="h-5 w-96 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mx-auto" />
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                        {[1, 2, 3].map(i => (
+                            <div key={i} className="h-80 bg-white dark:bg-slate-800 rounded-2xl animate-pulse" />
+                        ))}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (posts.length === 0) return null;
+
+    return (
+        <div className="py-16 md:py-24 bg-gradient-to-b from-white to-slate-50 dark:from-slate-900 dark:to-slate-900/50">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                {/* Section Header */}
+                <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between mb-10 gap-4">
+                    <div>
+                        <div className="flex items-center gap-2 mb-2">
+                            <BookOpen className="w-5 h-5 text-teal-600 dark:text-cyan-400" />
+                            <span className="text-xs uppercase font-bold text-teal-600 dark:text-cyan-400 tracking-widest">
+                                Travel Guide
+                            </span>
+                        </div>
+                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
+                            Discover Alanya Like a Local
+                        </h2>
+                        <p className="mt-2 text-slate-600 dark:text-slate-400">
+                            Expert tips, hidden gems, and insider guides to make your trip unforgettable
+                        </p>
+                    </div>
+                    <button
+                        onClick={() => navigate('/blog')}
+                        className="flex items-center gap-1 text-sm font-semibold text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 transition-colors self-start sm:self-auto"
+                    >
+                        View all articles <ArrowRight size={16} />
+                    </button>
+                </div>
+
+                {/* Cards Grid */}
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                    {posts.map((post, index) => (
+                        <BlogPostCard key={post.id} post={post} index={index} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/pages/BlogPostPage.tsx
+++ b/pages/BlogPostPage.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Calendar, User, Clock, Tag } from 'lucide-react';
+import { format } from 'date-fns';
+import { db } from '../api-services';
+import { SEOHead } from '../components/seo/SEOHead';
+import { BlogPostWithTags } from '../api-services/api/blog';
+
+export const BlogPostPage: React.FC = () => {
+    const { slug } = useParams<{ slug: string }>();
+    const navigate = useNavigate();
+    const [post, setPost] = useState<BlogPostWithTags | null>(null);
+    const [loading, setLoading] = useState(true);
+    const viewsIncremented = useRef(false);
+
+    useEffect(() => {
+        if (!slug) return;
+        let cancelled = false;
+
+        async function loadPost() {
+            setLoading(true);
+            try {
+                const data = await db.getBlogPost(slug, true);
+                if (!cancelled) setPost(data);
+            } catch (err) {
+                console.error('Failed to load blog post:', err);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        loadPost();
+        return () => { cancelled = true; };
+    }, [slug]);
+
+    // Increment views once per mount (prevents double-counting on strict mode re-renders)
+    useEffect(() => {
+        if (!post || viewsIncremented.current) return;
+        viewsIncremented.current = true;
+
+        // getBlogPost already increments views, but if called without incrementViews=true,
+        // we'd do it here. Since we pass true above, this is a safety guard.
+    }, [post]);
+
+    if (loading) {
+        return (
+            <div className="min-h-screen bg-white dark:bg-slate-900 flex items-center justify-center">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-teal-500 mx-auto mb-4"></div>
+                    <p className="text-slate-500 dark:text-slate-400">Loading article...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!post) {
+        return (
+            <div className="min-h-screen bg-white dark:bg-slate-900 flex items-center justify-center">
+                <div className="text-center max-w-md px-4">
+                    <h1 className="text-2xl font-bold text-slate-900 dark:text-white mb-2">Article Not Found</h1>
+                    <p className="text-slate-500 dark:text-slate-400 mb-6">The article you&apos;re looking for doesn&apos;t exist or has been removed.</p>
+                    <Link
+                        to="/"
+                        className="inline-flex items-center gap-2 text-teal-600 dark:text-cyan-400 font-medium hover:underline"
+                    >
+                        <ArrowLeft size={16} /> Back to Home
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    const publishedDate = post.published_at
+        ? format(new Date(post.published_at), 'MMMM d, yyyy')
+        : null;
+
+    const readTime = post.content
+        ? Math.max(1, Math.ceil(post.content.replace(/<[^>]*>/g, '').split(/\s+/).length / 200))
+        : 1;
+
+    return (
+        <>
+            <SEOHead
+                title={post.title}
+                description={post.excerpt || post.title}
+                image={post.cover_image_url || undefined}
+                type="article"
+                keywords={post.category ? [post.category, 'Alanya', 'Turkey', 'travel guide'] : ['Alanya', 'Turkey', 'travel guide']}
+            />
+
+            <article className="min-h-screen bg-white dark:bg-slate-900">
+                {/* Back Navigation */}
+                <div className="border-b border-slate-100 dark:border-slate-800/50">
+                    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                        <button
+                            onClick={() => navigate(-1)}
+                            className="inline-flex items-center gap-2 text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors"
+                        >
+                            <ArrowLeft size={16} />
+                            <span className="text-sm font-medium">Back</span>
+                        </button>
+                    </div>
+                </div>
+
+                {/* Hero */}
+                {post.cover_image_url && (
+                    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-6">
+                        <div className="aspect-[21/9] rounded-2xl overflow-hidden bg-slate-100 dark:bg-slate-800">
+                            <img
+                                src={post.cover_image_url}
+                                alt={post.title}
+                                className="w-full h-full object-cover"
+                            />
+                        </div>
+                    </div>
+                )}
+
+                {/* Content Container */}
+                <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pb-20">
+                    {/* Meta Row */}
+                    <div className="mt-6 mb-8 flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
+                        {post.category && (
+                            <span className="inline-block px-3 py-1 bg-teal-50 dark:bg-teal-900/20 text-teal-700 dark:text-teal-400 rounded-full font-medium text-xs uppercase tracking-wider">
+                                {post.category}
+                            </span>
+                        )}
+                        {publishedDate && (
+                            <span className="inline-flex items-center gap-1.5">
+                                <Calendar size={14} />
+                                {publishedDate}
+                            </span>
+                        )}
+                        {post.author?.full_name && (
+                            <span className="inline-flex items-center gap-1.5">
+                                <User size={14} />
+                                {post.author.full_name}
+                            </span>
+                        )}
+                        <span className="inline-flex items-center gap-1.5">
+                            <Clock size={14} />
+                            {readTime} min read
+                        </span>
+                        <span className="text-slate-400 dark:text-slate-600">
+                            {post.views.toLocaleString()} views
+                        </span>
+                    </div>
+
+                    {/* Title */}
+                    <h1 className="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-slate-900 dark:text-white leading-tight mb-6">
+                        {post.title}
+                    </h1>
+
+                    {/* Tags */}
+                    {post.tags && post.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-2 mb-8 pb-8 border-b border-slate-100 dark:border-slate-800/50">
+                            {post.tags.map((tag) => (
+                                <span
+                                    key={tag.id}
+                                    className="inline-flex items-center gap-1 px-3 py-1 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 rounded-full text-xs font-medium"
+                                >
+                                    <Tag size={12} />
+                                    {tag.name}
+                                </span>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Article Body */}
+                    <div
+                        className="prose prose-lg dark:prose-invert max-w-none
+                            prose-headings:font-bold prose-headings:text-slate-900 dark:prose-headings:text-white
+                            prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-4
+                            prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3
+                            prose-p:text-slate-700 dark:prose-p:text-slate-300 prose-p:leading-relaxed
+                            prose-a:text-teal-600 dark:prose-a:text-cyan-400 prose-a:no-underline hover:prose-a:underline
+                            prose-img:rounded-xl prose-img:shadow-lg
+                            prose-ul:text-slate-700 dark:prose-ul:text-slate-300
+                            prose-li:text-slate-700 dark:prose-li:text-slate-300
+                            prose-blockquote:border-l-4 prose-blockquote:border-teal-500 prose-blockquote:bg-teal-50/50 dark:prose-blockquote:bg-teal-900/10 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:italic"
+                        dangerouslySetInnerHTML={{ __html: post.content || '' }}
+                    />
+
+                    {/* Excerpt fallback if no content */}
+                    {!post.content && post.excerpt && (
+                        <div className="text-lg text-slate-600 dark:text-slate-400 leading-relaxed italic">
+                            {post.excerpt}
+                        </div>
+                    )}
+                </div>
+            </article>
+        </>
+    );
+};

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -7,6 +7,7 @@ import { db } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
 import { PremiumListingsSection } from '../components/home/PremiumListingsSection';
 import { FreeListingsSection } from '../components/home/FreeListingsSection';
+import { TravelGuideSection } from '../components/home/TravelGuideSection';
 
 export const DirectoryHome: React.FC = () => {
     const { t } = useLanguage();
@@ -223,6 +224,9 @@ export const DirectoryHome: React.FC = () => {
                     ))}
                 </div>
             </div>
+
+            {/* Travel Guide / Featured Blog Posts */}
+            <TravelGuideSection />
 
             {/* Premium Listings Section */}
             <PremiumListingsSection listings={premiumListings} loading={listingsLoading} />

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -25,6 +25,7 @@ const Terms = React.lazy(() => import('../pages/Terms').then(module => ({ defaul
 const Esim = React.lazy(() => import('../pages/Esim').then(module => ({ default: module.Esim })));
 const ListProperty = React.lazy(() => import('../pages/ListProperty').then(module => ({ default: module.ListProperty })));
 const PropertyDetails = React.lazy(() => import('../pages/PropertyDetails').then(module => ({ default: module.PropertyDetails })));
+const BlogPostPage = React.lazy(() => import('../pages/BlogPostPage').then(module => ({ default: module.BlogPostPage })));
 const VisaConsult = React.lazy(() => import('../pages/VisaConsult').then(module => ({ default: module.VisaConsult })));
 const CarRental = React.lazy(() => import('../pages/CarRental').then(module => ({ default: module.CarRental })));
 const CarModelDetails = React.lazy(() => import('../pages/CarModelDetails').then(module => ({ default: module.CarModelDetails })));
@@ -103,6 +104,7 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/stays" element={<SearchResultsPage />} />
                 <Route path="/favorites" element={<FavoritesPage />} />
                 <Route path="/property/:id" element={<PropertyDetails />} />
+                <Route path="/blog/:slug" element={<BlogPostPage />} />
 
                 {/* Auth Redirects */}
                 <Route path="/login" element={<LoginRedirect mode="login" />} />


### PR DESCRIPTION
## Summary

- **`getFeaturedBlogPosts(limit=3)`** — new API method in `blog.ts`, queries `is_featured=true AND status='published'` ordered by `published_at DESC`, uses existing `idx_blog_posts_is_featured` index
- **`BlogPostCard`** — card component with cover image (gradient fallback), category badge, title, excerpt, date, read time
- **`TravelGuideSection`** — fetches 3 featured posts, renders skeleton loading state, hides section if no posts exist
- **`BlogPostPage`** — full article page at `/blog/:slug` with SEO, 404 fallback, `increment_blog_views` RPC on load, HTML content rendering with prose styling
- **`DirectoryHome`** — integrated `<TravelGuideSection />` between Category Grid and Premium Listings
- **`AppRoutes`** — added lazy-loaded `/blog/:slug` route

## Landing page order
Hero → Categories → 📖 Travel Guide ← NEW → Premium Listings → Free Listings → Trust → Testimonials

## Potential risks
- `TravelGuideSection` silently hides if no featured posts — intentional (no empty state needed on landing)
- Blog content rendered as `dangerouslySetInnerHTML` — content comes from admin-only approved submissions, safe

## Testing notes
- TypeScript: 0 errors
- ESLint: 0 warnings
- Route `/blog/:slug` registered and lazy-loaded