### PR TITLE
fix: pass subscription_data.metadata in checkout + task 90 backend [90]

### DIFF
--- a/components/ai/TripItinerary.tsx
+++ b/components/ai/TripItinerary.tsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import { Clock, MapPin, ExternalLink, Sun, CloudRain, Star, ChevronRight, Share2, Download } from 'lucide-react';
+import React from 'react';
+import { Clock, MapPin, ExternalLink, Star, ChevronRight, Share2, Download } from 'lucide-react';
 import { useLanguage } from '../../context/LanguageContext';
 
 export interface ItineraryItem {
@@ -35,8 +35,7 @@ export const TripItinerary: React.FC<Props> = ({ itinerary }) => {
                     text: t('ai.itinerary.shareText'),
                     url: window.location.href,
                 });
-            } catch (error) {
-                console.log('Error sharing:', error);
+            } catch (_error) {
             }
         } else {
             // Fallback: Copy to clipboard

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -36,6 +36,25 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         { path: '/admin/reports', label: 'Reports', icon: Flag },
     ];
 
+    const navGroups = [
+        {
+            label: 'Listings',
+            items: navItems.filter(i => ['Properties', 'Fleet', 'Services', 'Directory', 'Restaurants', 'Products'].includes(i.label))
+        },
+        {
+            label: 'Commerce',
+            items: navItems.filter(i => ['Bookings'].includes(i.label))
+        },
+        {
+            label: 'Content',
+            items: navItems.filter(i => ['Reviews'].includes(i.label))
+        },
+        {
+            label: 'Users',
+            items: navItems.filter(i => ['Users', 'Reports'].includes(i.label))
+        },
+    ];
+
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex font-sans">
             {/* Mobile Sidebar Overlay */}
@@ -63,31 +82,65 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
                     </button>
                 </div>
 
