### PR TITLE
fix: L1/L3/L4 audit fixes — Stripe API version env, JSON responses, unused state

### DIFF
--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -21,7 +21,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded
     const { user } = useAuth();
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [inputText, setInputText] = useState('');
-    const [_loading, setLoading] = useState(false);
     const [isReportOpen, setIsReportOpen] = useState(false);
     const messagesContainerRef = useRef<HTMLDivElement>(null);
 
@@ -33,11 +32,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded
 
     useEffect(() => {
         let isMounted = true;
-        let isFirstLoad = true;
 
         const fetchMessages = async () => {
             if (!activeConversationId) return;
-            if (isFirstLoad) setLoading(true);
 
             try {
                 const data = await chatService.getMessages(activeConversationId);
@@ -54,11 +51,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded
                 // If unauthorized, go back to inbox view
                 if (err instanceof Error && err.message.toLowerCase().includes('authorized')) {
                     setActiveConversationId(null);
-                }
-            } finally {
-                if (isMounted && isFirstLoad) {
-                    setLoading(false);
-                    isFirstLoad = false;
                 }
             }
         };

--- a/supabase/functions/cancel-subscription/index.ts
+++ b/supabase/functions/cancel-subscription/index.ts
@@ -11,7 +11,7 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
 const stripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: '2025-01-27.acacia'
+  apiVersion: (Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia') as Stripe.StripeConstructorOptions['apiVersion'],
 })
 
 const corsHeaders = {

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -6,7 +6,7 @@ import { createClient } from 'npm:@supabase/supabase-js@2'
 declare const Deno: any
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY'), {
-  apiVersion: '2025-01-27.acacia',
+  apiVersion: (Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia') as Stripe.StripeConstructorOptions['apiVersion'],
 })
 
 const supabase = createClient(

--- a/supabase/functions/create-subscription-checkout/index.ts
+++ b/supabase/functions/create-subscription-checkout/index.ts
@@ -15,7 +15,7 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
 const stripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: '2025-01-27.acacia'
+  apiVersion: (Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia') as Stripe.StripeConstructorOptions['apiVersion'],
 })
 
 const corsHeaders = {

--- a/supabase/functions/get-subscription-portal/index.ts
+++ b/supabase/functions/get-subscription-portal/index.ts
@@ -11,7 +11,7 @@ const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
 const stripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: '2025-01-27.acacia'
+  apiVersion: (Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia') as Stripe.StripeConstructorOptions['apiVersion'],
 })
 
 const corsHeaders = {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -8,7 +8,8 @@ import { z } from 'npm:zod@3'
 declare const Deno: any
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY'), {
-  apiVersion: '2025-01-27.acacia',
+  // L1: Allow override via env var for easy API version updates without code change
+  apiVersion: (Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia') as Stripe.StripeConstructorOptions['apiVersion'],
 })
 
 const supabase = createClient(
@@ -27,7 +28,7 @@ Deno.serve(async (req: Request) => {
     event = await stripe.webhooks.constructEventAsync(body, signature!, webhookSecret)
   } catch (err: any) {
     console.error('Webhook signature verification failed:', err.message)
-    return new Response(`Webhook Error: ${err.message}`, { status: 400 })
+    return new Response(JSON.stringify({ error: `Webhook Error: ${err.message}` }), { status: 400, headers: { 'Content-Type': 'application/json' } })
   }
 
   // ============================================================
@@ -383,7 +384,7 @@ Deno.serve(async (req: Request) => {
 
             if (updateError) {
               console.error('Failed to confirm blog submission payment:', updateError)
-              return new Response('DB update failed', { status: 500 })
+              return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
             }
 
             // If updatedSub.length > 0, it's the first time.
@@ -468,7 +469,7 @@ Deno.serve(async (req: Request) => {
 
         if (ownerCheckError) {
           console.error('Ownership check failed:', ownerCheckError)
-          return new Response('Ownership check failed', { status: 500 })
+          return new Response(JSON.stringify({ error: 'Ownership check failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
         }
 
         const ownedIds = (ownedBookings ?? []).map((b: { id: string }) => b.id)
@@ -501,12 +502,12 @@ Deno.serve(async (req: Request) => {
 
         if (error) {
           console.error('Failed to confirm bookings:', error)
-          return new Response('DB update failed', { status: 500 })
+          return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
         }
 
         if (!updatedRows || updatedRows.length === 0) {
           console.error(`No rows updated for bookings: ${bookingIds.join(', ')} — state machine may have rejected transition`)
-          return new Response('DB update failed: no rows updated', { status: 500 })
+          return new Response(JSON.stringify({ error: 'DB update failed: no rows updated' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
         }
 
         // Use only the IDs that were actually confirmed (state machine may have skipped some)
@@ -577,7 +578,7 @@ Deno.serve(async (req: Request) => {
 
     if (fetchError) {
       console.error('Failed to fetch booking for payment_intent:', fetchError)
-      return new Response('DB lookup failed', { status: 500 })
+      return new Response(JSON.stringify({ error: 'DB lookup failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
     }
 
     if (!booking) {
@@ -594,7 +595,7 @@ Deno.serve(async (req: Request) => {
 
     if (updateError) {
       console.error('Failed to update booking payment_status to failed:', updateError)
-      return new Response('DB update failed', { status: 500 })
+      return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
     }
 
     const itemTitle = (booking.property as any)?.title ?? (booking.service as any)?.title ?? 'your booking'
@@ -682,7 +683,7 @@ Deno.serve(async (req: Request) => {
 
     if (fetchError) {
       console.error('Failed to fetch booking for refund:', fetchError)
-      return new Response('DB lookup failed', { status: 500 })
+      return new Response(JSON.stringify({ error: 'DB lookup failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
     }
 
     if (!booking) {
@@ -708,7 +709,7 @@ Deno.serve(async (req: Request) => {
 
     if (updateError) {
       console.error('Failed to update booking payment_status to refunded:', updateError)
-      return new Response('DB update failed', { status: 500 })
+      return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
     }
 
     // Create audit log


### PR DESCRIPTION
## Summary

Three low-priority audit fixes from the code review:

**L1 — Stripe API version from env (5 files)**
- Replace hardcoded `'2025-01-27.acacia'` with `Deno.env.get('STRIPE_API_VERSION') ?? '2025-01-27.acacia'`
- Affected: `stripe-webhook`, `create-checkout-session`, `create-subscription-checkout`, `cancel-subscription`, `get-subscription-portal`
- Fallback preserves current behaviour if env var not set

**L3 — Remove unused `_loading` state in ChatWindow**
- `_loading` was declared and `setLoading` called in `fetchMessages` but the value was never read in JSX
- Removed state + `isFirstLoad` flag entirely — dead code from incomplete feature

**L4 — JSON Content-Type on all error responses in stripe-webhook**
- Plain-text `new Response('DB update failed', { status: 500 })` → `JSON.stringify({ error: '...' })` with `Content-Type: application/json`
- Affected: 9 error responses (signature failure, DB update/lookup failures, ownership check)

## Risks

None — L1 fallback is safe, L3 is dead code removal, L4 only affects response body format that Stripe doesn't parse.