### PR TITLE
fix: wrap /ai-planner in AuthRoute [A5-C1]

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { LoginModal } from './components/auth/LoginModal';
 import { RegisterModal } from './components/auth/RegisterModal';
 import { LanguageProvider } from './context/LanguageContext';
-import { AuthProvider } from './context/AuthContext';
+import { AuthProvider, useAuth } from './context/AuthContext';
 import { LightboxProvider } from './context/LightboxContext';
 import { NotificationProvider } from './context/NotificationContext';
 import { PageTransition } from './components/PageTransition';
@@ -50,6 +50,34 @@ const ScrollToTop = () => {
   return null;
 };
 
+const AppContent: React.FC = () => {
+  const { isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen font-sans overflow-x-hidden w-full">
+      <Navbar />
+      <main className="flex-grow">
+        <PageTransition>
+          <ErrorBoundary>
+            <React.Suspense fallback={<PageLoader />}>
+              <AppRoutes />
+            </React.Suspense>
+          </ErrorBoundary>
+        </PageTransition>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
 const App: React.FC = () => {
   return (
     <HelmetProvider>
@@ -66,19 +94,7 @@ const App: React.FC = () => {
                       <ModalProvider>
                         <LightboxProvider>
                           <ChatProvider>
-                            <div className="flex flex-col min-h-screen font-sans overflow-x-hidden w-full">
-                              <Navbar />
-                              <main className="flex-grow">
-                                <PageTransition>
-                                  <ErrorBoundary>
-                                    <React.Suspense fallback={<PageLoader />}>
-                                      <AppRoutes />
-                                    </React.Suspense>
-                                  </ErrorBoundary>
-                                </PageTransition>
-                              </main>
-                              <Footer />
-                            </div>
+                            <AppContent />
                             <LoginModal />
                             <RegisterModal />
                             <React.Suspense fallback={null}>

--- a/api-services/api/properties.test.ts
+++ b/api-services/api/properties.test.ts
@@ -199,15 +199,17 @@ describe('propertiesService', () => {
           expect(reviews.data).toHaveLength(1);
 
           const noExistingChain = createMockChain(null);
+          const bookingChain = createMockChain(null);
+          bookingChain.then = (resolve: any) => resolve({ data: null, count: 1, error: null });
           const insertChain = createMockChain({ id: 'r2' });
           const propChain = createMockChain({ host_id: 'h1', title: 'T' });
           mockSupabase.from
               .mockReturnValueOnce(noExistingChain)
+              .mockReturnValueOnce(bookingChain)
               .mockReturnValueOnce(insertChain)
               .mockReturnValueOnce(propChain);
           await propertiesService.addReview({
               property_id: '550e8400-e29b-41d4-a716-446655440001',
-              user_id: '550e8400-e29b-41d4-a716-446655440002',
               rating: 5,
               comment: 'Great stay at this property'
           });

--- a/api-services/api/properties/reviews.ts
+++ b/api-services/api/properties/reviews.ts
@@ -38,19 +38,36 @@ export async function getReviewCount(propertyId: string) {
     return count || 0;
 }
 
-export async function addReview(review: Omit<Review, 'id' | 'created_at'>) {
+export async function addReview(review: Omit<Review, 'id' | 'created_at' | 'user_id'>) {
     const validatedData = reviewSchema.parse(review);
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) throw new Error('Not authenticated');
 
     const { data: existing } = await supabase
         .from('reviews')
         .select('id')
         .eq('property_id', validatedData.property_id)
-        .eq('user_id', validatedData.user_id)
+        .eq('user_id', user.id) // Use authenticated user's ID
         .maybeSingle();
 
     if (existing) throw new Error('You have already submitted a review for this property');
 
-    const { error } = await supabase.from('reviews').insert([validatedData]).select().single();
+    // Verify user has a confirmed or completed booking for this property
+    const { count: bookingCount, error: bookingError } = await supabase
+        .from('bookings')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', user.id) // Use authenticated user's ID
+        .eq('item_id', validatedData.property_id)
+        .eq('item_type', 'property')
+        .in('status', ['confirmed', 'completed']);
+
+    if (bookingError) throw bookingError;
+    if (!bookingCount) { // Check for 0 or null
+        throw new Error('You can only review properties you have booked and completed your stay at.');
+    }
+
+    const { error } = await supabase.from('reviews').insert([{ ...validatedData, user_id: user.id }]).select().single();
     if (error) throw error;
 
     const { data: property } = await supabase

--- a/api-services/api/schemas.ts
+++ b/api-services/api/schemas.ts
@@ -63,7 +63,6 @@ export const productVariantSchema = z.object({
 
 export const reviewSchema = z.object({
     property_id: z.string().uuid("Invalid property ID"),
-    user_id: z.string().uuid("Invalid user ID"),
     rating: z.number().int().min(1, "Rating must be at least 1").max(5, "Rating must be at most 5"),
     comment: z.string().min(5, "Comment must be at least 5 characters").max(1000, "Comment cannot exceed 1000 characters"),
     images: z.array(z.string()).default([]),

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -51,6 +51,10 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded
                 }
             } catch (err) {
                 console.error(err);
+                // If unauthorized, go back to inbox view
+                if (err instanceof Error && err.message.toLowerCase().includes('authorized')) {
+                    setActiveConversationId(null);
+                }
             } finally {
                 if (isMounted && isFirstLoad) {
                     setLoading(false);

--- a/components/reviews/ReviewModal.test.tsx
+++ b/components/reviews/ReviewModal.test.tsx
@@ -127,7 +127,6 @@ describe('ReviewModal', () => {
 
         expect(db.addReview).toHaveBeenCalledWith(expect.objectContaining({
             property_id: 'prop-1',
-            user_id: 'user-1',
             rating: 5,
             comment: 'Wonderful place!'
         }));

--- a/components/reviews/ReviewModal.tsx
+++ b/components/reviews/ReviewModal.tsx
@@ -45,7 +45,6 @@ export const ReviewModal: React.FC<ReviewModalProps> = ({ isOpen, onClose, prope
 
             await db.addReview({
                 property_id: propertyId,
-                user_id: userId,
                 rating,
                 comment,
                 images: uploadedUrls

--- a/context/AuthContext.test.tsx
+++ b/context/AuthContext.test.tsx
@@ -454,6 +454,65 @@ describe('AuthContext', () => {
         consoleSpy.mockRestore();
     });
 
+    // ─── A5-C2: role must never be read from JWT metadata ────────────────────
+
+    it('A5-C2: forces guest role on DB error even when JWT metadata has admin role', async () => {
+        const adminJwtUser = {
+            id: 'user-admin',
+            email: 'admin@example.com',
+            created_at: '2024-01-01',
+            user_metadata: { full_name: 'Admin User', role: 'admin' },
+        };
+
+        (supabase.auth.getSession as any).mockResolvedValue({
+            data: { session: { user: adminJwtUser } }
+        });
+        (supabase.from as any).mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockRejectedValue(new Error('DB unavailable'))
+        });
+
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useAuth(), { wrapper });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        // User stays logged in but role must be guest, not 'admin' from JWT
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(result.current.user?.role).toBe('guest');
+
+        consoleSpy.mockRestore();
+    });
+
+    it('A5-C2: forces guest role on DB error even when JWT metadata has host role', async () => {
+        const hostJwtUser = {
+            id: 'user-host',
+            email: 'host@example.com',
+            created_at: '2024-01-01',
+            user_metadata: { full_name: 'Host User', role: 'host' },
+        };
+
+        (supabase.auth.getSession as any).mockResolvedValue({
+            data: { session: { user: hostJwtUser } }
+        });
+        (supabase.from as any).mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockRejectedValue(new Error('DB timeout'))
+        });
+
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { result } = renderHook(() => useAuth(), { wrapper });
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isAuthenticated).toBe(true);
+        expect(result.current.user?.role).toBe('guest');
+
+        consoleSpy.mockRestore();
+    });
+
     it('useAuth throws when used outside of AuthProvider', () => {
         // renderHook without the wrapper means no AuthProvider
         expect(() => renderHook(() => useAuth())).toThrow(

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -27,6 +27,7 @@ interface AuthContextType {
     updateProfile: (data: Partial<User>) => void;
     updateEmail: (email: string) => Promise<void>;
     updatePassword: (password: string) => Promise<void>;
+    refreshUser: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -223,6 +224,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
     }, [user]);
 
+    // A5-M2: force re-fetch of profile from DB after role changes (e.g., become-host)
+    const refreshUser = useCallback(async () => {
+        await supabase.auth.refreshSession();
+        // refreshSession triggers onAuthStateChange → checkUser → re-fetches profile from DB
+    }, []);
+
     const updateEmail = useCallback(async (email: string) => {
         const { error } = await supabase.auth.updateUser({ email });
         if (error) throw error;
@@ -246,8 +253,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         updateUser,
         updateProfile: updateUser,
         updateEmail,
-        updatePassword
-    }), [user, isLoading, login, register, sendOtp, verifyOtp, logout, updateUser, updateEmail, updatePassword]);
+        updatePassword,
+        refreshUser,
+    }), [user, isLoading, login, register, sendOtp, verifyOtp, logout, updateUser, updateEmail, updatePassword, refreshUser]);
 
     return (
         <AuthContext.Provider value={value}>

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -43,7 +43,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             name: (metadata.full_name as string || metadata.name as string || sessionUser.email?.split('@')[0] || 'User') as string,
             email: (sessionUser.email || '') as string,
             avatar: (metadata.avatar_url as string || `https://ui-avatars.com/api/?name=${encodeURIComponent((metadata.full_name as string || 'U'))}&background=0D9488&color=fff`) as string | undefined,
-            role: (metadata.role as 'guest' | 'host' | 'admin') || 'guest',
+            role: 'guest', // Never trust JWT metadata for role — always fetch from DB profiles table
             company_name: metadata.company_name as string | undefined,
             joinedDate: sessionUser.created_at || '',
         };
@@ -86,7 +86,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 }
             } catch (err) {
                 console.error('Error fetching user profile:', err);
-                if (isMountedRef.current) setUser(mapSessionToUser(sessionUser));
+                // On DB error: keep user logged in but default to guest role for safety
+                if (isMountedRef.current) setUser({ ...mapSessionToUser(sessionUser), role: 'guest' });
             } finally {
                 if (isMountedRef.current) setIsLoading(false);
             }

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -86,8 +86,13 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 }
             } catch (err) {
                 console.error('Error fetching user profile:', err);
-                // On DB error: keep user logged in but default to guest role for safety
-                if (isMountedRef.current) setUser({ ...mapSessionToUser(sessionUser), role: 'guest' });
+                // On DB error: keep user logged in but force guest role for safety
+                if (isMountedRef.current) {
+                    setUser({
+                        ...mapSessionToUser(sessionUser),
+                        role: 'guest'
+                    });
+                }
             } finally {
                 if (isMountedRef.current) setIsLoading(false);
             }

--- a/pages/AiPlanner.tsx
+++ b/pages/AiPlanner.tsx
@@ -35,6 +35,21 @@ export const AiPlanner: React.FC = () => {
             .finally(() => setPremiumLoading(false));
     }, [user]);
 
+    // A5-M3: re-check premium status when user returns to tab
+    // Handles case: subscription cancelled/created while app was in background
+    useEffect(() => {
+        if (!user) return;
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'visible') {
+                subscriptionsService.getPremiumStatus()
+                    .then(s => setIsPremium(s.isPremium))
+                    .catch(() => setIsPremium(false));
+            }
+        };
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    }, [user]);
+
     useEffect(() => {
         sessionStorage.setItem('ai-planner-status', status);
         if (status === 'results') {

--- a/pages/InboxPage.tsx
+++ b/pages/InboxPage.tsx
@@ -23,6 +23,17 @@ export const InboxPage: React.FC = () => {
         }
     }, [searchParams, refreshConversations, setActiveConversationId]);
 
+    // A5-H1: validate ownership of deep-linked conversation once conversations are loaded.
+    // Fires whenever conversations list updates — if activeConversationId is not in the
+    // user's own list, clear it so ChatWindow never renders for a foreign conversation.
+    useEffect(() => {
+        if (!activeConversationId || conversations.length === 0) return;
+        const isOwned = conversations.some(c => c.id === activeConversationId);
+        if (!isOwned) {
+            setActiveConversationId(null);
+        }
+    }, [conversations, activeConversationId, setActiveConversationId]);
+
     // Redirect if not logged in
     if (!isAuthenticated) {
         return <Navigate to="/" replace />;

--- a/pages/Profile.test.tsx
+++ b/pages/Profile.test.tsx
@@ -6,12 +6,13 @@ import { db } from '../api-services';
 import { toast } from 'react-hot-toast';
 
 // Rule 1: vi.hoisted for shared mocks
-const { mockNavigate, mockLogout, mockUpdateUser, mockUpdateEmail, mockUpdatePassword } = vi.hoisted(() => ({
+const { mockNavigate, mockLogout, mockUpdateUser, mockUpdateEmail, mockUpdatePassword, mockRefreshUser } = vi.hoisted(() => ({
     mockNavigate: vi.fn(),
     mockLogout: vi.fn(),
     mockUpdateUser: vi.fn().mockResolvedValue(undefined),
     mockUpdateEmail: vi.fn().mockResolvedValue(undefined),
     mockUpdatePassword: vi.fn().mockResolvedValue(undefined),
+    mockRefreshUser: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Rule 2: Standard mocks
@@ -25,12 +26,13 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 vi.mock('../context/AuthContext', () => ({
     useAuth: () => ({
-        user: { id: 'user-123', name: 'Test User', email: 'test@example.com', role: 'guest' },
+        user: { id: 'user-123', name: 'Test User', email: 'test@example.com', role: 'host' },
         isAuthenticated: true,
         logout: mockLogout,
         updateUser: mockUpdateUser,
         updateEmail: mockUpdateEmail,
         updatePassword: mockUpdatePassword,
+        refreshUser: mockRefreshUser,
     })
 }));
 
@@ -58,7 +60,7 @@ vi.mock('../api-services', () => ({
         getUserProfile: vi.fn().mockResolvedValue({
             full_name: 'Test User',
             email: 'test@example.com',
-            role: 'guest'
+            role: 'host'
         }),
         updateUserProfile: vi.fn().mockResolvedValue({}),
         uploadAvatar: vi.fn().mockResolvedValue('https://example.com/new-avatar.jpg'),

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -15,7 +15,7 @@ import { ProfileSecurityTab } from '../components/user/profile/ProfileSecurityTa
 import { ProfilePayoutTab } from '../components/user/profile/ProfilePayoutTab';
 
 export const Profile: React.FC = () => {
-    const { user, logout, isAuthenticated, updateUser, updateEmail, updatePassword } = useAuth();
+    const { user, logout, isAuthenticated, updateUser, updateEmail, updatePassword, refreshUser } = useAuth();
     const { t } = useLanguage();
     const navigate = useNavigate();
 
@@ -257,7 +257,8 @@ export const Profile: React.FC = () => {
             await updateUser({ role: 'host' });
             toast.success(t('profile.host_success') || 'Congratulations! You are now a host.');
             setIsHostModalOpen(false);
-            // Refresh page or state to show new tabs
+            // A5-M2: re-fetch profile from DB so role change is confirmed via server state
+            await refreshUser();
         } catch (error: any) {
             console.error('Error upgrading to host:', error);
             toast.error('Failed to update role');
@@ -335,7 +336,7 @@ export const Profile: React.FC = () => {
                             />
                         )}
 
-                        {activeTab === 'payouts' && (
+                        {activeTab === 'payouts' && (user.role === 'host' || user.role === 'admin') && (
                             <ProfilePayoutTab
                                 payoutForm={payoutForm}
                                 setPayoutForm={setPayoutForm}

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -139,9 +139,9 @@ export const AppRoutes: React.FC = () => {
                     </HostRoute>
                 } />
                 <Route path="/bookmarks" element={<FavoritesPage />} />
-                <Route path="/book-vehicle/:id" element={<BookVehicle />} />
-                <Route path="/book-tour/:id" element={<BookTour />} />
-                <Route path="/book-wellness/:id" element={<BookWellness />} />
+                <Route path="/book-vehicle/:id" element={<AuthRoute><BookVehicle /></AuthRoute>} />
+                <Route path="/book-tour/:id" element={<AuthRoute><BookTour /></AuthRoute>} />
+                <Route path="/book-wellness/:id" element={<AuthRoute><BookWellness /></AuthRoute>} />
                 <Route path="/inbox" element={<AuthRoute><InboxPage /></AuthRoute>} />
 
                 {/* Host Routes - Protected */}

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -78,7 +78,7 @@ export const AppRoutes: React.FC = () => {
     return (
         <Routes>
             <Route path="/" element={<DirectoryHome />} />
-                <Route path="/ai-planner" element={<AiPlanner />} />
+                <Route path="/ai-planner" element={<AuthRoute><AiPlanner /></AuthRoute>} />
 
                 {/* SEO-Optimized Directory Category Routes */}
                 <Route path="/medical-tourism-alanya" element={<DirectoryCategoryPage categoryId="medical" />} />

--- a/supabase/functions/cleanup-blog-media/index.ts
+++ b/supabase/functions/cleanup-blog-media/index.ts
@@ -205,7 +205,7 @@ Deno.serve(async (req: Request) => {
           .remove(batch)
 
         if (deleteError) {
-          console.error('Failed to delete batch:', deleteError)
+          console.error('Failed to delete batch:', batch, deleteError)
         } else {
           deletedCount += batch.length
         }

--- a/supabase/functions/contact-lawyer/index.ts
+++ b/supabase/functions/contact-lawyer/index.ts
@@ -2,6 +2,8 @@
 import { createClient } from "npm:@supabase/supabase-js@2"
 // @ts-ignore
 import { z } from "npm:zod@3"
+// @ts-ignore
+import { retry } from '../../utils/retry';
 
 declare const Deno: any;
 
@@ -9,9 +11,10 @@ const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY')
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const LAWYER_ADMIN_EMAIL = Deno.env.get('LAWYER_ADMIN_EMAIL')
+const SITE_URL = Deno.env.get('SITE_URL') || 'https://alanyaholidays.com'
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': SITE_URL,
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
@@ -114,26 +117,32 @@ Deno.serve(async (req: Request) => {
       </div>
     `;
 
-    const resendRes = await fetch('https://api.resend.com/emails', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${RESEND_API_KEY}`,
-      },
-      body: JSON.stringify({
-        from: 'Alanya Holidays <noreply@alanyaholidays.com>',
-        to: LAWYER_ADMIN_EMAIL,
-        subject: `⚖️ New Lawyer Contact: ${escapeHtml(name)}`,
-        html: emailHtml,
-        reply_to: email, // Allow admin to reply directly to user
-      }),
-    });
+    try {
+      await retry(async () => {
+        const resendRes = await fetch('https://api.resend.com/emails', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${RESEND_API_KEY}`,
+          },
+          body: JSON.stringify({
+            from: 'Alanya Holidays <noreply@alanyaholidays.com>',
+            to: LAWYER_ADMIN_EMAIL,
+            subject: `⚖️ New Lawyer Contact: ${escapeHtml(name)}`,
+            html: emailHtml,
+            reply_to: email, // Allow admin to reply directly to user
+          }),
+        });
 
-    if (!resendRes.ok) {
-      const errorData = await resendRes.json();
-      console.error('Resend Error:', errorData);
+        if (!resendRes.ok) {
+          const errorData = await resendRes.json();
+          throw new Error(`Resend API error: ${JSON.stringify(errorData)}`);
+        }
+      });
+    } catch (emailError) {
+      console.error('Failed to send lawyer contact email after multiple retries:', emailError);
       // Don't throw here — DB write succeeded. Admin can check DB if email failed.
-      // But we should probably alert ourselves. For now, log and return success.
+      // We just log the failure.
     }
 
     return new Response(JSON.stringify({ success: true }), {

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -85,7 +85,7 @@ Deno.serve(async (req: Request) => {
     
     const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token)
     if (authError || !user) {
-      return new Response(JSON.stringify({ error: 'Unauthorized', details: authError?.message }), { 
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
         status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
       })
     }
@@ -177,7 +177,7 @@ Deno.serve(async (req: Request) => {
     const safeMessage = error instanceof Error && error.message ? 'An error occurred sending the email' : 'An unexpected error occurred';
     return new Response(JSON.stringify({ error: safeMessage }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 400,
+      status: 500,
     })
   }
 })

--- a/supabase/functions/yesim-proxy/index.ts
+++ b/supabase/functions/yesim-proxy/index.ts
@@ -49,7 +49,7 @@ async function checkRateLimit(userId: string, action: string): Promise<boolean> 
   })
   if (error) {
     console.error('Rate limit check failed:', error)
-    return true // Fail open on DB error to avoid blocking legitimate users
+    return false // Fail closed on DB error to prevent abuse
   }
   return data === true
 }

--- a/supabase/migrations/20260418175014_update_reviews_insert_rls_policy.sql
+++ b/supabase/migrations/20260418175014_update_reviews_insert_rls_policy.sql
@@ -1,0 +1,24 @@
+-- Update RLS policy for reviews_insert to include booking verification
+-- Migration date: 2026-04-18
+
+-- Drop existing policy if it exists
+DROP POLICY IF EXISTS "reviews_insert" ON public.reviews;
+
+-- Create new policy with booking verification
+CREATE POLICY "reviews_insert_with_booking_check" ON public.reviews
+  FOR INSERT
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.bookings
+      WHERE user_id = (SELECT auth.uid())
+      AND item_id = reviews.property_id
+      AND item_type = 'property'
+      AND status IN ('confirmed', 'completed')
+      -- Optionally, also check if check_out date is in the past to ensure review for completed stays
+      -- AND check_out < NOW()
+    )
+  );
+
+-- Also, re-enable RLS on the table, just in case
+ALTER TABLE public.reviews ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260419000000_blog_submission_payment_status_check.sql
+++ b/supabase/migrations/20260419000000_blog_submission_payment_status_check.sql
@@ -1,0 +1,10 @@
+-- Migration: 20260419000000_blog_submission_payment_status_check
+-- NOTE: This migration was superseded by 20260419000001_drop_redundant_payment_status_check.sql
+-- A2-H4 was already addressed in 20260418000000_blog_submissions_state_machine.sql:
+--   constraint check_blog_submissions_payment_status IN ('unpaid','paid','failed','refunded')
+-- The constraint added here was redundant and more restrictive (missing 'failed'),
+-- which would have blocked stripe-webhook from setting payment_status='failed'.
+
+ALTER TABLE public.blog_submissions
+    ADD CONSTRAINT blog_submissions_payment_status_check
+    CHECK (payment_status IN ('unpaid', 'paid', 'refunded'));

--- a/supabase/migrations/20260419000001_drop_redundant_payment_status_check.sql
+++ b/supabase/migrations/20260419000001_drop_redundant_payment_status_check.sql
@@ -1,0 +1,7 @@
+-- Migration: 20260419000001_drop_redundant_payment_status_check
+-- Purpose: Drop the redundant blog_submissions_payment_status_check constraint added in
+--   20260419000000 — it was missing 'failed' which is a valid value used by stripe-webhook.
+--   The correct constraint (check_blog_submissions_payment_status) already exists from
+--   20260418000000_blog_submissions_state_machine.sql.
+
+ALTER TABLE public.blog_submissions DROP CONSTRAINT IF EXISTS blog_submissions_payment_status_check;


### PR DESCRIPTION
## Summary

- **A5-C1** — wrap \`/ai-planner\` in \`AuthRoute\` (requires authentication)
- **A5-C2** — \`AuthContext\` role fallback always defaults to \`'guest'\` on profile fetch error or missing profile
- **A5-H1** — \`InboxPage\`: ownership validation of deep-linked \`conversationId\` against user's conversation list — foreign UUID cleared before \`ChatWindow\` renders
- **A5-H3** — \`AppContent\` in \`App.tsx\` blocks entire render tree while \`isLoading=true\`, eliminating flash of protected content (also fixed duplicate import left by previous session)
- **A5-H4** — verified: all admin API functions already enforce \`getUserRole()\` check at service layer
- **A5-M1** — add role guard on \`ProfilePayoutTab\` render in \`Profile.tsx\` (sidebar button was already hidden for guests)
- **A5-M2** — add \`refreshUser()\` to \`AuthContext\` (calls \`refreshSession\` → \`onAuthStateChange\` → re-fetches profile from DB); called in \`handleBecomeHost\` after role update in DB
- **A5-M3** — \`visibilitychange\` listener in \`AiPlanner.tsx\` re-checks \`isPremium\` when user returns to tab (handles subscription cancellation/creation in background)
- **A5-M4** — resolved by A5-H3 + \`AuthRoute\` spinner + booking pages' own \`loading\` state
- **A4-M1/M2/M3** — \`yesim-proxy\` rate limit fail-closed; \`send-email\` auth error details hidden, correct 5xx for server errors
- **A3-M1** — \`reviews\` RLS + API booking ownership check

## Key architectural decisions

- \`refreshUser()\` uses \`supabase.auth.refreshSession()\` rather than a manual profile re-fetch — triggers \`onAuthStateChange\` which runs the existing \`checkUser\` flow, keeping role resolution in one place
- \`InboxPage\` ownership check is a reactive \`useEffect\` on \`conversations\` — no ChatContext changes needed; RLS remains the final defense
- \`visibilitychange\` for premium re-check is the right UX signal: user pays on Stripe (new tab), returns to app, gate lifts immediately

## Testing notes

- TypeScript: 0 errors
- All existing tests pass
- Migration pair 20260419000000/000001 adds then drops a redundant \`payment_status\` CHECK — net DB state unchanged (correct constraint already in \`20260418000000\`)