### PR TITLE
fix: blog submissions free — remove Stripe, admin messages author via chat

### DIFF
--- a/api-services/api/blog.test.ts
+++ b/api-services/api/blog.test.ts
@@ -309,17 +309,12 @@ describe('blogService', () => {
     describe('createBlogSubmission', () => {
         const longContent = 'This is a long enough content for the blog submission to be valid. It has more than one hundred characters to pass the Zod schema validation check successfully.';
 
-        it('creates submission and returns Stripe checkout URL', async () => {
+        it('creates submission and returns submissionId', async () => {
             setupAuth();
             mockFromTable({
                 blog_submissions: { id: 'sub-1', user_id: 'user-123', title: 'My Blog', content: longContent },
-                profiles: { email: 'author@example.com' },
             });
             mockSupabase.rpc.mockResolvedValue({ data: true, error: null });
-            mockSupabase.functions.invoke.mockResolvedValue({
-                data: { url: 'https://checkout.stripe.com/test' },
-                error: null,
-            });
 
             const result = await blogService.createBlogSubmission({
                 title: 'My Blog',
@@ -327,24 +322,22 @@ describe('blogService', () => {
             });
 
             expect(result.submissionId).toBe('sub-1');
-            expect(result.checkoutUrl).toBe('https://checkout.stripe.com/test');
         });
 
-        it('cleans up submission if Stripe checkout fails', async () => {
+        it('creates submission with optional payment_details', async () => {
             setupAuth();
             mockFromTable({
-                blog_submissions: { id: 'sub-1', user_id: 'user-123', title: 'My Blog', content: longContent },
-                profiles: { email: 'author@example.com' },
+                blog_submissions: { id: 'sub-2', user_id: 'user-123', title: 'My Blog', content: longContent, payment_details: 'paypal@example.com' },
             });
-            mockSupabase.functions.invoke.mockResolvedValue({
-                data: null,
-                error: new Error('Stripe failed'),
-            });
+            mockSupabase.rpc.mockResolvedValue({ data: true, error: null });
 
-            await expect(blogService.createBlogSubmission({
+            const result = await blogService.createBlogSubmission({
                 title: 'My Blog',
                 content: longContent,
-            })).rejects.toThrow();
+                payment_details: 'paypal@example.com',
+            });
+
+            expect(result.submissionId).toBe('sub-2');
         });
     });
 
@@ -449,15 +442,6 @@ describe('blogService', () => {
                 .rejects.toThrow('Submission is already being processed or not in pending state');
         });
 
-        it('rejects approval if payment not confirmed', async () => {
-            setupAuth(mockAdminUser);
-            mockFromTable({
-                blog_submissions: { id: 's1', payment_status: 'unpaid', status: 'pending_review' },
-            });
-
-            await expect(blogService.approveBlogSubmission('s1'))
-                .rejects.toThrow('Submission payment not confirmed');
-        });
 
         it('rejects approval if status not pending_review', async () => {
             setupAuth(mockAdminUser);

--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -492,7 +492,8 @@ export const blogService = {
         content: string;
         video_url?: string;
         media_urls?: string[];
-    }): Promise<{ submissionId: string; checkoutUrl: string }> {
+        payment_details?: string;
+    }): Promise<{ submissionId: string }> {
         const { data: { user } } = await supabase.auth.getUser();
         if (!user) throw new Error('Not authenticated');
 
@@ -525,40 +526,15 @@ export const blogService = {
                 media_urls: (validatedData.media_urls || []).filter(url =>
                     isAuthorizedStorageUrl(url, user.id)
                 ),
-                status: 'pending_payment',
-                payment_status: 'unpaid',
+                status: 'pending_review',
+                payment_details: data.payment_details || null,
             }])
             .select()
             .single();
 
         if (subError || !submission) throw subError || new Error('Failed to create submission');
 
-        // Get user email for Stripe
-        const { data: profile } = await supabase
-            .from('profiles')
-            .select('email')
-            .eq('id', user.id)
-            .single();
-
-        // Invoke Stripe edge function for blog submission checkout
-        const { data: stripeData, error: stripeError } = await supabase.functions.invoke('create-checkout-session', {
-            body: {
-                mode: 'blog_submission',
-                email: profile?.email,
-                origin: window.location.origin,
-                blogSubmission: {
-                    submissionId: submission.id,
-                    title: submission.title,
-                    authorEmail: profile?.email,
-                },
-            },
-        });
-
-        if (stripeError || !stripeData?.url) {
-            throw stripeError || new Error('Failed to create Stripe checkout session');
-        }
-
-        return { submissionId: submission.id, checkoutUrl: stripeData.url };
+        return { submissionId: submission.id };
     },
 
     /**
@@ -623,13 +599,14 @@ export const blogService = {
             .single();
 
         if (subError || !submission) throw subError || new Error('Submission not found');
-        if (submission.payment_status !== 'paid') throw new Error('Submission payment not confirmed');
         if (submission.status !== 'pending_review') throw new Error('Submission is not pending review');
 
         // A2-C2: Update submission status first (optimistic lock)
         const { data: updatedSubRows, error: updateError } = await supabase
             .from('blog_submissions')
-            .update({ status: 'approved' })
+            .update({
+                status: 'approved',
+            })
             .eq('id', submissionId)
             .eq('status', 'pending_review')
             .select('id');

--- a/api-services/api/chat.ts
+++ b/api-services/api/chat.ts
@@ -210,6 +210,37 @@ export const chatService = {
         throw new Error('Failed to create or find conversation');
     },
 
+    // Create or retrieve a direct conversation between admin (as host) and a user (as guest), no property
+    async createDirectConversation(guestId: string): Promise<string> {
+        assertUUID(guestId, 'guestId');
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { data, error } = await supabase
+            .from('chat_conversations')
+            .insert([{ guest_id: guestId, host_id: user.id }])
+            .select('id')
+            .single();
+
+        if (!error) return data.id;
+
+        // Conversation already exists — fetch it
+        if (error.code === '23505' || error.message?.includes('duplicate')) {
+            const { data: existing, error: fetchError } = await supabase
+                .from('chat_conversations')
+                .select('id')
+                .eq('guest_id', guestId)
+                .eq('host_id', user.id)
+                .is('property_id', null)
+                .maybeSingle();
+
+            if (fetchError) throw fetchError;
+            if (existing) return existing.id;
+        }
+
+        throw error;
+    },
+
     // Mark messages as read
     async markAsRead(conversationId: string) {
         const { data: { user } } = await supabase.auth.getUser();

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -1,183 +1,209 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { useChat } from '../../context/ChatContext';
-import { useAuth } from '../../context/AuthContext';
-import { ChatMessage } from '../../types/models';
-import { chatService } from '../../api-services/api/chat';
+import React, { useEffect, useState, useRef } from "react";
+import { useChat } from "../../context/ChatContext";
+import { useAuth } from "../../context/AuthContext";
+import { ChatMessage } from "../../types/models";
+import { chatService } from "../../api-services/api/chat";
 
 // Subcomponents
-import { ChatHeader } from './subcomponents/ChatHeader';
-import { MessageList } from './subcomponents/MessageList';
-import { MessageInput } from './subcomponents/MessageInput';
-import { ReportModal } from './subcomponents/ReportModal';
+import { ChatHeader } from "./subcomponents/ChatHeader";
+import { MessageList } from "./subcomponents/MessageList";
+import { MessageInput } from "./subcomponents/MessageInput";
+import { ReportModal } from "./subcomponents/ReportModal";
 
 interface ChatWindowProps {
-    className?: string;
-    embedded?: boolean;
-    autoScroll?: boolean;
+  className?: string;
+  embedded?: boolean;
+  autoScroll?: boolean;
 }
 
-export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded = false, autoScroll = true }) => {
-    const { activeConversationId, setActiveConversationId, sendMessage, conversations, clearHistory } = useChat();
-    const { user } = useAuth();
-    const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const [inputText, setInputText] = useState('');
-    const [isReportOpen, setIsReportOpen] = useState(false);
-    const messagesContainerRef = useRef<HTMLDivElement>(null);
+export const ChatWindow: React.FC<ChatWindowProps> = ({
+  className = "",
+  embedded = false,
+  autoScroll = true,
+}) => {
+  const {
+    activeConversationId,
+    setActiveConversationId,
+    sendMessage,
+    conversations,
+    clearHistory,
+  } = useChat();
+  const { user } = useAuth();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputText, setInputText] = useState("");
+  const [isReportOpen, setIsReportOpen] = useState(false);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
 
-    const activeConversation = conversations.find(c => c.id === activeConversationId);
+  const activeConversation = conversations.find(
+    (c) => c.id === activeConversationId,
+  );
 
-    const otherPerson = activeConversation
-        ? (user?.id === activeConversation.guest_id ? activeConversation.host : activeConversation.guest)
-        : null;
+  const otherPerson = activeConversation
+    ? user?.id === activeConversation.guest_id
+      ? activeConversation.host
+      : activeConversation.guest
+    : null;
 
-    useEffect(() => {
-        let isMounted = true;
+  useEffect(() => {
+    let isMounted = true;
 
-        const fetchMessages = async () => {
-            if (!activeConversationId) return;
+    const fetchMessages = async () => {
+      if (!activeConversationId) return;
 
-            try {
-                const data = await chatService.getMessages(activeConversationId);
-                if (isMounted) {
-                    setMessages(prev => {
-                        if (prev.length === data.length && prev[prev.length - 1]?.id === data[data.length - 1]?.id) {
-                            return prev;
-                        }
-                        return data;
-                    });
-                }
-            } catch (err) {
-                console.error(err);
-                // If unauthorized, go back to inbox view
-                if (err instanceof Error && err.message.toLowerCase().includes('authorized')) {
-                    setActiveConversationId(null);
-                }
+      try {
+        const data = await chatService.getMessages(activeConversationId);
+        if (isMounted) {
+          setMessages((prev) => {
+            if (
+              prev.length === data.length &&
+              prev[prev.length - 1]?.id === data[data.length - 1]?.id
+            ) {
+              return prev;
             }
-        };
-
-        fetchMessages();
-
-        const channel = chatService.subscribeToMessages(activeConversationId, (newMsg) => {
-            if (isMounted) {
-                setMessages(prev => {
-                    if (prev.some(m => m.id === newMsg.id)) return prev;
-
-                    // Deduplication logic: Check if we have a matching optimistic message
-                    const tempMatchIndex = prev.findIndex(m =>
-                        m.id.startsWith('temp-') &&
-                        m.content === newMsg.content &&
-                        m.sender_id === newMsg.sender_id
-                    );
-
-                    if (tempMatchIndex !== -1) {
-                        // Replace the temp message with the real one immediately
-                        const newMessages = [...prev];
-                        newMessages[tempMatchIndex] = newMsg;
-                        return newMessages;
-                    }
-
-                    return [...prev, newMsg];
-                });
-            }
-        });
-
-        return () => {
-            isMounted = false;
-            channel.unsubscribe();
-        };
-    }, [activeConversationId, setActiveConversationId]);
-
-    useEffect(() => {
-        if (autoScroll && messagesContainerRef.current) {
-            const { scrollHeight } = messagesContainerRef.current;
-            messagesContainerRef.current.scrollTo({
-                top: scrollHeight,
-                behavior: 'smooth'
-            });
+            return data;
+          });
         }
-    }, [messages.length, activeConversationId, autoScroll]);
-
-    const handleSend = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!inputText.trim()) return;
-
-        const content = inputText;
-        const tempId = 'temp-' + Date.now();
-        setInputText('');
-
-        if (user && activeConversationId) {
-            const optimisticMsg: ChatMessage = {
-                id: tempId,
-                conversation_id: activeConversationId,
-                sender_id: user.id,
-                content: content,
-                is_read: false,
-                created_at: new Date().toISOString()
-            };
-            setMessages(prev => [...prev, optimisticMsg]);
+      } catch (err) {
+        console.error(err);
+        // If unauthorized, go back to inbox view
+        if (
+          err instanceof Error &&
+          err.message.toLowerCase().includes("authorized")
+        ) {
+          setActiveConversationId(null);
         }
-
-        try {
-            const realMsg = await sendMessage(content);
-            if (realMsg) {
-                setMessages(prev => {
-                    // Check if realtime subscription already added the message
-                    if (prev.some(m => m.id === realMsg.id)) {
-                        return prev.filter(m => m.id !== tempId);
-                    }
-                    return prev.map(m => m.id === tempId ? realMsg : m);
-                });
-            }
-        } catch (err) {
-            console.error("Failed to send message:", err);
-            setMessages(prev => prev.filter(m => m.id !== tempId));
-            setInputText(content);
-        }
+      }
     };
 
-    if (!activeConversationId) return null;
+    fetchMessages();
 
-    const reportedId = user?.id === activeConversation?.host_id
-        ? activeConversation?.guest_id
-        : activeConversation?.host_id;
+    const channel = chatService.subscribeToMessages(
+      activeConversationId,
+      (newMsg) => {
+        if (isMounted) {
+          setMessages((prev) => {
+            if (prev.some((m) => m.id === newMsg.id)) return prev;
 
-    return (
-        <div className={`flex flex-col bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 shadow-2xl overflow-hidden ${embedded ? 'rounded-none border-0 shadow-none h-full' : 'fixed top-[72px] bottom-0 left-0 right-0 sm:top-28 sm:bottom-6 sm:right-6 sm:left-auto sm:w-[400px] rounded-t-3xl sm:rounded-3xl z-50'} ${className} font-sans`}>
+            // Deduplication logic: Check if we have a matching optimistic message
+            const tempMatchIndex = prev.findIndex(
+              (m) =>
+                m.id.startsWith("temp-") &&
+                m.content === newMsg.content &&
+                m.sender_id === newMsg.sender_id,
+            );
 
-            <ChatHeader
-                otherPerson={otherPerson}
-                activeConversation={activeConversation}
-                activeConversationId={activeConversationId}
-                setActiveConversationId={setActiveConversationId}
-                embedded={embedded}
-                onClearHistory={async () => {
-                    await clearHistory(activeConversationId);
-                    setMessages([]);
-                }}
-                onReportIssue={() => setIsReportOpen(true)}
-            />
+            if (tempMatchIndex !== -1) {
+              // Replace the temp message with the real one immediately
+              const newMessages = [...prev];
+              newMessages[tempMatchIndex] = newMsg;
+              return newMessages;
+            }
 
-            <ReportModal
-                isOpen={isReportOpen}
-                onClose={() => setIsReportOpen(false)}
-                conversationId={activeConversationId}
-                reportedId={reportedId || ''}
-            />
-
-            <MessageList
-                messages={messages}
-                currentUser={user}
-                otherPerson={otherPerson}
-                embedded={embedded}
-                containerRef={messagesContainerRef}
-            />
-
-            <MessageInput
-                inputText={inputText}
-                setInputText={setInputText}
-                onSend={handleSend}
-                embedded={embedded}
-            />
-        </div>
+            return [...prev, newMsg];
+          });
+        }
+      },
     );
+
+    return () => {
+      isMounted = false;
+      channel.unsubscribe();
+    };
+  }, [activeConversationId]);
+
+  useEffect(() => {
+    if (autoScroll && messagesContainerRef.current) {
+      const { scrollHeight } = messagesContainerRef.current;
+      messagesContainerRef.current.scrollTo({
+        top: scrollHeight,
+        behavior: "smooth",
+      });
+    }
+  }, [messages.length, activeConversationId, autoScroll]);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputText.trim()) return;
+
+    const content = inputText;
+    const tempId = "temp-" + Date.now();
+    setInputText("");
+
+    if (user && activeConversationId) {
+      const optimisticMsg: ChatMessage = {
+        id: tempId,
+        conversation_id: activeConversationId,
+        sender_id: user.id,
+        content: content,
+        is_read: false,
+        created_at: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, optimisticMsg]);
+    }
+
+    try {
+      const realMsg = await sendMessage(content);
+      if (realMsg) {
+        setMessages((prev) => {
+          // Check if realtime subscription already added the message
+          if (prev.some((m) => m.id === realMsg.id)) {
+            return prev.filter((m) => m.id !== tempId);
+          }
+          return prev.map((m) => (m.id === tempId ? realMsg : m));
+        });
+      }
+    } catch (err) {
+      console.error("Failed to send message:", err);
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
+      setInputText(content);
+    }
+  };
+
+  if (!activeConversationId) return null;
+
+  const reportedId =
+    user?.id === activeConversation?.host_id
+      ? activeConversation?.guest_id
+      : activeConversation?.host_id;
+
+  return (
+    <div
+      className={`flex flex-col bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800/50 shadow-2xl overflow-hidden ${embedded ? "rounded-none border-0 shadow-none h-full" : "fixed top-72px bottom-0 left-0 right-0 sm:top-28 sm:bottom-6 sm:right-6 sm:left-auto sm:w-400px rounded-t-3xl sm:rounded-3xl z-50"} ${className} font-sans`}
+    >
+      <ChatHeader
+        otherPerson={otherPerson}
+        activeConversation={activeConversation}
+        activeConversationId={activeConversationId}
+        setActiveConversationId={setActiveConversationId}
+        embedded={embedded}
+        onClearHistory={async () => {
+          await clearHistory(activeConversationId);
+          setMessages([]);
+        }}
+        onReportIssue={() => setIsReportOpen(true)}
+      />
+
+      <ReportModal
+        isOpen={isReportOpen}
+        onClose={() => setIsReportOpen(false)}
+        conversationId={activeConversationId}
+        reportedId={reportedId || ""}
+      />
+
+      <MessageList
+        messages={messages}
+        currentUser={user}
+        otherPerson={otherPerson}
+        embedded={embedded}
+        containerRef={messagesContainerRef}
+      />
+
+      <MessageInput
+        inputText={inputText}
+        setInputText={setInputText}
+        onSend={handleSend}
+        embedded={embedded}
+      />
+    </div>
+  );
 };

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -85,7 +85,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ className = '', embedded
             isMounted = false;
             channel.unsubscribe();
         };
-    }, [activeConversationId]);
+    }, [activeConversationId, setActiveConversationId]);
 
     useEffect(() => {
         if (autoScroll && messagesContainerRef.current) {

--- a/components/layouts/AdminLayout.tsx
+++ b/components/layouts/AdminLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat, Coffee, MessageSquare } from 'lucide-react';
+import { LayoutDashboard, Home, Users, Calendar, Car, LogOut, Menu, X, Flag, ShoppingBag, Map as MapIcon, BookOpen, ChefHat, Coffee, MessageSquare, PenLine } from 'lucide-react';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
 
 interface AdminLayoutProps {
@@ -34,6 +34,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         { path: '/admin/products', label: 'Products', icon: ShoppingBag },
         { path: '/admin/users', label: 'Users', icon: Users },
         { path: '/admin/reviews', label: 'Reviews', icon: MessageSquare },
+        { path: '/admin/blog-submissions', label: 'Blog Submissions', icon: PenLine },
         { path: '/admin/reports', label: 'Reports', icon: Flag },
     ];
 
@@ -48,7 +49,7 @@ export const AdminLayout: React.FC<AdminLayoutProps> = ({ children }) => {
         },
         {
             label: 'Content',
-            items: navItems.filter(i => ['Reviews'].includes(i.label))
+            items: navItems.filter(i => ['Reviews', 'Blog Submissions'].includes(i.label))
         },
         {
             label: 'Users',

--- a/pages/BlogSubmissionSuccess.tsx
+++ b/pages/BlogSubmissionSuccess.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { CheckCircle, BookOpen, Clock, Mail } from 'lucide-react';
 
 export const BlogSubmissionSuccess: React.FC = () => {
-    const [searchParams] = useSearchParams();
-    const sessionId = searchParams.get('session_id');
 
     return (
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16 flex items-center">

--- a/pages/BlogSubmissionSuccess.tsx
+++ b/pages/BlogSubmissionSuccess.tsx
@@ -22,7 +22,7 @@ export const BlogSubmissionSuccess: React.FC = () => {
                     Submission Received!
                 </h1>
                 <p className="text-slate-500 dark:text-slate-400 mb-8 leading-relaxed">
-                    Thank you for submitting your article. Payment confirmed — our editorial team will review it shortly.
+                    Thank you for submitting your article. It has been accepted for review — our editorial team will check it shortly.
                 </p>
 
                 {/* Steps */}
@@ -32,8 +32,8 @@ export const BlogSubmissionSuccess: React.FC = () => {
                             <CheckCircle size={16} className="text-teal-600 dark:text-cyan-400" />
                         </div>
                         <div>
-                            <p className="text-sm font-semibold text-slate-800 dark:text-slate-200">Payment confirmed</p>
-                            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">€5 publication fee received</p>
+                            <p className="text-sm font-semibold text-slate-800 dark:text-slate-200">Submission received</p>
+                            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">We'll review your article soon</p>
                         </div>
                     </div>
                     <div className="flex items-start gap-3">
@@ -51,16 +51,10 @@ export const BlogSubmissionSuccess: React.FC = () => {
                         </div>
                         <div>
                             <p className="text-sm font-semibold text-slate-800 dark:text-slate-200">Email notification</p>
-                            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">You'll be emailed when your article is published or if we need changes</p>
+                            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">You'll be emailed if your article is selected and published</p>
                         </div>
                     </div>
                 </div>
-
-                {sessionId && (
-                    <p className="text-xs text-slate-400 dark:text-slate-500 mb-6">
-                        Reference: {sessionId}
-                    </p>
-                )}
 
                 {/* Actions */}
                 <div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/pages/BlogSubmitPage.tsx
+++ b/pages/BlogSubmitPage.tsx
@@ -1,20 +1,15 @@
 import React, { useState, useRef } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { useCurrency } from '../context/CurrencyContext';
 import { db } from '../api-services';
 import { toast } from 'react-hot-toast';
-import { PenLine, X, ImagePlus, Video, ArrowLeft, CreditCard, Info } from 'lucide-react';
+import { PenLine, X, ImagePlus, Video, ArrowLeft, Send, Info } from 'lucide-react';
 
 const MAX_IMAGES = 5;
-const SUBMISSION_FEE_EUR = 5;
 
 export const BlogSubmitPage: React.FC = () => {
     const { user } = useAuth();
-    const { convertPrice, formatPrice } = useCurrency();
     const navigate = useNavigate();
-
-    const displayFee = formatPrice(convertPrice(SUBMISSION_FEE_EUR, 'EUR'));
 
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
@@ -99,18 +94,17 @@ export const BlogSubmitPage: React.FC = () => {
                 }
             }
 
-            // Create submission + get Stripe URL
-            const toastId = toast.loading('Creating submission...');
-            const { checkoutUrl } = await db.createBlogSubmission({
+            // Create submission
+            const toastId = toast.loading('Submitting article...');
+            await db.createBlogSubmission({
                 title: title.trim(),
                 content: content.trim(),
                 video_url: videoUrl.trim() || undefined,
                 media_urls: uploadedUrls,
             });
 
-            toast.success('Redirecting to payment...', { id: toastId });
-            // Redirect to Stripe Checkout
-            window.location.href = checkoutUrl;
+            toast.success('Article submitted successfully!', { id: toastId });
+            navigate('/blog/submission-success');
         } catch (err: any) {
             toast.error(err.message || 'Failed to submit article');
         } finally {
@@ -143,7 +137,7 @@ export const BlogSubmitPage: React.FC = () => {
                         Share Your Story
                     </h1>
                     <p className="mt-2 text-slate-500 dark:text-slate-400">
-                        Write about Alanya — tips, guides, hidden gems. After a one-time publication fee of <strong className="text-slate-700 dark:text-slate-300">{displayFee}</strong>, your article goes through editorial review before being published.
+                        Write about Alanya — tips, guides, hidden gems. If your article is accepted and published, we will send you €5 as a token of appreciation!
                     </p>
                 </div>
 
@@ -151,7 +145,7 @@ export const BlogSubmitPage: React.FC = () => {
                 <div className="flex gap-3 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800/50 rounded-xl mb-8">
                     <Info size={18} className="text-blue-500 dark:text-blue-400 shrink-0 mt-0.5" />
                     <div className="text-sm text-blue-700 dark:text-blue-300">
-                        <strong>How it works:</strong> Fill in the form → pay {displayFee} via Stripe → our team reviews within 2–3 business days → you get an email when it's published.
+                        <strong>How it works:</strong> Fill in the form → our team reviews within 2–3 business days → if approved, we publish your article and pay €5 to your provided payment details.
                     </div>
                 </div>
 
@@ -271,8 +265,7 @@ export const BlogSubmitPage: React.FC = () => {
                     {/* Submit */}
                     <div className="flex items-center justify-between pt-2">
                         <div className="text-sm text-slate-500 dark:text-slate-400">
-                            <span className="font-semibold text-slate-700 dark:text-slate-300">Publication fee: {displayFee}</span>
-                            {' '}— charged once via Stripe
+                            Submission is <span className="font-semibold text-slate-700 dark:text-slate-300">free</span> — best articles earn €5
                         </div>
                         <button
                             type="submit"
@@ -289,8 +282,8 @@ export const BlogSubmitPage: React.FC = () => {
                                 </>
                             ) : (
                                 <>
-                                    <CreditCard size={16} />
-                                    Continue to Payment
+                                    <Send size={16} />
+                                    Submit Article
                                 </>
                             )}
                         </button>

--- a/pages/admin/AdminBlogSubmissionsPage.tsx
+++ b/pages/admin/AdminBlogSubmissionsPage.tsx
@@ -1,0 +1,162 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { db } from '../../api-services';
+import { chatService } from '../../api-services/api/chat';
+import { toast } from 'react-hot-toast';
+import { Check, X, MessageSquare, Loader2, ChevronDown, ChevronUp } from 'lucide-react';
+
+export const AdminBlogSubmissionsPage: React.FC = () => {
+    const navigate = useNavigate();
+    const [submissions, setSubmissions] = useState<any[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [expandedId, setExpandedId] = useState<string | null>(null);
+
+    const fetchData = async () => {
+        setIsLoading(true);
+        try {
+            const data = await db.getBlogSubmissions();
+            setSubmissions(data);
+        } catch {
+            toast.error('Failed to load submissions');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => { fetchData(); }, []);
+
+    const handleApprove = async (id: string) => {
+        try {
+            await db.approveBlogSubmission(id);
+            toast.success('Submission approved and published');
+            fetchData();
+        } catch (e: any) {
+            toast.error(e.message);
+        }
+    };
+
+    const handleReject = async (id: string) => {
+        const reason = window.prompt('Rejection reason (will be sent to author):');
+        if (reason === null) return; // cancelled
+        try {
+            await db.rejectBlogSubmission(id, reason.trim());
+            toast.success('Submission rejected');
+            fetchData();
+        } catch (e: any) {
+            toast.error(e.message);
+        }
+    };
+
+    const handleMessageAuthor = async (authorId: string) => {
+        try {
+            const conversationId = await chatService.createDirectConversation(authorId);
+            navigate(`/messages?conversation=${conversationId}`);
+        } catch (e: any) {
+            toast.error(e.message || 'Failed to open chat');
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center p-12">
+                <Loader2 className="animate-spin text-teal-500" size={32} />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Blog Submissions</h1>
+
+            {submissions.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">No submissions yet.</p>
+            ) : (
+                <div className="bg-white dark:bg-slate-800 rounded-xl shadow overflow-x-auto">
+                    <table className="w-full text-left text-sm">
+                        <thead className="bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
+                            <tr>
+                                <th className="p-4">Title</th>
+                                <th className="p-4">Author</th>
+                                <th className="p-4">Payment Details</th>
+                                <th className="p-4">Status</th>
+                                <th className="p-4">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {submissions.map((sub) => (
+                                <React.Fragment key={sub.id}>
+                                    <tr className="border-t border-slate-100 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors">
+                                        <td className="p-4">
+                                            <button
+                                                onClick={() => setExpandedId(expandedId === sub.id ? null : sub.id)}
+                                                className="flex items-center gap-1 font-medium text-slate-800 dark:text-slate-200 hover:text-teal-600 dark:hover:text-teal-400 text-left"
+                                            >
+                                                {expandedId === sub.id ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                                                {sub.title}
+                                            </button>
+                                        </td>
+                                        <td className="p-4 text-slate-600 dark:text-slate-400">
+                                            {sub.user?.email ?? '—'}
+                                        </td>
+                                        <td className="p-4 text-slate-600 dark:text-slate-400">
+                                            {sub.payment_details ?? <span className="text-slate-400 italic">not provided</span>}
+                                        </td>
+                                        <td className="p-4">
+                                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                                sub.status === 'approved' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' :
+                                                sub.status === 'rejected' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                                                'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+                                            }`}>
+                                                {sub.status}
+                                            </span>
+                                        </td>
+                                        <td className="p-4">
+                                            <div className="flex items-center gap-2">
+                                                {sub.status === 'pending_review' && (
+                                                    <>
+                                                        <button
+                                                            onClick={() => handleApprove(sub.id)}
+                                                            title="Approve"
+                                                            className="p-1.5 rounded-lg text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 transition-colors"
+                                                        >
+                                                            <Check size={16} />
+                                                        </button>
+                                                        <button
+                                                            onClick={() => handleReject(sub.id)}
+                                                            title="Reject"
+                                                            className="p-1.5 rounded-lg text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                                                        >
+                                                            <X size={16} />
+                                                        </button>
+                                                    </>
+                                                )}
+                                                {sub.user_id && (
+                                                    <button
+                                                        onClick={() => handleMessageAuthor(sub.user_id)}
+                                                        title="Message author"
+                                                        className="p-1.5 rounded-lg text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                                                    >
+                                                        <MessageSquare size={16} />
+                                                    </button>
+                                                )}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    {expandedId === sub.id && (
+                                        <tr className="border-t border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/80">
+                                            <td colSpan={5} className="p-4">
+                                                <p className="text-slate-700 dark:text-slate-300 whitespace-pre-wrap text-sm leading-relaxed">
+                                                    {sub.content}
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    )}
+                                </React.Fragment>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -65,6 +65,7 @@ const AdminProductsPage = React.lazy(() => import('../pages/admin/ProductsPage')
 const AdminEditProductPage = React.lazy(() => import('../pages/admin/AdminEditProductPage').then(module => ({ default: module.AdminEditProductPage })));
 const DirectoryAdminPage = React.lazy(() => import('../pages/admin/DirectoryAdminPage').then(module => ({ default: module.DirectoryAdminPage })));
 const AdminEditDirectoryPage = React.lazy(() => import('../pages/admin/AdminEditDirectoryPage').then(module => ({ default: module.AdminEditDirectoryPage })));
+const AdminBlogSubmissionsPage = React.lazy(() => import('../pages/admin/AdminBlogSubmissionsPage').then(module => ({ default: module.AdminBlogSubmissionsPage })));
 
 // Lazy Load Host Pages
 const HostDashboard = React.lazy(() => import('../pages/host/HostDashboard').then(module => ({ default: module.HostDashboard })));
@@ -305,6 +306,13 @@ export const AppRoutes: React.FC = () => {
                     <AdminRoute>
                         <AdminLayout>
                             <AdminEditDirectoryPage />
+                        </AdminLayout>
+                    </AdminRoute>
+                } />
+                <Route path="/admin/blog-submissions" element={
+                    <AdminRoute>
+                        <AdminLayout>
+                            <AdminBlogSubmissionsPage />
                         </AdminLayout>
                     </AdminRoute>
                 } />

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -647,7 +647,7 @@ function generateEmailContent(type: string, data: any): { subject: string, html:
                     `
                     <p style="font-size: 16px;">Thank you! Your blog post <strong>${escapeHtml(data.postTitle)}</strong> has been received.</p>
                     <div class="card">
-                        <p style="text-align: center; margin: 0;">Your submission is awaiting payment confirmation. Once payment is processed, our editorial team will review your content within 3-5 business days.</p>
+                <p style="text-align: center; margin: 0;">Your submission is under review by our editorial team. We will check it shortly.</p>
                     </div>
                     <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">You will receive an email once your post is reviewed and published.</p>
                     `,

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -318,141 +318,22 @@ Deno.serve(async (req: Request) => {
   } // end invoice.payment_failed
 
   // ============================================================
-  // Existing Booking / Blog Subscription Handlers
+  // Blog Submission Payment Handler
   // ============================================================
 
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
 
-    const paymentIntentId = typeof session.payment_intent === 'string'
-      ? session.payment_intent
-      : (session.payment_intent as any)?.id ?? null
-
-    // Idempotency: skip if already processed (payment_status already 'paid')
-    const bookingIds = session.metadata?.bookingIds?.split(',').filter(Boolean) ?? []
-    if (bookingIds.length > 0) {
-      // H1: .single() throws on 0 rows — use .maybeSingle() for proper null handling
-      const { data: existing } = await supabase
-        .from('bookings')
-        .select('id, payment_status')
-        .eq('stripe_session_id', session.id)
-        .limit(1)
-        .maybeSingle()
-
-      if (existing?.payment_status === 'paid') {
-        console.warn(`Skipping duplicate webhook for session ${session.id}`)
-        return new Response(JSON.stringify({ received: true }), {
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
+    if (session.metadata?.type === 'blog_submission') {
+        // Blog submissions are now free — this handler should no longer be triggered by Stripe.
+        // We log it just in case an old link is used or manual payment attempt occurs.
+        console.warn(`Unexpected blog_submission payment received for session: ${session.id}`)
+        return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
     }
 
-    if (session.payment_status === 'paid') {
-      // --- Handle blog submission payment ---
-      if (session.metadata?.type === 'blog_submission') {
-        const submissionId = session.metadata.submissionId
-        if (submissionId) {
-          // M1: verify amount_total is $5 (500 cents) — protects against our own billing bugs
-          if (session.amount_total !== 500) {
-            console.error(`Blog submission amount mismatch: expected 500, got ${session.amount_total}`)
-            return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
-          }
+    // Existing Booking Handler
+    // ...
 
-          const { data: submission, error: subError } = await supabase
-            .from('blog_submissions')
-            .select('id, user_id, title, status, payment_status')
-            .eq('id', submissionId)
-            .maybeSingle()
-
-          if (subError) {
-            console.error('Blog submission lookup error:', subError)
-          } else if (submission) {
-            // A2-C4: Use UPDATE with WHERE to detect if this is the first successful run
-            // Guard: also check status='pending_payment' to avoid triggering the H4 state machine
-            // if the submission was rejected by an admin before payment arrived (rejected → pending_review
-            // is blocked by the trigger, causing a DB exception and an infinite Stripe retry loop).
-            const { data: updatedSub, error: updateError } = await supabase
-              .from('blog_submissions')
-              .update({
-                payment_status: 'paid',
-                status: 'pending_review',
-              })
-              .eq('id', submissionId)
-              .eq('payment_status', 'unpaid')
-              .eq('status', 'pending_payment')
-              .select('id')
-
-            if (updateError) {
-              console.error('Failed to confirm blog submission payment:', updateError)
-              return new Response(JSON.stringify({ error: 'DB update failed' }), { status: 500, headers: { 'Content-Type': 'application/json' } })
-            }
-
-            // If updatedSub.length > 0, it's the first time.
-            // If 0, it's a retry (or already paid), but we proceed to notifications anyway
-            // to ensure they are sent if the previous run failed mid-way.
-            if (updatedSub && updatedSub.length > 0) {
-              console.warn(`Confirmed blog submission payment: ${submissionId}`)
-            } else {
-              console.warn(`Webhook retry or already paid for blog submission: ${submissionId}`)
-            }
-
-            // Notify all admins about new submission awaiting review
-            const { data: admins } = await supabase
-              .from('profiles')
-              .select('id')
-              .eq('role', 'admin')
-
-            if (admins && admins.length > 0) {
-              await supabase.from('notifications').insert(
-                admins.map((admin: { id: string }) => ({
-                  user_id: admin.id,
-                  title: 'New Blog Submission',
-                  message: `A new blog submission "${submission.title}" is ready for review.`,
-                  type: 'info',
-                  link: `/admin/blog-submissions/${submissionId}`,
-                }))
-              )
-            }
-
-            // Send email to author: submission received, awaiting moderation
-            const { data: authorProfile } = await supabase
-              .from('profiles')
-              .select('email, full_name')
-              .eq('id', submission.user_id)
-              .maybeSingle()
-
-            const authorEmail = authorProfile?.email
-            if (authorEmail) {
-              const siteUrl = Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'
-              // M4: fire-and-forget + M5: audit_logs on failure
-              supabase.functions.invoke('send-email', {
-                body: {
-                  to: authorEmail,
-                  type: 'blog_submission_received',
-                  data: {
-                    postTitle: submission.title,
-                    link: `${siteUrl}/blog`,
-                  },
-                },
-              }).then(() => {
-                console.warn(`Sent received email to ${authorEmail}`)
-              }).catch((e: unknown) => {
-                const msg = e instanceof Error ? e.message : String(e)
-                console.error(`Failed to send blog submission received email:`, msg)
-                supabase.from('audit_logs').insert({
-                  event_type: 'EMAIL_DELIVERY_FAILED',
-                  details: { email_type: 'blog_submission_received', submission_id: submissionId, error: msg },
-                }).then(() => {}).catch(() => {})
-              })
-            }
-          } else {
-            console.warn(`Blog submission not found in DB: ${submissionId}`)
-          }
-        }
-      }
-
-      // --- Handle booking payments (existing logic) ---
-      else if (bookingIds.length > 0) {
         // A1-C1: Verify all bookingIds belong to the userId from this session
         const sessionUserId = session.metadata?.userId
         if (!sessionUserId) {

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -318,22 +318,40 @@ Deno.serve(async (req: Request) => {
   } // end invoice.payment_failed
 
   // ============================================================
-  // Blog Submission Payment Handler
+  // Booking / Checkout Handler
   // ============================================================
 
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
 
+    // Blog submissions are now free — log and ignore if an old link triggers this
     if (session.metadata?.type === 'blog_submission') {
-        // Blog submissions are now free — this handler should no longer be triggered by Stripe.
-        // We log it just in case an old link is used or manual payment attempt occurs.
-        console.warn(`Unexpected blog_submission payment received for session: ${session.id}`)
-        return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+      console.warn(`Unexpected blog_submission payment received for session: ${session.id}`)
+      return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
     }
 
-    // Existing Booking Handler
-    // ...
+    const paymentIntentId = typeof session.payment_intent === 'string'
+      ? session.payment_intent
+      : (session.payment_intent as any)?.id ?? null
 
+    // Idempotency: skip if already processed
+    const bookingIds = session.metadata?.bookingIds?.split(',').filter(Boolean) ?? []
+    if (bookingIds.length > 0) {
+      const { data: existing } = await supabase
+        .from('bookings')
+        .select('id, payment_status')
+        .eq('stripe_session_id', session.id)
+        .limit(1)
+        .maybeSingle()
+
+      if (existing?.payment_status === 'paid') {
+        console.warn(`Skipping duplicate webhook for session ${session.id}`)
+        return new Response(JSON.stringify({ received: true }), { headers: { 'Content-Type': 'application/json' } })
+      }
+    }
+
+    if (session.payment_status === 'paid') {
+      if (bookingIds.length > 0) {
         // A1-C1: Verify all bookingIds belong to the userId from this session
         const sessionUserId = session.metadata?.userId
         if (!sessionUserId) {
@@ -443,8 +461,8 @@ Deno.serve(async (req: Request) => {
           })
         }
       }
-    }
-  }
+    } // end if session.payment_status === 'paid'
+  } // end checkout.session.completed
 
   if (event.type === 'payment_intent.payment_failed') {
     const paymentIntent = event.data.object as Stripe.PaymentIntent

--- a/supabase/migrations/20260419100000_migrate_blog_to_free_payouts.sql
+++ b/supabase/migrations/20260419100000_migrate_blog_to_free_payouts.sql
@@ -1,0 +1,57 @@
+-- Migration: 20260419100000_migrate_blog_to_free_payouts
+-- Purpose: Remove Stripe payment requirement for blog submissions.
+-- Admin contacts author via chat to arrange payment manually.
+
+-- 1. Add payment_details for author's PayPal/IBAN (optional, shown to admin in chat context)
+ALTER TABLE public.blog_submissions
+    ADD COLUMN payment_details TEXT;
+
+-- 2. Update default status and clean up old data
+-- We update pending_payment to pending_review to keep active submissions
+UPDATE public.blog_submissions SET status = 'pending_review' WHERE status = 'pending_payment';
+
+ALTER TABLE public.blog_submissions ALTER COLUMN status SET DEFAULT 'pending_review';
+
+-- 3. Update existing CHECK constraint for status to remove 'pending_payment'
+ALTER TABLE public.blog_submissions DROP CONSTRAINT blog_submissions_status_check;
+ALTER TABLE public.blog_submissions ADD CONSTRAINT blog_submissions_status_check
+    CHECK (status IN ('pending_review', 'approved', 'rejected'));
+
+-- 4. Remove Stripe and legacy payment columns
+ALTER TABLE public.blog_submissions DROP COLUMN stripe_session_id;
+ALTER TABLE public.blog_submissions DROP COLUMN payment_expires_at;
+ALTER TABLE public.blog_submissions DROP COLUMN payment_status;
+
+-- 5. Drop old indexes
+DROP INDEX IF EXISTS idx_blog_submissions_stripe_session;
+
+-- 6. Update the status transition trigger function
+CREATE OR REPLACE FUNCTION public.validate_blog_submission_status_transition()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_old_status TEXT;
+    v_new_status TEXT;
+    v_allowed BOOLEAN;
+BEGIN
+    v_old_status := OLD.status;
+    v_new_status := NEW.status;
+
+    IF v_old_status IS NOT DISTINCT FROM v_new_status THEN
+        RETURN NEW;
+    END IF;
+
+    v_allowed := CASE
+        WHEN v_old_status = 'pending_review' AND v_new_status IN ('approved', 'rejected') THEN TRUE
+        WHEN v_old_status = 'approved' AND v_new_status = 'pending_review' THEN TRUE
+        ELSE FALSE
+    END;
+
+    IF NOT v_allowed THEN
+        RAISE EXCEPTION 'Invalid blog submission status transition: % -> %', v_old_status, v_new_status
+            USING ERRCODE = 'check_violation',
+                  DETAIL = format('Transition from "%s" to "%s" is not allowed.', v_old_status, v_new_status);
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

- **Blog submission is now free** — removed Stripe Checkout from submission flow; posts go directly to `pending_review`
- **Admin contacts author via chat** — replaced "Mark Paid" button with "Message Author" (opens/creates direct chat conversation)
- **Fixed double `<AdminLayout>`** in `AdminBlogSubmissionsPage`
- **Fixed reject button** — now calls `rejectBlogSubmission` with a reason via `window.prompt`
- **Added `createDirectConversation`** to `chatService` — creates chat without `property_id` (nullable in schema)
- **Migration** — adds `payment_details` column, removes `stripe_session_id`, `payment_status`, `payment_expires_at`; updates status constraint and transition trigger
- **Fixed ESLint** — added `setActiveConversationId` to `ChatWindow` useEffect deps

## Key decisions

- No Stripe Connect / payout tracking — admin arranges payment directly with author via chat
- `payment_details` column removed from submission form (admin asks in chat if needed)
- Direct conversation uses `property_id = NULL` which is allowed by schema

## Testing notes

- TypeScript: 0 errors
- ESLint: 0 warnings
- All blog tests updated and passing