### PR TITLE
fix: A2-H1–H5 blog reliability audit + 6 additional bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ conductor/
 .qwen
 .geminiignore
 
+.playwright-mcp
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "chrome-devtools": {
+    "playwright": {
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp"]
+      "args": ["-y", "@playwright/mcp@latest"]
     },
     "supabase": {
       "type": "http",

--- a/api-services/api/blog.test.ts
+++ b/api-services/api/blog.test.ts
@@ -393,12 +393,17 @@ describe('blogService', () => {
             const mockSubmission = {
                 id: 's1', user_id: 'user-1', title: 'Approved Post',
                 content: 'This is a long content that will be used as the blog post content for publication.',
-                video_url: null, media_urls: ['img1.jpg'],
+                video_url: null, media_urls: ['http://localhost:54321/storage/v1/object/public/blog-media/user-1/img1.jpg'],
                 payment_status: 'paid', status: 'pending_review',
             };
+            let blogSubmissionsCallCount = 0;
             let blogPostsCallCount = 0;
             mockSupabase.from.mockImplementation((table: string) => {
-                if (table === 'blog_submissions') return createChain(mockSubmission);
+                if (table === 'blog_submissions') {
+                    blogSubmissionsCallCount++;
+                    if (blogSubmissionsCallCount === 1) return createChain(mockSubmission); // SELECT .single()
+                    return createChain([{ id: 's1' }]); // UPDATE .select('id') → array with 1 row (optimistic lock matched)
+                }
                 if (table === 'blog_posts') {
                     blogPostsCallCount++;
                     if (blogPostsCallCount === 1) return createChain([]); // resolveSlug
@@ -413,6 +418,28 @@ describe('blogService', () => {
 
             expect(result.title).toBe('Approved Post');
             expect(mockSupabase.from).toHaveBeenCalledWith('blog_posts');
+        });
+
+        it('throws if optimistic lock fails (concurrent approval)', async () => {
+            setupAuth(mockAdminUser);
+            const mockSubmission = {
+                id: 's1', user_id: 'user-1', title: 'Approved Post',
+                content: 'This is a long content that will be used as the blog post content for publication.',
+                video_url: null, media_urls: [],
+                payment_status: 'paid', status: 'pending_review',
+            };
+            let blogSubmissionsCallCount = 0;
+            mockSupabase.from.mockImplementation((table: string) => {
+                if (table === 'blog_submissions') {
+                    blogSubmissionsCallCount++;
+                    if (blogSubmissionsCallCount === 1) return createChain(mockSubmission); // SELECT .single()
+                    return createChain([]); // UPDATE returns 0 rows — race condition
+                }
+                return createChain(null);
+            });
+
+            await expect(blogService.approveBlogSubmission('s1'))
+                .rejects.toThrow('Submission is already being processed or not in pending state');
         });
 
         it('rejects approval if payment not confirmed', async () => {
@@ -447,7 +474,7 @@ describe('blogService', () => {
         it('rejects submission with reason and deletes media files', async () => {
             setupAuth(mockAdminUser);
             const mockSubmission = {
-                id: 's1', user_id: 'user-1', title: 'Rejected',
+                id: 's1', user_id: 'user-1', title: 'Rejected', status: 'pending_review',
                 content: 'Long enough content for the submission.', media_urls: ['https://example.com/storage/v1/object/public/blog-media/user-1/abc.jpg'],
             };
             mockFromTable({

--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -4,6 +4,20 @@ import { BlogPost, BlogTag, BlogPostStatus, BlogSubmission } from '../../types/m
 import { blogPostSchema, blogSubmissionSchema } from './schemas';
 import { slugify, generateUniqueSlug } from '../../utils/slugify';
 
+const SUPABASE_HOST = new URL(import.meta.env.VITE_SUPABASE_URL || 'http://localhost:54321').hostname;
+const IS_DEV = import.meta.env.DEV === true;
+
+function isAuthorizedStorageUrl(url: string, userId: string): boolean {
+    try {
+        const parsed = new URL(url);
+        const validHost = parsed.hostname === SUPABASE_HOST || (IS_DEV && parsed.hostname === 'localhost');
+        const validPath = parsed.pathname.startsWith(`/storage/v1/object/public/blog-media/${userId}/`);
+        return validHost && validPath;
+    } catch {
+        return false;
+    }
+}
+
 // ============================================================
 // Types
 // ============================================================
@@ -491,7 +505,7 @@ export const blogService = {
                 content: validatedData.content,
                 video_url: validatedData.video_url || null,
                 media_urls: (validatedData.media_urls || []).filter(url =>
-                    url.includes(`/blog-media/${user.id}/`)
+                    isAuthorizedStorageUrl(url, user.id)
                 ),
                 status: 'pending_payment',
                 payment_status: 'unpaid',
@@ -523,8 +537,6 @@ export const blogService = {
         });
 
         if (stripeError || !stripeData?.url) {
-            // Clean up the submission if Stripe checkout failed
-            await supabase.from('blog_submissions').delete().eq('id', submission.id);
             throw stripeError || new Error('Failed to create Stripe checkout session');
         }
 
@@ -609,9 +621,17 @@ export const blogService = {
             throw new Error('Submission is already being processed or not in pending state');
         }
 
+        const coverImageUrl = submission.media_urls?.[0] || null;
+
         let post;
         let uniqueSlug = '';
         try {
+            // H5: Strict domain + path validation for cover image [A2-H5]
+            // Inside try-catch so rollback fires if validation fails after status was set to 'approved'
+            if (coverImageUrl && !isAuthorizedStorageUrl(coverImageUrl, submission.user_id)) {
+                throw new Error('Invalid cover image domain');
+            }
+
             // Create blog post from submission
             const baseSlug = slugify(submission.title);
             uniqueSlug = await resolveSlug(baseSlug);
@@ -624,7 +644,7 @@ export const blogService = {
                     content: submission.content,
                     excerpt: generateExcerpt(submission.content),
                     video_url: submission.video_url,
-                    cover_image_url: submission.media_urls?.[0] || null,
+                    cover_image_url: coverImageUrl,
                     author_id: submission.user_id,
                     status: 'published',
                     is_featured: false,
@@ -637,10 +657,13 @@ export const blogService = {
             post = newPost;
         } catch (err) {
             // Compensation: rollback status if post creation fails
-            await supabase
+            const { error: rollbackError } = await supabase
                 .from('blog_submissions')
                 .update({ status: 'pending_review' })
                 .eq('id', submissionId);
+            if (rollbackError) {
+                console.error(`Compensation rollback failed for submission ${submissionId}:`, rollbackError.message, '— submission stuck in approved without a post');
+            }
             throw err;
         }
 
@@ -701,8 +724,22 @@ export const blogService = {
             .single();
 
         if (subError || !submission) throw subError || new Error('Submission not found');
+        if (!['pending_payment', 'pending_review'].includes(submission.status)) {
+            throw new Error(`Cannot reject submission with status '${submission.status}'`);
+        }
 
-        // Delete media files from storage
+        // Update submission status first — only delete files if this succeeds
+        const { error: rejectError } = await supabase
+            .from('blog_submissions')
+            .update({
+                status: 'rejected',
+                rejection_reason: reason,
+            })
+            .eq('id', submissionId);
+
+        if (rejectError) throw rejectError;
+
+        // Delete media files from storage only after status is committed
         if (submission.media_urls && submission.media_urls.length > 0) {
             try {
                 // Extract file paths from public URLs
@@ -724,15 +761,6 @@ export const blogService = {
                 // Non-critical — continue with rejection
             }
         }
-
-        // Update submission
-        await supabase
-            .from('blog_submissions')
-            .update({
-                status: 'rejected',
-                rejection_reason: reason,
-            })
-            .eq('id', submissionId);
 
         // Notify author
         await supabase.from('notifications').insert({

--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -490,7 +490,9 @@ export const blogService = {
                 title: validatedData.title,
                 content: validatedData.content,
                 video_url: validatedData.video_url || null,
-                media_urls: validatedData.media_urls || [],
+                media_urls: (validatedData.media_urls || []).filter(url =>
+                    url.includes(`/blog-media/${user.id}/`)
+                ),
                 status: 'pending_payment',
                 payment_status: 'unpaid',
             }])
@@ -594,34 +596,53 @@ export const blogService = {
         if (submission.payment_status !== 'paid') throw new Error('Submission payment not confirmed');
         if (submission.status !== 'pending_review') throw new Error('Submission is not pending review');
 
-        // Create blog post from submission
-        const baseSlug = slugify(submission.title);
-        const uniqueSlug = await resolveSlug(baseSlug);
-
-        const { data: post, error: postError } = await supabase
-            .from('blog_posts')
-            .insert([{
-                title: submission.title,
-                slug: uniqueSlug,
-                content: submission.content,
-                excerpt: generateExcerpt(submission.content),
-                video_url: submission.video_url,
-                cover_image_url: submission.media_urls?.[0] || null,
-                author_id: submission.user_id,
-                status: 'published',
-                is_featured: false,
-                published_at: new Date().toISOString(),
-            }])
-            .select()
-            .single();
-
-        if (postError || !post) throw postError || new Error('Failed to create blog post');
-
-        // Update submission status
-        await supabase
+        // A2-C2: Update submission status first (optimistic lock)
+        const { data: updatedSubRows, error: updateError } = await supabase
             .from('blog_submissions')
             .update({ status: 'approved' })
-            .eq('id', submissionId);
+            .eq('id', submissionId)
+            .eq('status', 'pending_review')
+            .select('id');
+
+        if (updateError) throw updateError;
+        if (!updatedSubRows || updatedSubRows.length === 0) {
+            throw new Error('Submission is already being processed or not in pending state');
+        }
+
+        let post;
+        let uniqueSlug = '';
+        try {
+            // Create blog post from submission
+            const baseSlug = slugify(submission.title);
+            uniqueSlug = await resolveSlug(baseSlug);
+
+            const { data: newPost, error: postError } = await supabase
+                .from('blog_posts')
+                .insert([{
+                    title: submission.title,
+                    slug: uniqueSlug,
+                    content: submission.content,
+                    excerpt: generateExcerpt(submission.content),
+                    video_url: submission.video_url,
+                    cover_image_url: submission.media_urls?.[0] || null,
+                    author_id: submission.user_id,
+                    status: 'published',
+                    is_featured: false,
+                    published_at: new Date().toISOString(),
+                }])
+                .select()
+                .single();
+
+            if (postError || !newPost) throw postError || new Error('Failed to create blog post');
+            post = newPost;
+        } catch (err) {
+            // Compensation: rollback status if post creation fails
+            await supabase
+                .from('blog_submissions')
+                .update({ status: 'pending_review' })
+                .eq('id', submissionId);
+            throw err;
+        }
 
         // Notify author
         const { data: authorProfile } = await supabase
@@ -689,7 +710,7 @@ export const blogService = {
                     .map((url: string) => {
                         // URL format: {supabaseUrl}/storage/v1/object/public/blog-media/{userId}/{filename}
                         const match = url.match(/\/blog-media\/(.+)$/);
-                        return match ? match[1] : null;
+                        return match && match[1].startsWith(`${submission.user_id}/`) ? match[1] : null;
                     })
                     .filter(Boolean) as string[];
 

--- a/supabase/functions/cleanup-blog-media/index.ts
+++ b/supabase/functions/cleanup-blog-media/index.ts
@@ -88,14 +88,24 @@ Deno.serve(async (req: Request) => {
     const cutoffDate = new Date()
     cutoffDate.setDate(cutoffDate.getDate() - ORPHANED_DAYS)
 
-    // Get active submissions (pending_review or pending_payment) with media_urls
-    const { data: activeSubmissions } = await supabase
+    // [A2-H3] Get active submissions, excluding expired pending_payment
+    const { data: rawSubmissions } = await supabase
       .from('blog_submissions')
-      .select('media_urls')
+      .select('status, payment_expires_at, media_urls')
       .in('status', ['pending_payment', 'pending_review'])
 
-    // Get published blog posts (we'd need to extract media from cover_image_url too,
-    // but cover_image_url is a single URL, not an array)
+    const now = new Date()
+    const activeSubmissions = (rawSubmissions || []).filter((sub: any) => {
+      if (sub.status === 'pending_review') return true
+      if (sub.status === 'pending_payment') {
+        // No expiry = Stripe session was never created (H2 scenario) → not protected, orphan logic handles it
+        if (!sub.payment_expires_at) return false
+        return new Date(sub.payment_expires_at) > now
+      }
+      return false
+    })
+
+    // Get published blog posts
     const { data: publishedPosts } = await supabase
       .from('blog_posts')
       .select('cover_image_url')

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -149,13 +149,26 @@ Deno.serve(async (req: Request) => {
         },
       })
 
-      await supabase
-        .from('blog_submissions')
-        .update({
-          stripe_session_id: session.id,
-          payment_expires_at: paymentExpiresAt,
-        })
-        .eq('id', payload.submissionId)
+      try {
+        const { error: updateError } = await supabase
+          .from('blog_submissions')
+          .update({
+            stripe_session_id: session.id,
+            payment_expires_at: paymentExpiresAt,
+          })
+          .eq('id', payload.submissionId)
+
+        if (updateError) throw updateError
+      } catch (err) {
+        console.error('Failed to update blog_submission with session ID:', err)
+        // H1: Expire Stripe session if DB update fails [A2-H1]
+        try {
+          await stripe.checkout.sessions.expire(session.id)
+        } catch (expireErr) {
+          console.error('Failed to expire Stripe session:', expireErr)
+        }
+        throw new Error('Failed to record payment session. Please try again.')
+      }
 
       return new Response(
         JSON.stringify({ url: session.url }),
@@ -270,16 +283,29 @@ Deno.serve(async (req: Request) => {
         )
       }
 
-      await supabase
-        .from('bookings')
-        .update({
-          stripe_session_id: session.id,
-          payment_expires_at: paymentExpiresAt,
-          // payment_intent_id is NOT saved here — Stripe only provides it
-          // after the session is completed. It's saved by stripe-webhook
-          // on the 'checkout.session.completed' event.
-        })
-        .in('id', verifiedIds)
+      try {
+        const { error: updateError } = await supabase
+          .from('bookings')
+          .update({
+            stripe_session_id: session.id,
+            payment_expires_at: paymentExpiresAt,
+            // payment_intent_id is NOT saved here — Stripe only provides it
+            // after the session is completed. It's saved by stripe-webhook
+            // on the 'checkout.session.completed' event.
+          })
+          .in('id', verifiedIds)
+
+        if (updateError) throw updateError
+      } catch (err) {
+        console.error('Failed to update bookings with session ID:', err)
+        // H1: Expire Stripe session if DB update fails [A2-H1]
+        try {
+          await stripe.checkout.sessions.expire(session.id)
+        } catch (expireErr) {
+          console.error('Failed to expire Stripe session:', expireErr)
+        }
+        throw new Error('Failed to record payment session. Please try again.')
+      }
     }
 
     return new Response(

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -367,6 +367,9 @@ Deno.serve(async (req: Request) => {
             console.error('Blog submission lookup error:', subError)
           } else if (submission) {
             // A2-C4: Use UPDATE with WHERE to detect if this is the first successful run
+            // Guard: also check status='pending_payment' to avoid triggering the H4 state machine
+            // if the submission was rejected by an admin before payment arrived (rejected → pending_review
+            // is blocked by the trigger, causing a DB exception and an infinite Stripe retry loop).
             const { data: updatedSub, error: updateError } = await supabase
               .from('blog_submissions')
               .update({
@@ -375,6 +378,7 @@ Deno.serve(async (req: Request) => {
               })
               .eq('id', submissionId)
               .eq('payment_status', 'unpaid')
+              .eq('status', 'pending_payment')
               .select('id')
 
             if (updateError) {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -366,26 +366,30 @@ Deno.serve(async (req: Request) => {
           if (subError) {
             console.error('Blog submission lookup error:', subError)
           } else if (submission) {
-            // M2: early-exit race protection — if already paid, skip immediately
-            if (submission.payment_status === 'paid') {
-              console.warn(`Skipping duplicate webhook for blog submission ${submissionId}`)
-              return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
-            }
-            // Idempotency: skip if already paid
-            const { error: updateError } = await supabase
+            // A2-C4: Use UPDATE with WHERE to detect if this is the first successful run
+            const { data: updatedSub, error: updateError } = await supabase
               .from('blog_submissions')
               .update({
                 payment_status: 'paid',
                 status: 'pending_review',
               })
               .eq('id', submissionId)
+              .eq('payment_status', 'unpaid')
+              .select('id')
 
             if (updateError) {
               console.error('Failed to confirm blog submission payment:', updateError)
               return new Response('DB update failed', { status: 500 })
             }
 
-            console.warn(`Confirmed blog submission payment: ${submissionId}`)
+            // If updatedSub.length > 0, it's the first time.
+            // If 0, it's a retry (or already paid), but we proceed to notifications anyway
+            // to ensure they are sent if the previous run failed mid-way.
+            if (updatedSub && updatedSub.length > 0) {
+              console.warn(`Confirmed blog submission payment: ${submissionId}`)
+            } else {
+              console.warn(`Webhook retry or already paid for blog submission: ${submissionId}`)
+            }
 
             // Notify all admins about new submission awaiting review
             const { data: admins } = await supabase

--- a/supabase/migrations/20260418000000_blog_submissions_state_machine.sql
+++ b/supabase/migrations/20260418000000_blog_submissions_state_machine.sql
@@ -1,0 +1,59 @@
+-- Migration: 20260418000000_blog_submissions_state_machine
+-- Purpose: Add CHECK constraints and state machine trigger for blog_submissions [A2-H4]
+
+-- 1. Add CHECK constraint for payment_status (status already has one)
+-- NOT VALID: skip validation of existing rows (safe for production with live data);
+-- VALIDATE runs separately to avoid locking the table on large datasets.
+ALTER TABLE public.blog_submissions
+    ADD CONSTRAINT check_blog_submissions_payment_status
+    CHECK (payment_status IN ('unpaid', 'paid', 'failed', 'refunded'))
+    NOT VALID;
+
+ALTER TABLE public.blog_submissions
+    VALIDATE CONSTRAINT check_blog_submissions_payment_status;
+
+-- 2. State machine function for blog_submissions
+CREATE OR REPLACE FUNCTION public.validate_blog_submission_status_transition()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_old_status TEXT;
+    v_new_status TEXT;
+    v_allowed BOOLEAN;
+BEGIN
+    v_old_status := OLD.status;
+    v_new_status := NEW.status;
+
+    -- No transition if status hasn't changed
+    IF v_old_status IS NOT DISTINCT FROM v_new_status THEN
+        RETURN NEW;
+    END IF;
+
+    -- Determine if this transition is allowed
+    v_allowed := CASE
+        -- From pending_payment: can go to pending_review (paid) or rejected
+        WHEN v_old_status = 'pending_payment' AND v_new_status IN ('pending_review', 'rejected') THEN TRUE
+        -- From pending_review: can go to approved or rejected
+        WHEN v_old_status = 'pending_review' AND v_new_status IN ('approved', 'rejected') THEN TRUE
+        -- From approved: can go back to pending_review (compensation rollback [A2-C2])
+        WHEN v_old_status = 'approved' AND v_new_status = 'pending_review' THEN TRUE
+        -- rejected, approved (unless rollback) are terminal
+        ELSE FALSE
+    END;
+
+    IF NOT v_allowed THEN
+        RAISE EXCEPTION 'Invalid blog submission status transition: % -> %', v_old_status, v_new_status
+            USING ERRCODE = 'check_violation',
+                  DETAIL = format('Transition from "%s" to "%s" is not allowed.', v_old_status, v_new_status);
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Create the trigger
+DROP TRIGGER IF EXISTS trg_validate_blog_submission_status_transition ON public.blog_submissions;
+
+CREATE TRIGGER trg_validate_blog_submission_status_transition
+    BEFORE UPDATE OF status ON public.blog_submissions
+    FOR EACH ROW
+    EXECUTE FUNCTION public.validate_blog_submission_status_transition();


### PR DESCRIPTION
## Summary

Closes all A2-H (high priority) audit issues for the blog submission flow, plus 6 additional bugs found during code review.

### A2-H fixes

- **H1** — `create-checkout-session`: expire Stripe session via `stripe.checkout.sessions.expire()` if DB update fails (both blog and booking paths). Prevents orphaned payable sessions.
- **H2** — `blog.ts`: removed `delete()` on Stripe checkout failure. Submission stays in `pending_payment`; cron handles cleanup. User can retry without losing their draft.
- **H3** — `cleanup-blog-media`: `pending_payment` submissions with expired `payment_expires_at` are no longer treated as active. `NULL` expiry (session never created) is also treated as orphaned — falls through to 7-day cutoff logic.
- **H4** — new migration `20260418000000_blog_submissions_state_machine.sql`: adds `payment_status CHECK` constraint (`NOT VALID` + `VALIDATE`) and a `BEFORE UPDATE` trigger enforcing valid status transitions (`pending_payment → pending_review|rejected`, `pending_review → approved|rejected`, `approved → pending_review` for rollback only).
- **H5** — `blog.ts`: replaced `url.includes(...)` with `new URL(url).hostname === SUPABASE_HOST`. `localhost` only accepted when `import.meta.env.DEV === true`. Validation applied at both submission creation and approval.

### Additional bugs found and fixed during review

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | Medium | H5 `throw` was outside `try-catch` → rollback never fired on invalid cover image domain | Moved validation inside `try` block |
| 2 | Medium | `rejectBlogSubmission` deleted storage files before DB update → files lost if trigger raised exception | Flipped order: update status first, then delete files |
| 3 | Medium | `rejectBlogSubmission` didn't check update `error` → proceeded to file deletion on DB failure | Destructure `{ error }`, throw if set |
| 4 | Critical | `stripe-webhook`: admin rejects `pending_payment` submission → user pays anyway → webhook tries `rejected → pending_review` → H4 trigger raises → 500 → infinite Stripe retry loop | Added `.eq('status', 'pending_payment')` guard to webhook UPDATE |
| 5 | Low | Compensation rollback error silently swallowed — submission stuck in `approved` without a post, no trace in logs | `console.error` with submission ID on rollback failure |
| 6 | Medium | Test mock returned object instead of array for `UPDATE .select('id')` → optimistic lock check never exercised | Fixed mock to return array; added new test for concurrent approval race condition |

### Migration notes

`NOT VALID` + `VALIDATE CONSTRAINT` pattern used for `payment_status` CHECK — safe to run against a live table without a full-scan lock. Trigger uses `BEFORE UPDATE OF status` to minimize firing surface.

### Potential risks

- H4 trigger will reject any status transition not in the allowlist. Any code path that writes `blog_submissions.status` directly (future admin tooling, manual SQL) must respect the state machine.
- The `approved → pending_review` rollback transition is intentional and documented in the trigger body.

### Testing

- 61/61 unit tests green
- TypeScript: 0 errors
- ESLint: 0 warnings
- Build: success