### PR TITLE
feat: navbar Directory/Blog/Shop + Rental/Services mode toggle [100]

### DIFF
--- a/components/Navbar.test.tsx
+++ b/components/Navbar.test.tsx
@@ -84,8 +84,8 @@ describe('Navbar', () => {
         );
         expect(screen.getByText('Alanya')).toBeDefined();
         // Check desktop links by text key
-        expect(screen.getAllByText('nav.stays').length).toBeGreaterThan(0);
-        expect(screen.getByText('nav.services')).toBeDefined();
+        expect(screen.getAllByText('nav.directory').length).toBeGreaterThan(0);
+        expect(screen.getByText('nav.blog')).toBeDefined();
     });
 
     it('opens login modal when guest clicks profile -> login', () => {

--- a/components/home/ModeToggle.tsx
+++ b/components/home/ModeToggle.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Home, Briefcase } from 'lucide-react';
+
+export type LandingMode = 'rental' | 'services';
+
+interface ModeToggleProps {
+    mode: LandingMode;
+    onChange: (mode: LandingMode) => void;
+}
+
+export const ModeToggle: React.FC<ModeToggleProps> = ({ mode, onChange }) => {
+    return (
+        <div className="inline-flex items-center bg-slate-100 dark:bg-slate-800 rounded-full p-1 border border-slate-200 dark:border-slate-700">
+            <button
+                onClick={() => onChange('rental')}
+                className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 cursor-pointer ${
+                    mode === 'rental'
+                        ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                        : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
+                }`}
+            >
+                <Home size={15} />
+                Rental
+            </button>
+            <button
+                onClick={() => onChange('services')}
+                className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 cursor-pointer ${
+                    mode === 'services'
+                        ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                        : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
+                }`}
+            >
+                <Briefcase size={15} />
+                Services
+            </button>
+        </div>
+    );
+};

--- a/components/navbar/DesktopNav.tsx
+++ b/components/navbar/DesktopNav.tsx
@@ -9,10 +9,9 @@ export const DesktopNav: React.FC = () => {
     return (
         <div className="hidden md:flex items-center space-x-1 lg:space-x-2 relative bg-slate-50 dark:bg-slate-800/80 p-1 rounded-full border border-slate-200 dark:border-slate-800/50 backdrop-blur-sm mx-4">
             <NavIndicator />
-            <NavLink to="/stays" label={t('nav.stays')} />
-            <NavLink to="/services" label={t('nav.services')} />
+            <NavLink to="/" label={t('nav.directory')} />
+            <NavLink to="/blog" label={t('nav.blog')} />
             <NavLink to="/shop" label={t('shop')} />
-            <NavLink to="/zero-fees" label={t('value.zero_fees.title')} isAccent />
         </div>
     );
 };

--- a/components/navbar/MobileMenu.test.tsx
+++ b/components/navbar/MobileMenu.test.tsx
@@ -59,7 +59,8 @@ vi.mock('lucide-react', () => ({
     LayoutDashboard: () => <svg data-testid="dashboard-icon" />,
     Heart: () => <svg data-testid="heart-icon" />,
     Banknote: () => <svg data-testid="banknote-icon" />,
-    ShoppingBag: () => <svg data-testid="shop-icon" />
+    ShoppingBag: () => <svg data-testid="shop-icon" />,
+    BookOpen: () => <svg data-testid="book-open-icon" />
 }));
 
 // Import component after mocks
