### PR TITLE
fix: currency CORS via Edge Function proxy + cafes category

### DIFF
--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -109,7 +109,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       isMounted = false;
       channel.unsubscribe();
     };
-  }, [activeConversationId]);
+  }, [activeConversationId, setActiveConversationId]);
 
   useEffect(() => {
     if (autoScroll && messagesContainerRef.current) {

--- a/components/reviews/ReviewModal.tsx
+++ b/components/reviews/ReviewModal.tsx
@@ -14,7 +14,7 @@ interface ReviewModalProps {
     onSuccess: () => void;
 }
 
-export const ReviewModal: React.FC<ReviewModalProps> = ({ isOpen, onClose, propertyId, userId, onSuccess }) => {
+export const ReviewModal: React.FC<ReviewModalProps> = ({ isOpen, onClose, propertyId, userId: _userId, onSuccess }) => {
     const { t } = useLanguage();
     const [rating, setRating] = useState(5);
     const [comment, setComment] = useState('');

--- a/components/ui/PremiumGate.test.tsx
+++ b/components/ui/PremiumGate.test.tsx
@@ -21,11 +21,8 @@ vi.mock('react-router-dom', () => ({
 }));
 
 describe('PremiumGate', () => {
-    let mockLocationHref = '';
-
     beforeEach(() => {
         vi.clearAllMocks();
-        mockLocationHref = '';
         Object.defineProperty(window, 'location', {
             value: { href: '' },
             writable: true,

--- a/context/CurrencyContext.tsx
+++ b/context/CurrencyContext.tsx
@@ -29,15 +29,13 @@ function loadCachedRates(): Record<Currency, number> | null {
 }
 
 async function fetchLiveRates(): Promise<Record<Currency, number>> {
-    const res = await fetch('https://api.frankfurter.app/latest?from=EUR&to=USD,TRY');
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    const res = await fetch(`${supabaseUrl}/functions/v1/currency-rates`, {
+        headers: { apikey: supabaseKey },
+    });
     if (!res.ok) throw new Error('Failed to fetch rates');
-    const json = await res.json();
-    // json.rates = { USD: 1.08, TRY: 38.5 }
-    const rates: Record<Currency, number> = {
-        EUR: 1,
-        USD: json.rates.USD,
-        TRY: json.rates.TRY,
-    };
+    const rates: Record<Currency, number> = await res.json();
     const cache: RatesCache = { rates, fetchedAt: Date.now() };
     localStorage.setItem(RATES_CACHE_KEY, JSON.stringify(cache));
     return rates;

--- a/data/directoryData.ts
+++ b/data/directoryData.ts
@@ -122,6 +122,24 @@ export const directoryCategoryIntros: Record<string, DirectoryCategoryIntro> = {
       { question: 'Are there good breakfast cafés in Alanya?', answer: 'Yes — Turkish breakfast is a highlight of any visit. Look for cafés advertising "serpme kahvaltı" (spread breakfast) in Mahmutlar and Oba. Expect a full spread of cheeses, eggs, olives, honey, and fresh bread for around €8–€15 per person.' }
     ]
   },
+  'cafes': {
+    title: 'Best Cafés & Coffee Shops in Alanya 2026 | Local Guide',
+    description: 'Find the best cafés and coffee shops in Alanya. From specialty coffee in the Old Town to beachside breakfast spots and neighbourhood patisseries. Updated 2026 local guide.',
+    longDescription: [
+      'Alanya\'s café scene has grown considerably over the last few years, moving well beyond the tourist strip into neighbourhood spots that rival anything you\'d find in Istanbul. Whether you\'re after a slow Turkish breakfast, specialty espresso, or a quiet spot to work, the city has more to offer than most visitors realise.',
+      'Old Town & Castle District: The streets around the castle and the historic bazaar area have a cluster of atmospheric small cafés serving Turkish tea, Turkish coffee, and light breakfasts. Many have rooftop or terrace seating with views over the Red Tower and harbour. These are the best spots for a leisurely morning before the heat sets in.',
+      'Cleopatra Beach Area: The main beach strip has plenty of cafés aimed at tourists, but step back one or two streets and you\'ll find more characterful options. Specialty coffee has arrived here — a handful of independent cafés now serve proper espresso-based drinks using quality Turkish and Ethiopian beans.',
+      'Mahmutlar: The neighbourhood\'s café culture is built around the local community — mostly expats and long-term residents. You\'ll find excellent Turkish breakfast cafés (serpme kahvaltı) for €8–€12 per person, alongside small pastry shops and tea gardens. The pace is slower and the prices significantly lower than the tourist areas.',
+      'Oba & Kestel: These residential neighbourhoods have become home to a newer wave of Turkish specialty coffee shops catering to young locals and expat families. If you\'re staying in either area, it\'s worth exploring the side streets for hidden gems that don\'t appear in travel guides.'
+    ],
+    faqs: [
+      { question: 'Where can I get good specialty coffee in Alanya?', answer: 'Specialty coffee options are concentrated around the Old Town, Cleopatra Beach area, and increasingly in Oba and Mahmutlar. Look for cafés advertising "filter coffee" or "V60" — these are reliably good indicators of quality.' },
+      { question: 'What is a traditional Turkish breakfast like?', answer: 'A full Turkish breakfast (serpme kahvaltı) includes an assortment of cheeses, olives, tomatoes, cucumbers, eggs cooked to order, honey, clotted cream (kaymak), jams, and fresh bread. Many cafés in Mahmutlar and Oba serve this spread for €8–€15 per person. It\'s one of the best-value meals in Alanya.' },
+      { question: 'Do cafés in Alanya have Wi-Fi?', answer: 'Most cafés in tourist and expat areas offer free Wi-Fi. Quality varies — the more established specialty coffee spots tend to have better connections. It\'s worth asking before settling in for a work session.' },
+      { question: 'What is Turkish tea (çay) culture like?', answer: 'Tea is the national drink and is served in small tulip-shaped glasses. It\'s brewed strong and drunk without milk, sometimes with a sugar cube. Tea is often complimentary or very cheap (€0.50–€1) and is a social ritual as much as a drink. Refusing tea is mildly impolite — accepting and sipping slowly is the local norm.' },
+      { question: 'Are there vegan or dairy-free café options in Alanya?', answer: 'Options are improving. Several cafés in the tourist areas now offer oat milk and almond milk alternatives. The specialty coffee shops are the safest bet. Traditional Turkish cafés may not always have alternatives, so it\'s worth checking beforehand.' }
+    ]
+  },
   'real-estate': {
     title: 'Buy Property in Alanya, Turkey | Foreigner & Expat Guide to Real Estate 2026',
     description: 'Complete guide to buying property in Alanya as a foreigner. Neighbourhood breakdowns for Oba, Kestel, Mahmutlar and more. Trusted local agents, legal process explained.',

--- a/pages/AiPlanner.test.tsx
+++ b/pages/AiPlanner.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AiPlanner } from './AiPlanner';
 import { planTrip } from '../api-services/aiService';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -398,3 +398,7 @@ entrypoint = "./functions/send-email/index.ts"
 enabled = true
 verify_jwt = false
 entrypoint = "./functions/cleanup-blog-media/index.ts"
+
+[functions.currency-rates]
+enabled = true
+verify_jwt = false

--- a/supabase/functions/currency-rates/index.ts
+++ b/supabase/functions/currency-rates/index.ts
@@ -1,0 +1,76 @@
+// Currency rates proxy — fetches from frankfurter.app server-side, caches for 1 hour
+// Browser → Edge Function → frankfurter.app (CORS controlled by us, no JWT required)
+
+declare const Deno: any;
+
+const SITE_URL = Deno.env.get("SITE_URL") || "https://alanyaholidays.com";
+const ALLOWED_ORIGINS = new Set([
+    SITE_URL,
+    "https://alanyaholidays.com",
+    "http://localhost:3000",
+    "http://localhost:5173",
+]);
+
+// In-memory cache — lives as long as the function instance is warm
+let ratesCache: { rates: Record<string, number>; fetchedAt: number } | null = null;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function getCorsHeaders(req: Request) {
+    const origin = req.headers.get("origin") || "";
+    const allowedOrigin = ALLOWED_ORIGINS.has(origin) ? origin : SITE_URL;
+    return {
+        "Access-Control-Allow-Origin": allowedOrigin,
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    };
+}
+
+Deno.serve(async (req: Request) => {
+    const cors = getCorsHeaders(req);
+
+    if (req.method === "OPTIONS") {
+        return new Response("ok", { headers: cors });
+    }
+
+    if (req.method !== "GET") {
+        return new Response(JSON.stringify({ error: "Method not allowed" }), {
+            status: 405,
+            headers: { ...cors, "Content-Type": "application/json" },
+        });
+    }
+
+    // Require anon key OR auth header — either is sufficient for public access
+    const apikey = req.headers.get("apikey");
+    if (!apikey && !req.headers.get("authorization")) {
+        return new Response(JSON.stringify({ error: "Unauthorized" }), {
+            status: 401,
+            headers: { ...cors, "Content-Type": "application/json" },
+        });
+    }
+
+    // Return cached rates if fresh
+    if (ratesCache && Date.now() - ratesCache.fetchedAt < CACHE_TTL_MS) {
+        return new Response(JSON.stringify(ratesCache.rates), {
+            headers: { ...cors, "Content-Type": "application/json", "X-Cache": "HIT" },
+        });
+    }
+
+    try {
+        const res = await fetch("https://api.frankfurter.app/latest?from=EUR&to=USD,TRY");
+        if (!res.ok) throw new Error(`Frankfurter responded with ${res.status}`);
+        const json = await res.json();
+
+        const rates = { EUR: 1, USD: json.rates.USD, TRY: json.rates.TRY };
+        ratesCache = { rates, fetchedAt: Date.now() };
+
+        return new Response(JSON.stringify(rates), {
+            headers: { ...cors, "Content-Type": "application/json", "X-Cache": "MISS" },
+        });
+    } catch (error: unknown) {
+        console.error("Failed to fetch currency rates:", error instanceof Error ? error.message : String(error));
+        return new Response(JSON.stringify({ error: "Failed to fetch rates" }), {
+            status: 502,
+            headers: { ...cors, "Content-Type": "application/json" },
+        });
+    }
+});


### PR DESCRIPTION
## Summary

- **Currency CORS fix** — прямой fetch к `frankfurter.app` из браузера блокировался CORS политикой. Добавлена Edge Function `currency-rates`, которая проксирует запрос server-side (Deno не ограничен CORS). In-memory кеш на 1 час. `CurrencyContext` теперь обращается к Edge Function вместо внешнего API напрямую.
- **Cafes category fix** — при нажатии на кнопку «Кафе» в сетке категорий, `DirectoryCategoryPage` делал `<Navigate to="/" replace />` из-за отсутствующего ключа `cafes` в `directoryCategoryIntros`. Добавлена полноценная запись с title, description, longDescription и faqs.

## Architectural decisions

- Edge Function не требует JWT — публичный endpoint, защита только по `apikey` (anon key, публичный)
- Fallback на статичные курсы в `CurrencyContext` остался без изменений — если функция упадёт, клиент молча использует захардкоженные курсы

## Testing

- TypeScript: 0 errors
- Функция задеплоена: `currency-rates` ACTIVE v4