-                <nav className="p-4 space-y-1 overflow-y-auto">
-                    {navItems.map((item) => {
-                        const Icon = item.icon;
-                        const isActive = item.exact
-                            ? location.pathname === item.path
-                            : location.pathname.startsWith(item.path);
-
+                <nav className="p-4 space-y-6 overflow-y-auto">
+                    {/* Dashboard (always on top, outside groups) */}
+                    {(() => {
+                        const dashboardItem = navItems[0];
+                        const Icon = dashboardItem.icon;
+                        const isActive = dashboardItem.exact
+                            ? location.pathname === dashboardItem.path
+                            : location.pathname.startsWith(dashboardItem.path);
                         return (
-                            <NavLink
-                                key={item.path}
-                                to={item.path}
-                                onClick={() => setIsMobileMenuOpen(false)}
-                                className={({ isActive: _linkActive }) => `
-                                    flex items-center gap-3 px-4 py-3.5 rounded-xl transition-all duration-200 group
-                                    ${isActive ? 'bg-teal-50 dark:bg-slate-800/50 text-teal-600 dark:text-cyan-400 dark:text-slate-200 font-medium shadow-sm' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/90 hover:text-slate-900 dark:hover:text-white'}
-                                `}
-                            >
-                                <Icon size={20} className={isActive ? 'text-teal-600 dark:text-cyan-400 dark:text-slate-200' : 'text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300'} />
-                                <span>{item.label}</span>
-                                {item.label === 'Bookings' && (
-                                    <span className="ml-auto w-2 h-2 rounded-full bg-orange-500 hidden" />
-                                )}
-                            </NavLink>
+                            <div key={dashboardItem.path} className="space-y-1">
+                                <NavLink
+                                    to={dashboardItem.path}
+                                    onClick={() => setIsMobileMenuOpen(false)}
+                                    className={`
+                                        flex items-center gap-3 px-4 py-3.5 rounded-xl transition-all duration-200 group
+                                        ${isActive ? 'bg-teal-50 dark:bg-slate-800/50 text-teal-600 dark:text-cyan-400 dark:text-slate-200 font-medium shadow-sm' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/90 hover:text-slate-900 dark:hover:text-white'}
+                                    `}
+                                >
+                                    <Icon size={20} className={isActive ? 'text-teal-600 dark:text-cyan-400 dark:text-slate-200' : 'text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300'} />
+                                    <span>{dashboardItem.label}</span>
+                                </NavLink>
+
+                                {/* Nav Groups */}
+                                {navGroups.map((group) => (
+                                    <div key={group.label} className="pt-4 first:pt-0">
+                                        <h3 className="px-4 mb-2 text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                                            {group.label}
+                                        </h3>
+                                        <div className="space-y-1">
+                                            {group.items.map((item) => {
+                                                const ItemIcon = item.icon;
+                                                const isItemActive = item.exact
+                                                    ? location.pathname === item.path
+                                                    : location.pathname.startsWith(item.path);
+
+                                                return (
+                                                    <NavLink
+                                                        key={item.path}
+                                                        to={item.path}
+                                                        onClick={() => setIsMobileMenuOpen(false)}
+                                                        className={`
+                                                            flex items-center gap-3 px-4 py-3.5 rounded-xl transition-all duration-200 group
+                                                            ${isItemActive ? 'bg-teal-50 dark:bg-slate-800/50 text-teal-600 dark:text-cyan-400 dark:text-slate-200 font-medium shadow-sm' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800/90 hover:text-slate-900 dark:hover:text-white'}
+                                                        `}
+                                                    >
+                                                        <ItemIcon size={20} className={isItemActive ? 'text-teal-600 dark:text-cyan-400 dark:text-slate-200' : 'text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-300'} />
+                                                        <span>{item.label}</span>
+                                                        {item.label === 'Bookings' && (
+                                                            <span className="ml-auto w-2 h-2 rounded-full bg-orange-500 hidden" />
+                                                        )}
+                                                    </NavLink>
+                                                );
+                                            })}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
                         );
-                    })}
+                    })()}
                 </nav>
 
                 <div className="p-4 border-t border-slate-100 dark:border-slate-800/50 space-y-1">

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules', '.venv', 'testsprite_tests', 'scripts', 'coverage'] },
+  { ignores: ['dist', 'node_modules', '.venv', 'testsprite_tests', 'scripts', 'coverage', '.claude'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -195,7 +195,7 @@ Deno.serve(async (req: Request) => {
       { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     )
 
-  } catch (error) {
+  } catch (_error) {
     return new Response(
       JSON.stringify({ error: 'An unexpected error occurred. Please try again later.' }),
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }

--- a/supabase/functions/contact-lawyer/index.ts
+++ b/supabase/functions/contact-lawyer/index.ts
@@ -9,7 +9,6 @@ const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const LAWYER_ADMIN_EMAIL = Deno.env.get('LAWYER_ADMIN_EMAIL')
-const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/create-subscription-checkout/index.ts
+++ b/supabase/functions/create-subscription-checkout/index.ts
@@ -1,0 +1,149 @@
+// @ts-ignore
+import Stripe from "npm:stripe@17"
+// @ts-ignore
+import { createClient } from "npm:@supabase/supabase-js@2"
+// @ts-ignore
+import { z } from "npm:zod@3"
+
+declare const Deno: any;
+
+const STRIPE_SECRET_KEY = Deno.env.get('STRIPE_SECRET_KEY')
+const STRIPE_PREMIUM_MONTHLY_PRICE_ID = Deno.env.get('STRIPE_PREMIUM_MONTHLY_PRICE_ID')
+const STRIPE_PREMIUM_ANNUAL_PRICE_ID = Deno.env.get('STRIPE_PREMIUM_ANNUAL_PRICE_ID')
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: '2025-01-27.acacia'
+})
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': SITE_URL,
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const planSchema = z.enum(['monthly', 'annual'])
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // --- Authentication ---
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+    const token = authHeader.replace(/^Bearer\s+/i, '')
+
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token)
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    const userId = user.id
+    const body = await req.json()
+    const validationResult = planSchema.safeParse(body.plan)
+    if (!validationResult.success) {
+      return new Response(JSON.stringify({ error: 'Invalid plan. Must be "monthly" or "annual"' }), {
+        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+    const plan = validationResult.data
+
+    // --- Check if already subscribed ---
+    // Check status in DB directly (no RLS for admin client)
+    const { data: existingSub } = await supabaseAdmin
+      .from('premium_subscriptions')
+      .select('id, status')
+      .eq('user_id', userId)
+      .maybeSingle()
+
+    if (existingSub && existingSub.status === 'active') {
+      return new Response(JSON.stringify({ error: 'User already has an active subscription' }), {
+        status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // --- Select Price ID ---
+    const priceId = plan === 'monthly' ? STRIPE_PREMIUM_MONTHLY_PRICE_ID : STRIPE_PREMIUM_ANNUAL_PRICE_ID
+    if (!priceId) {
+      return new Response(JSON.stringify({ error: 'Stripe Price ID not configured' }), {
+        status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      })
+    }
+
+    // --- Get or Create Stripe Customer ---
+    let customerId: string | null = null
+
+    if (existingSub?.id) {
+      // If user has a previous record (even cancelled), reuse customer ID
+      // We stored customer_id there.
+    }
+
+    // For simplicity, we always create a new Customer for the checkout.
+    // Stripe Customer Portal will allow them to manage existing cards.
+    // However, to reuse, we should have stored stripe_customer_id.
+    // Let's try to find existing customer from previous attempts
+    if (existingSub) {
+      const { data: subDetails } = await supabaseAdmin
+        .from('premium_subscriptions')
+        .select('stripe_customer_id')
+        .eq('user_id', userId)
+        .not('stripe_customer_id', 'is', null)
+        .limit(1)
+        .maybeSingle()
+
+      if (subDetails) {
+        customerId = subDetails.stripe_customer_id
+      }
+    }
+
+    // --- Create Checkout Session ---
+    const sessionParams: any = {
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      metadata: {
+        userId: userId,
+        plan: plan
+      },
+      // CRITICAL: subscription_data.metadata is what appears on the Subscription object.
+      // The top-level metadata is only on the CheckoutSession — not copied to Subscription.
+      // stripe-webhook reads subscription.metadata.userId and subscription.metadata.plan.
+      subscription_data: {
+        metadata: {
+          userId: userId,
+          plan: plan,
+        }
+      },
+      success_url: `${SITE_URL}/profile?subscription=success`,
+      cancel_url: `${SITE_URL}/profile?subscription=cancelled`,
+      allow_promotion_codes: true,
+    }
+
+    if (customerId) {
+      sessionParams.customer = customerId
+    } else {
+      sessionParams.customer_email = user.email
+    }
+
+    const session = await stripe.checkout.sessions.create(sessionParams)
+
+    return new Response(JSON.stringify({ url: session.url }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    })
+
+  } catch (error) {
+    console.error('Create Subscription Checkout Error:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    })
+  }
+})

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -28,6 +28,290 @@ Deno.serve(async (req: Request) => {
     return new Response(`Webhook Error: ${err.message}`, { status: 400 })
   }
 
+  // ============================================================
+  // Premium Subscription Handlers (Task 90)
+  // ============================================================
+
+  if (event.type === 'customer.subscription.created') {
+    const subscription = event.data.object as Stripe.Subscription
+    const customerId = subscription.customer as string
+    const metadata = subscription.metadata
+
+    if (!metadata?.userId || !metadata?.plan) {
+      console.warn('subscription.created: Missing metadata (userId or plan) — skipping premium flow')
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    // Idempotency: check if already exists
+    const { data: existing } = await supabase
+      .from('premium_subscriptions')
+      .select('id')
+      .eq('stripe_subscription_id', subscription.id)
+      .maybeSingle()
+
+    if (existing) {
+      console.warn(`Skipping duplicate subscription.created webhook for sub ${subscription.id}`)
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    // Determine status: trialing if trial_end < now, otherwise active
+    let status: 'active' | 'trialing' = 'active'
+    if (subscription.status === 'trialing' || (subscription.trial_end && new Date(subscription.trial_end * 1000) > new Date())) {
+      status = 'trialing'
+    }
+
+    const currentPeriodEnd = new Date(subscription.current_period_end * 1000).toISOString()
+
+    // Insert into DB
+    const { error: insertError } = await supabase
+      .from('premium_subscriptions')
+      .insert({
+        user_id: metadata.userId,
+        plan: metadata.plan,
+        status: status,
+        stripe_subscription_id: subscription.id,
+        stripe_customer_id: customerId,
+        current_period_end: currentPeriodEnd,
+        cancel_at_period_end: subscription.cancel_at_period_end,
+      })
+
+    if (insertError) {
+      console.error('Failed to insert premium subscription:', insertError)
+      return new Response(JSON.stringify({ error: 'DB insert failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
+    }
+
+    console.warn(`Premium subscription created for user ${metadata.userId} — plan: ${metadata.plan}`)
+
+    // In-app notification
+    await supabase.from('notifications').insert({
+      user_id: metadata.userId,
+      title: '🎉 Welcome to Premium!',
+      message: 'You now have access to AI Trip Planner and Premium benefits.',
+      type: 'success',
+      link: '/profile',
+    })
+
+    // Email
+    const { data: userProfile } = await supabase
+      .from('profiles')
+      .select('email, full_name')
+      .eq('id', metadata.userId)
+      .maybeSingle()
+
+    if (userProfile?.email) {
+      try {
+        await supabase.functions.invoke('send-email', {
+          body: {
+            to: userProfile.email,
+            type: 'welcome_email', // Using existing template, or we can add 'welcome_premium'
+            data: {
+              name: userProfile.full_name || 'there',
+              link: `${Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'}/profile`,
+            },
+          },
+        })
+      } catch (e) {
+        console.error('Failed to send welcome email:', e)
+      }
+    }
+
+    return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+  } // end customer.subscription.created
+
+  if (event.type === 'customer.subscription.updated') {
+    const subscription = event.data.object as Stripe.Subscription
+
+    // Find sub record by stripe_subscription_id
+    const { data: subRecord, error: fetchError } = await supabase
+      .from('premium_subscriptions')
+      .select('id, stripe_customer_id, user_id, status, cancel_at_period_end')
+      .eq('stripe_subscription_id', subscription.id)
+      .maybeSingle()
+
+    if (fetchError || !subRecord) {
+      console.error('subscription.updated: Failed to find subscription record:', fetchError?.message ?? 'not found')
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    // Always update period end and cancel flag first
+    const currentPeriodEnd = new Date(subscription.current_period_end * 1000).toISOString()
+    const cancelAtPeriodEnd = subscription.cancel_at_period_end ?? false
+    const newStatus: 'active' | 'trialing' | 'past_due' | 'cancelled' = subscription.status === 'active' ? 'active' : subscription.status === 'trialing' ? 'trialing' : subscription.status === 'past_due' ? 'past_due' : 'cancelled'
+
+    const { error: updateError } = await supabase
+      .from('premium_subscriptions')
+      .update({
+        status: newStatus,
+        current_period_end: currentPeriodEnd,
+        cancel_at_period_end: cancelAtPeriodEnd,
+      })
+      .eq('id', subRecord.id)
+
+    if (updateError) {
+      console.error('Failed to update premium subscription status:', updateError)
+      return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
+    }
+
+    console.warn(`Premium subscription updated: id ${subRecord.id}, status -> ${newStatus}`)
+
+    // Recovery notification: if it was past_due and now active
+    if (subRecord.status === 'past_due' && newStatus === 'active') {
+      await supabase.from('notifications').insert({
+        user_id: subRecord.user_id,
+        title: 'Subscription Restored',
+        message: 'Your Premium subscription has been restored. Enjoy your benefits!',
+        type: 'success',
+        link: '/profile',
+      })
+    }
+
+    // Cancellation notification (Stripe sets cancel_at_period_end but status is still active until period ends)
+    if (cancelAtPeriodEnd && !subRecord.cancel_at_period_end) {
+      await supabase.from('notifications').insert({
+        user_id: subRecord.user_id,
+        title: 'Subscription Cancellation Scheduled',
+        message: `Your Premium subscription will end on ${currentPeriodEnd}. You still have access until then.`,
+        type: 'warning',
+        link: '/profile',
+      })
+    }
+
+    return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+  } // end customer.subscription.updated
+
+  if (event.type === 'customer.subscription.deleted') {
+    const subscription = event.data.object as Stripe.Subscription
+
+    const { data: subRecord, error: fetchError } = await supabase
+      .from('premium_subscriptions')
+      .select('id, user_id, stripe_customer_id, current_period_end')
+      .eq('stripe_subscription_id', subscription.id)
+      .maybeSingle()
+
+    if (fetchError || !subRecord) {
+      console.warn('subscription.deleted: Subscription record not found or already deleted')
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    const { error: updateError } = await supabase
+      .from('premium_subscriptions')
+      .update({ status: 'cancelled' })
+      .eq('id', subRecord.id)
+
+    if (updateError) {
+      console.error('Failed to cancel premium subscription in DB:', updateError)
+      return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
+    }
+
+    console.warn(`Premium subscription cancelled: id ${subRecord.id}`)
+
+    // Notification
+    await supabase.from('notifications').insert({
+      user_id: subRecord.user_id,
+      title: 'Subscription Cancelled',
+      message: `Your Premium subscription has ended. You had access until ${new Date(subRecord.current_period_end).toLocaleDateString()}.`,
+      type: 'info',
+      link: '/profile',
+    })
+
+    // Email
+    const { data: userProfile } = await supabase
+      .from('profiles')
+      .select('email, full_name')
+      .eq('id', subRecord.user_id)
+      .maybeSingle()
+
+    if (userProfile?.email) {
+      try {
+        await supabase.functions.invoke('send-email', {
+          body: {
+            to: userProfile.email,
+            type: 'refund_processed', // We can add a specific 'subscription_cancelled' later if needed
+            data: {
+              amount: '',
+              itemTitle: 'Premium Subscription',
+              link: `${Deno.env.get('SITE_URL') ?? 'https://alnya-holidays.com'}/profile`,
+            },
+          },
+        })
+      } catch (e) {
+        console.error('Failed to send cancellation email:', e)
+      }
+    }
+
+    return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+  } // end customer.subscription.deleted
+
+  if (event.type === 'invoice.payment_failed') {
+    const invoice = event.data.object as Stripe.Invoice
+    const customerId = invoice.customer as string
+
+    // Find user's subscription by customer ID
+    const { data: subRecord, error: fetchError } = await supabase
+      .from('premium_subscriptions')
+      .select('id, user_id, stripe_subscription_id')
+      .eq('stripe_customer_id', customerId)
+      .eq('status', 'active') // Only update if it was active
+      .maybeSingle()
+
+    if (fetchError || !subRecord) {
+      console.warn('invoice.payment_failed: No active subscription found for customer')
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+    }
+
+    const { error: updateError } = await supabase
+      .from('premium_subscriptions')
+      .update({ status: 'past_due' })
+      .eq('id', subRecord.id)
+
+    if (updateError) {
+      console.error('Failed to update subscription to past_due:', updateError)
+      return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
+    }
+
+    console.warn(`Premium subscription marked past_due: id ${subRecord.id}`)
+
+    // Notification
+    await supabase.from('notifications').insert({
+      user_id: subRecord.user_id,
+      title: '⚠️ Payment Failed',
+      message: 'Your Premium subscription payment failed. Please update your payment method to maintain access.',
+      type: 'error',
+      link: '/profile',
+    })
+
+    // Email
+    const { data: userProfile } = await supabase
+      .from('profiles')
+      .select('email')
+      .eq('id', subRecord.user_id)
+      .maybeSingle()
+
+    if (userProfile?.email) {
+      try {
+        await supabase.functions.invoke('send-email', {
+          body: {
+            to: userProfile.email,
+            type: 'booking_rejected', // Reusing template for payment issue (no specific template exists)
+            data: {
+              itemTitle: 'Premium Subscription',
+              reason: 'Payment failed. Please update your card details.',
+              searchLink: `${Deno.env.get('SITE_URL') ?? 'https://alnya-holidays.com'}/profile`,
+            },
+          },
+        })
+      } catch (e) {
+        console.error('Failed to send payment failed email:', e)
+      }
+    }
+
+    return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+  } // end invoice.payment_failed
+
+  // ============================================================
+  // Existing Booking / Blog Subscription Handlers
+  // ============================================================
+
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
 

--- a/supabase/migrations/202604151300_premium_subscriptions.sql
+++ b/supabase/migrations/202604151300_premium_subscriptions.sql
@@ -1,0 +1,57 @@
+-- Create table for premium subscriptions
+CREATE TABLE IF NOT EXISTS public.premium_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID UNIQUE NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    plan TEXT NOT NULL CHECK (plan IN ('monthly', 'annual')),
+    status TEXT NOT NULL DEFAULT 'trialing' CHECK (status IN ('active', 'cancelled', 'past_due', 'trialing')),
+    stripe_subscription_id TEXT UNIQUE NOT NULL,
+    stripe_customer_id TEXT NOT NULL,
+    current_period_end TIMESTAMPTZ NOT NULL,
+    cancel_at_period_end BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Index for stripe_subscription_id lookups (user_id already has UNIQUE constraint above)
+CREATE UNIQUE INDEX idx_premium_subscriptions_stripe_sub_id ON public.premium_subscriptions (stripe_subscription_id);
+
+-- RLS Policies
+ALTER TABLE public.premium_subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- User can only read their own subscription
+CREATE POLICY "Users can view their own subscription"
+ON public.premium_subscriptions
+FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Admin can view all subscriptions
+CREATE POLICY "Admins can view all subscriptions"
+ON public.premium_subscriptions
+FOR SELECT
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid() AND role = 'admin'
+    )
+);
+
+-- INSERT/UPDATE/DELETE only for service role (via webhook and RPC logic)
+-- We create the table without public insert policy.
+-- The `is_premium` RPC will use SECURITY DEFINER to bypass this for checks.
+-- Webhook will use SERVICE_ROLE_KEY which bypasses RLS anyway.
+
+-- Trigger for updated_at auto-update
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_premium_subscriptions_updated_at
+    BEFORE UPDATE ON public.premium_subscriptions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/202604151301_is_premium.sql
+++ b/supabase/migrations/202604151301_is_premium.sql
@@ -1,0 +1,23 @@
+-- Create function to check if user has active premium subscription
+CREATE OR REPLACE FUNCTION public.is_premium(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    exists_result BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM public.premium_subscriptions
+        WHERE user_id = p_user_id
+          AND status = 'active'
+          AND current_period_end > NOW()
+    ) INTO exists_result;
+
+    RETURN COALESCE(exists_result, FALSE);
+END;
+$$;
+
+-- Grant execute to authenticated users only (anon has no business checking premium status)
+GRANT EXECUTE ON FUNCTION public.is_premium(UUID) TO authenticated;


### PR DESCRIPTION
## Summary

### Critical fix
`create-subscription-checkout` was only setting `metadata` on the Checkout Session object. Stripe does **not** copy session metadata to the Subscription object. The webhook handler reads `subscription.metadata.userId` and `subscription.metadata.plan` — without this fix it always skipped the premium flow with "Missing metadata".

Added `subscription_data.metadata` with `userId` and `plan` so the Subscription object carries this data when the webhook fires.

### Task 90 backend
- `supabase/migrations/202604151300_premium_subscriptions.sql` — `premium_subscriptions` table with RLS, trigger
- `supabase/migrations/202604151301_is_premium.sql` — `is_premium(UUID)` RPC, SECURITY DEFINER
- `supabase/functions/create-subscription-checkout/` — subscription checkout with duplicate-subscription guard
- `supabase/functions/cancel-subscription/` — cancel at period end
- `supabase/functions/get-subscription-portal/` — Stripe Customer Portal URL
- `stripe-webhook` — handlers for subscription.created/updated/deleted + invoice.payment_failed
- `api-services/api/subscriptions.ts` — client API

### Additional fixes
- Removed duplicate UNIQUE index on `user_id` in migration
- Removed unnecessary `GRANT ... TO anon` on `is_premium`
- Removed unused `customerId` variable in stripe-webhook subscription.updated handler
- ESLint: `.claude` worktrees excluded, TripItinerary unused imports cleaned up

## Manual steps required before this goes live
1. Create Stripe Product + 2 Prices (monthly $9.99, annual $79.99)
2. Add secrets: `STRIPE_PREMIUM_MONTHLY_PRICE_ID`, `STRIPE_PREMIUM_ANNUAL_PRICE_ID`
3. Enable Stripe Customer Portal
4. Add webhook events: `customer.subscription.created/updated/deleted`, `invoice.payment_failed`
5. Run `supabase db push`