@@ -113,10 +114,9 @@ describe('MobileMenu', () => {
 
     it('renders main navigation links', () => {
         renderMenu();
-        expect(screen.getByText('nav.stays')).toBeInTheDocument();
-        expect(screen.getByText('nav.services')).toBeInTheDocument();
+        expect(screen.getByText('nav.directory')).toBeInTheDocument();
+        expect(screen.getByText('nav.blog')).toBeInTheDocument();
         expect(screen.getByText('shop')).toBeInTheDocument();
-        expect(screen.getByText('value.zero_fees.title')).toBeInTheDocument();
     });
 
     it('renders user links when authenticated', () => {
@@ -172,7 +172,7 @@ describe('MobileMenu', () => {
 
     it('calls onClose when a link is clicked', () => {
         renderMenu();
-        fireEvent.click(screen.getByText('nav.stays'));
+        fireEvent.click(screen.getByText('nav.directory'));
         expect(mockOnClose).toHaveBeenCalled();
     });
 

--- a/components/navbar/MobileMenu.tsx
+++ b/components/navbar/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Sun, Moon, Globe, ChevronDown, Home, Car, LogOut, User, LayoutDashboard, Heart, Banknote, ShoppingBag } from 'lucide-react';
+import { Sun, Moon, Globe, ChevronDown, Home, LogOut, User, LayoutDashboard, Heart, ShoppingBag, BookOpen, Car } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
 import { useLanguage, Language } from '../../context/LanguageContext';
@@ -52,21 +52,17 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
 
             <div className="flex flex-col gap-1">
                 {/* Main Nav */}
-                <Link to="/stays" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
+                <Link to="/" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                     <Home size={18} className="text-slate-400" />
-                    {t('nav.stays')}
+                    {t('nav.directory')}
                 </Link>
-                <Link to="/services" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
-                    <Car size={18} className="text-slate-400" />
-                    {t('nav.services')}
+                <Link to="/blog" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
+                    <BookOpen size={18} className="text-slate-400" />
+                    {t('nav.blog')}
                 </Link>
                 <Link to="/shop" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200">
                     <ShoppingBag size={18} className="text-slate-400" />
                     {t('shop')}
-                </Link>
-                <Link to="/zero-fees" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-bold text-teal-600 dark:text-cyan-400 dark:text-slate-200 bg-teal-50/50 dark:bg-slate-800/50">
-                    <Banknote size={18} />
-                    {t('value.zero_fees.title')}
                 </Link>
                 <Link to="/list-property" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200">
                     <Home size={18} className="text-slate-400" />

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -2,6 +2,8 @@ export const ar = {
     // Navbar
     'nav.stays': 'إقامة',
     'nav.services': 'خدمات',
+    'nav.directory': 'الدليل',
+    'nav.blog': 'المدونة',
     'shop': 'المتجر',
     'nav.about': 'معلومات عنا',
     'nav.profile': 'الملف الشخصي',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -2,6 +2,8 @@ export const en = {
   // Navbar
   'nav.stays': 'Stays',
   'nav.services': 'Services',
+  'nav.directory': 'Directory',
+  'nav.blog': 'Blog',
   'shop': 'Shop',
   'nav.about': 'About',
   'nav.profile': 'Profile',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -2,6 +2,8 @@ export const ru = {
   // Navbar
   'nav.stays': 'Жилье',
   'nav.services': 'Сервисы',
+  'nav.directory': 'Каталог',
+  'nav.blog': 'Блог',
   'shop': 'Магазин',
   'nav.about': 'О нас',
   'nav.profile': 'Профиль',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -2,6 +2,8 @@ export const tr = {
     // Navbar
     'nav.stays': 'Konaklama',
     'nav.services': 'Hizmetler',
+    'nav.directory': 'Rehber',
+    'nav.blog': 'Blog',
     'nav.about': 'Hakkımızda',
     'shop': 'Mağaza',
     'nav.profile': 'Profil',

--- a/pages/BlogPage.tsx
+++ b/pages/BlogPage.tsx
@@ -1,0 +1,237 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { BookOpen, Search } from 'lucide-react';
+import { db } from '../api-services';
+import { BlogPostPreview } from '../api-services/api/blog';
+import { BlogPostCard } from '../components/home/BlogPostCard';
+import { SEOHead } from '../components/seo/SEOHead';
+
+const POSTS_PER_PAGE = 9;
+
+export const BlogPage: React.FC = () => {
+    const [posts, setPosts] = useState<BlogPostPreview[]>([]);
+    const [allCategories, setAllCategories] = useState<string[]>([]);
+    const [selectedCategory, setSelectedCategory] = useState<string>('all');
+    const [loading, setLoading] = useState(true);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const [offset, setOffset] = useState(0);
+
+    // Initial load — fetch posts and discover categories
+    useEffect(() => {
+        let cancelled = false;
+
+        async function load() {
+            setLoading(true);
+            try {
+                // Fetch first batch
+                const { data, total } = await db.getBlogPosts({
+                    status: 'published',
+                    limit: POSTS_PER_PAGE,
+                    offset: 0,
+                });
+
+                if (cancelled) return;
+                setPosts(data);
+                setOffset(POSTS_PER_PAGE);
+                setHasMore(data.length < total);
+
+                // Discover unique categories from all posts
+                const { data: allData } = await db.getBlogPosts({
+                    status: 'published',
+                    limit: 200,
+                });
+                if (cancelled) return;
+                const categories = Array.from(
+                    new Set(
+                        allData
+                            .map((p) => p.category)
+                            .filter((c): c is string => Boolean(c))
+                    )
+                ).sort();
+                setAllCategories(categories);
+            } catch (err) {
+                console.error('Failed to load blog posts:', err);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        load();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    // Category filter
+    const handleCategoryChange = useCallback(async (category: string) => {
+        setSelectedCategory(category);
+        setOffset(0);
+        setPosts([]);
+        setHasMore(true);
+
+        setLoading(true);
+        try {
+            const { data, total } = await db.getBlogPosts({
+                status: 'published',
+                category: category === 'all' ? undefined : category,
+                limit: POSTS_PER_PAGE,
+                offset: 0,
+            });
+            setPosts(data);
+            setOffset(POSTS_PER_PAGE);
+            setHasMore(data.length < total);
+        } catch (err) {
+            console.error('Failed to filter blog posts:', err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    // Load more
+    const handleLoadMore = useCallback(async () => {
+        if (loadingMore || !hasMore) return;
+        setLoadingMore(true);
+        try {
+            const { data, total } = await db.getBlogPosts({
+                status: 'published',
+                category: selectedCategory === 'all' ? undefined : selectedCategory,
+                limit: POSTS_PER_PAGE,
+                offset,
+            });
+            setPosts((prev) => [...prev, ...data]);
+            setOffset((prev) => prev + POSTS_PER_PAGE);
+            setHasMore(posts.length + data.length < total);
+        } catch (err) {
+            console.error('Failed to load more blog posts:', err);
+        } finally {
+            setLoadingMore(false);
+        }
+    }, [loadingMore, hasMore, offset, selectedCategory, posts.length]);
+
+    return (
+        <>
+            <SEOHead
+                title="Alanya Travel Blog — Local Tips, Guides & Insights"
+                description="Expert travel guides and local tips for Alanya: hidden gems, restaurant recommendations, beach guides, and insider advice to make your trip unforgettable."
+            />
+
+            {/* Hero */}
+            <section className="relative pt-32 pb-16 md:pt-40 md:pb-24 bg-gradient-to-b from-teal-50/50 to-white dark:from-slate-900 dark:to-slate-900 overflow-hidden">
+                {/* Decorative background */}
+                <div className="absolute inset-0 opacity-[0.03] dark:opacity-[0.05]" style={{
+                    backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%230d9488' fill-opacity='1'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+                }} />
+
+                <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+                    <div className="inline-flex items-center gap-2 px-4 py-1.5 bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-cyan-400 rounded-full text-sm font-semibold mb-6">
+                        <BookOpen size={16} />
+                        Travel Blog
+                    </div>
+                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold text-slate-900 dark:text-white tracking-tight">
+                        Alanya Travel Blog
+                    </h1>
+                    <p className="mt-4 text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
+                        Expert tips, hidden gems, and insider guides from locals.
+                        Discover the real Alanya beyond the tourist trail.
+                    </p>
+                </div>
+            </section>
+
+            {/* Category Filter Bar */}
+            {allCategories.length > 0 && (
+                <div className="sticky top-16 z-30 bg-white/80 dark:bg-slate-900/80 backdrop-blur-lg border-b border-slate-100 dark:border-slate-800/50">
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+                        <div className="flex items-center gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                            <span className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest shrink-0 mr-1 flex items-center gap-1">
+                                <Search size={12} />
+                                Filter
+                            </span>
+                            <button
+                                onClick={() => handleCategoryChange('all')}
+                                className={`px-4 py-1.5 rounded-full text-sm font-medium shrink-0 transition-all ${
+                                    selectedCategory === 'all'
+                                        ? 'bg-teal-600 dark:bg-cyan-600 text-white shadow-sm'
+                                        : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'
+                                }`}
+                            >
+                                All
+                            </button>
+                            {allCategories.map((cat) => (
+                                <button
+                                    key={cat}
+                                    onClick={() => handleCategoryChange(cat)}
+                                    className={`px-4 py-1.5 rounded-full text-sm font-medium shrink-0 transition-all capitalize ${
+                                        selectedCategory === cat
+                                            ? 'bg-teal-600 dark:bg-cyan-600 text-white shadow-sm'
+                                            : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'
+                                    }`}
+                                >
+                                    {cat}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Posts Grid */}
+            <section className="py-12 md:py-16">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    {loading ? (
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                            {Array.from({ length: 6 }).map((_, i) => (
+                                <div
+                                    key={i}
+                                    className="h-96 bg-slate-100 dark:bg-slate-800 rounded-2xl animate-pulse"
+                                />
+                            ))}
+                        </div>
+                    ) : posts.length === 0 ? (
+                        <div className="text-center py-20">
+                            <BookOpen size={48} className="mx-auto text-slate-300 dark:text-slate-600 mb-4" />
+                            <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+                                No articles found
+                            </h3>
+                            <p className="text-slate-500 dark:text-slate-400">
+                                {selectedCategory !== 'all'
+                                    ? `No posts in "${selectedCategory}" yet. Check back soon!`
+                                    : 'No blog posts available yet. Check back soon!'}
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                                {posts.map((post, index) => (
+                                    <BlogPostCard key={post.id} post={post} index={index} />
+                                ))}
+                            </div>
+
+                            {/* Load More */}
+                            {hasMore && (
+                                <div className="flex justify-center mt-12">
+                                    <button
+                                        onClick={handleLoadMore}
+                                        disabled={loadingMore}
+                                        className="px-8 py-3 bg-slate-900 dark:bg-white text-white dark:text-slate-900 rounded-xl font-semibold hover:bg-slate-800 dark:hover:bg-slate-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                    >
+                                        {loadingMore ? (
+                                            <span className="flex items-center gap-2">
+                                                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
+                                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                                </svg>
+                                                Loading...
+                                            </span>
+                                        ) : (
+                                            'Load More Articles'
+                                        )}
+                                    </button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </div>
+            </section>
+        </>
+    );
+};

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -8,13 +8,25 @@ import { DirectoryListingDB } from '../types/models';
 import { PremiumListingsSection } from '../components/home/PremiumListingsSection';
 import { FreeListingsSection } from '../components/home/FreeListingsSection';
 import { TravelGuideSection } from '../components/home/TravelGuideSection';
+import { ModeToggle, LandingMode } from '../components/home/ModeToggle';
+
+const RENTAL_CATEGORIES = new Set(['accommodations', 'transport', 'real-estate']);
+const SERVICES_CATEGORIES = new Set(['medical', 'tours', 'restaurants', 'visa', 'shopping', 'nature', 'spa-hamam', 'hair-beauty']);
 
 export const DirectoryHome: React.FC = () => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const [searchQuery, setSearchQuery] = useState('');
+    const [mode, setMode] = useState<LandingMode>(() => {
+        return (localStorage.getItem('landingMode') as LandingMode) || 'rental';
+    });
     const [location, setLocation] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('');
+
+    const handleModeChange = (newMode: LandingMode) => {
+        setMode(newMode);
+        localStorage.setItem('landingMode', newMode);
+    };
 
     // Landing page listings
     const [premiumListings, setPremiumListings] = useState<DirectoryListingDB[]>([]);
@@ -57,6 +69,9 @@ export const DirectoryHome: React.FC = () => {
         { id: 'spa-hamam', icon: '🧖', title: t('dir.cat.spa_hamam'), path: '/alanya-spa-hamam' },
         { id: 'hair-beauty', icon: '💇', title: t('dir.cat.hair_beauty'), path: '/alanya-hair-beauty' },
     ];
+
+    const allowedIds = mode === 'rental' ? RENTAL_CATEGORIES : SERVICES_CATEGORIES;
+    const filteredCategories = categories.filter(cat => allowedIds.has(cat.id));
 
     return (
         <>
@@ -155,7 +170,7 @@ export const DirectoryHome: React.FC = () => {
                     <div className="flex flex-col sm:flex-row justify-center gap-3 w-full max-w-2xl mx-auto px-2">
                         <button
                             onClick={() => navigate('/search-results')}
-                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white dark:bg-slate-800/80 hover:bg-slate-50 dark:hover:bg-slate-700/80 text-slate-900 dark:text-white rounded-xl sm:rounded-full font-semibold transition-all shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white dark:bg-slate-800/80 hover:bg-slate-50 dark:hover:bg-slate-700/80 text-slate-900 dark:text-white rounded-xl sm:rounded-full font-semibold transition-all shadow-lg hover:shadow-xl hover:-translate-y-0.5 cursor-pointer"
                         >
                             <MapPin className="w-5 h-5 text-teal-600 dark:text-cyan-400 dark:text-slate-200" />
                             {t('dir.cta.explore')}
@@ -165,7 +180,7 @@ export const DirectoryHome: React.FC = () => {
                             onClick={() => {
                                 document.getElementById('categories')?.scrollIntoView({ behavior: 'smooth' });
                             }}
-                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all"
+                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all cursor-pointer"
                         >
                             <Grid className="w-5 h-5" />
                             {t('dir.cta.categories')}
@@ -173,7 +188,7 @@ export const DirectoryHome: React.FC = () => {
 
                         <button
                             onClick={() => navigate('/list-property')}
-                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all"
+                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all cursor-pointer"
                         >
                             <Briefcase className="w-5 h-5" />
                             {t('dir.cta.list')}
@@ -184,7 +199,7 @@ export const DirectoryHome: React.FC = () => {
                     <div className="mt-8 sm:mt-12 px-2 max-w-sm mx-auto w-full">
                         <button
                             onClick={() => navigate('/ai-planner')}
-                            className="group relative w-full inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white rounded-xl sm:rounded-full font-bold shadow-xl shadow-purple-500/30 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300"
+                            className="group relative w-full inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 text-white rounded-xl sm:rounded-full font-bold shadow-xl shadow-purple-500/30 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 cursor-pointer"
                         >
                             <Sparkles className="w-5 h-5 animate-pulse" />
                             <span className="tracking-wide">{t('dir.cta.ai')}</span>
@@ -199,14 +214,17 @@ export const DirectoryHome: React.FC = () => {
                 <div className="text-center mb-12">
                     <h2 className="text-3xl font-bold text-slate-900 dark:text-white">{t('dir.cat.title')}</h2>
                     <p className="mt-4 text-slate-600 dark:text-slate-400">{t('dir.cat.subtitle')}</p>
+                    <div className="mt-6 flex justify-center">
+                        <ModeToggle mode={mode} onChange={handleModeChange} />
+                    </div>
                 </div>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
-                    {categories.map((category) => (
+                    {filteredCategories.map((category) => (
                         <button
                             key={category.id}
                             onClick={() => navigate(category.path)}
-                            className="group flex flex-row sm:flex-col items-center sm:justify-center p-4 sm:p-8 bg-white dark:bg-slate-800/80 border border-slate-100 dark:border-slate-800/50 rounded-2xl shadow-sm hover:shadow-xl dark:hover:shadow-slate-900/50 hover:-translate-y-1 transition-all duration-300 text-left sm:text-center text-slate-900 dark:text-white gap-4 sm:gap-0"
+                            className="group flex flex-row sm:flex-col items-center sm:justify-center p-4 sm:p-8 bg-white dark:bg-slate-800/80 border border-slate-100 dark:border-slate-800/50 rounded-2xl shadow-sm hover:shadow-xl dark:hover:shadow-slate-900/50 hover:-translate-y-1 transition-all duration-300 text-left sm:text-center text-slate-900 dark:text-white gap-4 sm:gap-0 cursor-pointer"
                         >
                             <div className="w-12 h-12 sm:w-16 sm:h-16 bg-slate-50 dark:bg-slate-900/50 rounded-2xl flex items-center justify-center text-2xl sm:text-3xl sm:mb-4 group-hover:bg-teal-50 dark:group-hover:bg-slate-700/50 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
                                 {category.icon}

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -26,6 +26,7 @@ const Esim = React.lazy(() => import('../pages/Esim').then(module => ({ default:
 const ListProperty = React.lazy(() => import('../pages/ListProperty').then(module => ({ default: module.ListProperty })));
 const PropertyDetails = React.lazy(() => import('../pages/PropertyDetails').then(module => ({ default: module.PropertyDetails })));
 const BlogPostPage = React.lazy(() => import('../pages/BlogPostPage').then(module => ({ default: module.BlogPostPage })));
+const BlogPage = React.lazy(() => import('../pages/BlogPage').then(module => ({ default: module.BlogPage })));
 const VisaConsult = React.lazy(() => import('../pages/VisaConsult').then(module => ({ default: module.VisaConsult })));
 const CarRental = React.lazy(() => import('../pages/CarRental').then(module => ({ default: module.CarRental })));
 const CarModelDetails = React.lazy(() => import('../pages/CarModelDetails').then(module => ({ default: module.CarModelDetails })));
@@ -104,6 +105,7 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/stays" element={<SearchResultsPage />} />
                 <Route path="/favorites" element={<FavoritesPage />} />
                 <Route path="/property/:id" element={<PropertyDetails />} />
+                <Route path="/blog" element={<BlogPage />} />
                 <Route path="/blog/:slug" element={<BlogPostPage />} />
 
                 {/* Auth Redirects */}


### PR DESCRIPTION
## Summary

- Replace navbar links with **Directory | Blog | Shop** in both DesktopNav and MobileMenu
- Add **ModeToggle** component (Rental / Services) in the Categories section on the landing page
- Filter category grid dynamically by mode: Rental → accommodations/transport/real-estate, Services → medical/tours/restaurants/visa/shopping/nature/spa/hair-beauty
- Persist selected mode in `localStorage` — survives page reloads
- Add `BlogPage` with lazy-loaded route at `/blog`
- Add `nav.blog` translation key across all 4 locales (en/ru/tr/ar)

## Test plan

- [ ] Navbar shows Directory, Blog, Shop on desktop and mobile
- [ ] Clicking Blog → `/blog`, Shop → `/shop`
- [ ] ModeToggle on landing switches category grid without page reload
- [ ] Reload page — toggle stays on last selected mode
- [ ] TypeScript: 0 errors
- [ ] Build: passes