### PR TITLE
feat: LST-004 Voyager tier feature set

### DIFF
--- a/api-services/api/directory.test.ts
+++ b/api-services/api/directory.test.ts
@@ -4,6 +4,7 @@ import { directoryService } from './directory';
 const { mockSupabase } = vi.hoisted(() => ({
     mockSupabase: {
         from: vi.fn(),
+        rpc: vi.fn(),
         auth: {
             getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
         }
@@ -27,6 +28,7 @@ const mockListing = {
     price_level: 2,
     languages_spoken: ['en'],
     certifications: [],
+    video_url: null,
     created_at: '2025-01-01',
     updated_at: '2025-01-01'
 };
@@ -187,6 +189,56 @@ describe('directoryService', () => {
             mockSupabase.from.mockReturnValue(chain);
 
             await expect(directoryService.deleteDirectoryListing('dir-1')).rejects.toEqual({ message: 'delete failed' });
+        });
+    });
+
+    describe('trackListingView', () => {
+        it('calls track_listing_view RPC', async () => {
+            mockSupabase.rpc = vi.fn().mockResolvedValue({ error: null });
+
+            await directoryService.trackListingView('dir-1');
+            expect(mockSupabase.rpc).toHaveBeenCalledWith('track_listing_view', { p_listing_id: 'dir-1' });
+        });
+    });
+
+    describe('trackListingClick', () => {
+        it('calls track_listing_click RPC with correct type', async () => {
+            mockSupabase.rpc = vi.fn().mockResolvedValue({ error: null });
+
+            await directoryService.trackListingClick('dir-1', 'whatsapp');
+            expect(mockSupabase.rpc).toHaveBeenCalledWith('track_listing_click', {
+                p_listing_id: 'dir-1',
+                p_click_type: 'whatsapp'
+            });
+        });
+    });
+
+    describe('getDirectoryAnalyticsForOwner', () => {
+        it('returns analytics data', async () => {
+            const mockAnalytics = [
+                {
+                    listing_id: 'dir-1',
+                    listing_name: 'Test Clinic',
+                    total_views: 100,
+                    total_whatsapp_clicks: 10,
+                    total_website_clicks: 5,
+                    total_map_clicks: 3,
+                    daily_data: []
+                }
+            ];
+            mockSupabase.rpc = vi.fn().mockResolvedValue({ data: mockAnalytics, error: null });
+
+            const result = await directoryService.getDirectoryAnalyticsForOwner(30);
+            expect(result).toEqual(mockAnalytics);
+            expect(mockSupabase.rpc).toHaveBeenCalledWith('get_directory_analytics_for_owner', {
+                p_owner_id: 'u1',
+                p_days: 30
+            });
+        });
+
+        it('throws when not authenticated', async () => {
+            mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+            await expect(directoryService.getDirectoryAnalyticsForOwner()).rejects.toThrow('Not authenticated');
         });
     });
 });

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../supabase';
-import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingDB, ListingAnalyticsSummary } from '../../types/models';
 
 // eslint-disable-next-line no-control-regex
 const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
@@ -190,6 +190,7 @@ export const directoryService = {
             gallery: Array.isArray(listing.gallery) ? listing.gallery : [],
             location: (listing.location ?? '').slice(0, 200),
             google_map_url: listing.google_map_url?.slice(0, 500),
+            video_url: listing.video_url?.slice(0, 500) || null,
             is_featured: false,
             is_verified: false,
             tier: listing.tier || 'explorer',
@@ -255,5 +256,31 @@ export const directoryService = {
             console.error('Error deleting directory listing:', error);
             throw error;
         }
+    },
+
+    async trackListingView(listingId: string): Promise<void> {
+        const { error } = await supabase.rpc('track_listing_view', { p_listing_id: listingId });
+        if (error) console.error('Error tracking view:', error);
+    },
+
+    async trackListingClick(listingId: string, clickType: 'whatsapp' | 'website' | 'map'): Promise<void> {
+        const { error } = await supabase.rpc('track_listing_click', {
+            p_listing_id: listingId,
+            p_click_type: clickType
+        });
+        if (error) console.error('Error tracking click:', error);
+    },
+
+    async getDirectoryAnalyticsForOwner(days: number = 30): Promise<ListingAnalyticsSummary[]> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        const { data, error } = await supabase.rpc('get_directory_analytics_for_owner', {
+            p_owner_id: user.id,
+            p_days: days
+        });
+
+        if (error) throw error;
+        return (data || []) as ListingAnalyticsSummary[];
     }
 };

--- a/components/directory/DirectoryListingCard.test.tsx
+++ b/components/directory/DirectoryListingCard.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DirectoryListingCard } from './DirectoryListingCard';
+import { DirectoryListingDB } from '../../types/models';
+
+const { mockDb } = vi.hoisted(() => ({
+    mockDb: {
+        trackListingClick: vi.fn().mockResolvedValue(undefined),
+        trackListingView: vi.fn().mockResolvedValue(undefined),
+    }
+}));
+
+vi.mock('../../api-services', () => ({
+    db: mockDb
+}));
+
+const baseListing: DirectoryListingDB = {
+    id: 'dir-1',
+    name: 'Test Clinic',
+    category_id: 'medical',
+    short_description: 'A clinic',
+    location: 'Alanya Center',
+    gallery: [],
+    is_featured: false,
+    is_verified: false,
+    tier: 'explorer',
+    whatsapp: '+905551234567',
+    website: 'https://example.com',
+    google_map_url: 'https://maps.google.com',
+};
+
+describe('DirectoryListingCard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows WhatsApp button for Voyager tier', () => {
+        render(
+            <DirectoryListingCard
+                listing={{ ...baseListing, tier: 'voyager' }}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        expect(screen.getByText('WhatsApp')).toBeInTheDocument();
+    });
+
+    it('hides WhatsApp button for Explorer tier', () => {
+        render(
+            <DirectoryListingCard
+                listing={baseListing}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        expect(screen.queryByText('WhatsApp')).not.toBeInTheDocument();
+    });
+
+    it('shows Recommended badge for paid tiers', () => {
+        render(
+            <DirectoryListingCard
+                listing={{ ...baseListing, tier: 'voyager' }}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        expect(screen.getByText('Recommended')).toBeInTheDocument();
+    });
+
+    it('hides Recommended badge for Explorer tier', () => {
+        render(
+            <DirectoryListingCard
+                listing={baseListing}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        expect(screen.queryByText('Recommended')).not.toBeInTheDocument();
+    });
+
+    it('tracks website click', () => {
+        render(
+            <DirectoryListingCard
+                listing={baseListing}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        const websiteBtn = screen.getByText('Website');
+        fireEvent.click(websiteBtn);
+        expect(mockDb.trackListingClick).toHaveBeenCalledWith('dir-1', 'website');
+    });
+
+    it('tracks map click', () => {
+        render(
+            <DirectoryListingCard
+                listing={baseListing}
+                onClick={() => {}}
+                isAuthenticated={true}
+            />
+        );
+        const mapBtn = screen.getByText('Map');
+        fireEvent.click(mapBtn);
+        expect(mockDb.trackListingClick).toHaveBeenCalledWith('dir-1', 'map');
+    });
+});

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, ThumbsUp, ThumbsDown, Award } from 'lucide-react';
 import { DirectoryListingDB } from '../../types/models';
+import { db } from '../../api-services';
 
 interface DirectoryListingCardProps {
     listing: DirectoryListingDB;
@@ -15,6 +16,7 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
     listing, onClick, userVote, onVote, isAuthenticated, isVoting
 }) => {
     const netVotes = listing.net_votes || 0;
+    const isPaidTier = (tier?: string) => tier && tier !== 'explorer';
 
     const handleVote = (e: React.MouseEvent, vote: 1 | -1) => {
         e.stopPropagation();
@@ -37,6 +39,11 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                 {listing.is_featured && (
                     <div className="absolute top-4 left-4 bg-amber-500 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg flex items-center gap-1">
                         <Star size={12} className="fill-white" /> Featured
+                    </div>
+                )}
+                {isPaidTier(listing.tier) && (
+                    <div className="absolute top-4 right-4 bg-teal-500 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg flex items-center gap-1">
+                        <Award size={12} className="fill-white" /> Recommended
                     </div>
                 )}
             </div>
@@ -135,21 +142,28 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                 </div>
 
                 {/* Actions CTA (Subtle buttons, retaining functionality) */}
-                <div className="grid grid-cols-3 gap-2 pt-4 border-t border-slate-100 dark:border-slate-800">
+                <div className={`grid gap-2 pt-4 border-t border-slate-100 dark:border-slate-800 ${
+                    isPaidTier(listing.tier) && listing.whatsapp ? 'grid-cols-3' : 'grid-cols-2'
+                }`}>
+                    {isPaidTier(listing.tier) && listing.whatsapp && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                db.trackListingClick(listing.id, 'whatsapp').catch(console.error);
+                                window.open(`https://wa.me/${listing.whatsapp?.replace(/\D/g, '')}`, '_blank');
+                            }}
+                            className="flex items-center justify-center gap-1.5 py-2 text-sm font-medium rounded-lg text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20"
+                        >
+                            <MessageCircle size={16} /> WhatsApp
+                        </button>
+                    )}
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            window.open(`https://wa.me/${listing.whatsapp?.replace(/\D/g, '')}`, '_blank');
-                        }}
-                        className={`flex items-center justify-center gap-1.5 py-2 text-sm font-medium rounded-lg transition-colors ${listing.whatsapp ? 'text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20' : 'text-slate-400 opacity-50 cursor-not-allowed'}`}
-                        disabled={!listing.whatsapp}
-                    >
-                        <MessageCircle size={16} /> WhatsApp
-                    </button>
-                    <button
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            if (listing.website) window.open(listing.website, '_blank');
+                            if (listing.website) {
+                                db.trackListingClick(listing.id, 'website').catch(console.error);
+                                window.open(listing.website, '_blank');
+                            }
                         }}
                         className={`flex items-center justify-center gap-1.5 py-2 text-sm font-medium rounded-lg transition-colors ${listing.website ? 'text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20' : 'text-slate-400 opacity-50 cursor-not-allowed'}`}
                         disabled={!listing.website}
@@ -160,6 +174,7 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                         className="flex items-center justify-center gap-1.5 py-2 text-sm font-medium rounded-lg text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
                         onClick={(e) => {
                             e.stopPropagation();
+                            db.trackListingClick(listing.id, 'map').catch(console.error);
                             if (listing.google_map_url) {
                                 window.open(listing.google_map_url, '_blank');
                             } else {

--- a/components/directory/DirectoryListingModal.test.tsx
+++ b/components/directory/DirectoryListingModal.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DirectoryListingModal } from './DirectoryListingModal';
+import { DirectoryListingDB } from '../../types/models';
+
+const { mockDb } = vi.hoisted(() => ({
+    mockDb: {
+        trackListingClick: vi.fn().mockResolvedValue(undefined),
+    }
+}));
+
+vi.mock('../../api-services', () => ({
+    db: mockDb
+}));
+
+vi.mock('../../utils/videoEmbed', () => ({
+    parseVideoEmbed: vi.fn((url: string) => {
+        if (url.includes('youtube.com/watch?v=')) {
+            return { embedUrl: 'https://www.youtube.com/embed/abc123', provider: 'youtube' as const, videoId: 'abc123' };
+        }
+        return null;
+    })
+}));
+
+const baseListing: DirectoryListingDB = {
+    id: 'dir-1',
+    name: 'Test Clinic',
+    category_id: 'medical',
+    short_description: 'A clinic',
+    location: 'Alanya Center',
+    gallery: ['https://example.com/img.jpg'],
+    is_featured: false,
+    is_verified: false,
+    tier: 'explorer',
+    whatsapp: '+905551234567',
+    website: 'https://example.com',
+    google_map_url: 'https://maps.google.com',
+};
+
+describe('DirectoryListingModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('hides WhatsApp button for Explorer tier', () => {
+        render(
+            <DirectoryListingModal
+                listing={baseListing}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.queryByText('Chat on WhatsApp')).not.toBeInTheDocument();
+    });
+
+    it('shows WhatsApp button for Voyager tier with whatsapp number', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, tier: 'voyager' }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.getByText('Chat on WhatsApp')).toBeInTheDocument();
+    });
+
+    it('hides WhatsApp button for Voyager tier without whatsapp number', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, tier: 'voyager', whatsapp: undefined }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.queryByText('Chat on WhatsApp')).not.toBeInTheDocument();
+    });
+
+    it('shows Recommended badge for Signature tier', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, tier: 'signature' }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.getByText('Recommended')).toBeInTheDocument();
+    });
+
+    it('hides Recommended badge for Explorer tier', () => {
+        render(
+            <DirectoryListingModal
+                listing={baseListing}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.queryByText('Recommended')).not.toBeInTheDocument();
+    });
+
+    it('renders video iframe when video_url is present', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, video_url: 'https://youtube.com/watch?v=abc123' }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        const iframe = screen.getByTitle('Listing video');
+        expect(iframe).toBeInTheDocument();
+        expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/abc123');
+    });
+
+    it('does not render video iframe when video_url is null', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, video_url: undefined }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        expect(screen.queryByTitle('Listing video')).not.toBeInTheDocument();
+    });
+
+    it('tracks website click', () => {
+        render(
+            <DirectoryListingModal
+                listing={baseListing}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        const websiteBtn = screen.getByText('Visit Website');
+        fireEvent.click(websiteBtn);
+        expect(mockDb.trackListingClick).toHaveBeenCalledWith('dir-1', 'website');
+    });
+
+    it('tracks map click', () => {
+        render(
+            <DirectoryListingModal
+                listing={baseListing}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        const mapBtn = screen.getByText('View on Map');
+        fireEvent.click(mapBtn);
+        expect(mockDb.trackListingClick).toHaveBeenCalledWith('dir-1', 'map');
+    });
+
+    it('tracks whatsapp click for paid tier', () => {
+        render(
+            <DirectoryListingModal
+                listing={{ ...baseListing, tier: 'voyager' }}
+                isOpen={true}
+                onClose={() => {}}
+            />
+        );
+        const whatsappBtn = screen.getByText('Chat on WhatsApp');
+        fireEvent.click(whatsappBtn);
+        expect(mockDb.trackListingClick).toHaveBeenCalledWith('dir-1', 'whatsapp');
+    });
+});

--- a/components/directory/DirectoryListingModal.tsx
+++ b/components/directory/DirectoryListingModal.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, Info } from 'lucide-react';
+import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, Info, Award } from 'lucide-react';
 import { DirectoryListingDB } from '../../types/models';
 import { Modal } from '../ui/Modal';
+import { db } from '../../api-services';
+import { parseVideoEmbed } from '../../utils/videoEmbed';
 
 interface DirectoryListingModalProps {
     listing: DirectoryListingDB | null;
@@ -11,6 +13,9 @@ interface DirectoryListingModalProps {
 
 export const DirectoryListingModal: React.FC<DirectoryListingModalProps> = ({ listing, isOpen, onClose }) => {
     if (!listing) return null;
+
+    const isPaidTier = (tier?: string) => tier && tier !== 'explorer';
+    const videoEmbed = listing.video_url ? parseVideoEmbed(listing.video_url) : null;
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} maxWidth="2xl" title={listing.name} lockBodyScroll={false}>
@@ -37,6 +42,11 @@ export const DirectoryListingModal: React.FC<DirectoryListingModalProps> = ({ li
                     {listing.is_verified && (
                         <div className="flex items-center gap-1 font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 px-3 py-1.5 rounded-lg">
                             <BadgeCheck size={16} /> Verified
+                        </div>
+                    )}
+                    {isPaidTier(listing.tier) && (
+                        <div className="flex items-center gap-1 font-medium bg-teal-50 dark:bg-teal-900/20 text-teal-600 dark:text-teal-400 px-3 py-1.5 rounded-lg">
+                            <Award size={16} /> Recommended
                         </div>
                     )}
                     <div className="flex items-center gap-1 font-medium bg-slate-100 dark:bg-slate-800 px-3 py-1.5 rounded-lg">
@@ -70,6 +80,22 @@ export const DirectoryListingModal: React.FC<DirectoryListingModalProps> = ({ li
                                 {listing.short_description}
                             </p>
                         </div>
+
+                        {videoEmbed && (
+                            <div className="space-y-2">
+                                <h4 className="font-semibold text-slate-900 dark:text-white text-sm">Video</h4>
+                                <div className="relative w-full rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800 aspect-video">
+                                    <iframe
+                                        src={videoEmbed.embedUrl}
+                                        title="Listing video"
+                                        className="absolute inset-0 w-full h-full border-0"
+                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                        allowFullScreen
+                                        loading="lazy"
+                                    />
+                                </div>
+                            </div>
+                        )}
 
                         {(listing.certifications?.length || listing.languages_spoken?.length) ? (
                             <div className="space-y-4">
@@ -119,25 +145,35 @@ export const DirectoryListingModal: React.FC<DirectoryListingModalProps> = ({ li
                             <h3 className="font-bold text-slate-900 dark:text-white mb-4">Contact provider</h3>
                             
                             <div className="space-y-3">
+                                {isPaidTier(listing.tier) && listing.whatsapp ? (
+                                    <button
+                                        onClick={() => {
+                                            db.trackListingClick(listing.id, 'whatsapp').catch(console.error);
+                                            window.open(`https://wa.me/${listing.whatsapp?.replace(/\D/g, '')}`, '_blank');
+                                        }}
+                                        className="w-full flex items-center justify-center gap-2 py-3.5 px-4 font-semibold rounded-xl bg-green-500 hover:bg-green-600 text-white shadow-sm hover:shadow transition-all"
+                                    >
+                                        <MessageCircle size={18} /> Chat on WhatsApp
+                                    </button>
+                                ) : null}
+
                                 <button
-                                    onClick={() => window.open(`https://wa.me/${listing.whatsapp?.replace(/\D/g, '')}`, '_blank')}
-                                    className={`w-full flex items-center justify-center gap-2 py-3.5 px-4 font-semibold rounded-xl transition-all ${listing.whatsapp ? 'bg-green-500 hover:bg-green-600 text-white shadow-sm hover:shadow' : 'bg-slate-100 dark:bg-slate-800 text-slate-400 cursor-not-allowed'}`}
-                                    disabled={!listing.whatsapp}
-                                >
-                                    <MessageCircle size={18} /> Chat on WhatsApp
-                                </button>
-                                
-                                <button
-                                    onClick={() => listing.website && window.open(listing.website, '_blank')}
+                                    onClick={() => {
+                                        if (listing.website) {
+                                            db.trackListingClick(listing.id, 'website').catch(console.error);
+                                            window.open(listing.website, '_blank');
+                                        }
+                                    }}
                                     className={`w-full flex items-center justify-center gap-2 py-3 px-4 font-semibold rounded-xl border border-slate-200 dark:border-slate-700 transition-all ${listing.website ? 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800' : 'text-slate-400 bg-slate-50 dark:bg-slate-800/30 cursor-not-allowed'}`}
                                     disabled={!listing.website}
                                 >
                                     <Globe size={18} /> Visit Website
                                 </button>
-                                
+
                                 <button
                                     className="w-full flex items-center justify-center gap-2 py-3 px-4 font-semibold rounded-xl border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-all"
                                     onClick={() => {
+                                        db.trackListingClick(listing.id, 'map').catch(console.error);
                                         if (listing.google_map_url) {
                                             window.open(listing.google_map_url, '_blank');
                                         } else {

--- a/components/layouts/HostLayout.tsx
+++ b/components/layouts/HostLayout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { LayoutDashboard, Home, Calendar, Inbox, LogOut, Menu, X, Plus, Car, Map as MapIcon } from 'lucide-react';
+import { LayoutDashboard, Home, Calendar, Inbox, LogOut, Menu, X, Plus, Car, Map as MapIcon, BarChart3 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { Button } from '../../components/ui/Button';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
@@ -33,6 +33,7 @@ export const HostLayout: React.FC<HostLayoutProps> = ({ children }) => {
         { path: '/host/properties', label: 'My Properties', icon: Home },
         { path: '/host/fleet', label: 'My Fleet', icon: Car },
         { path: '/host/services', label: 'My Services', icon: MapIcon },
+        { path: '/host/directory-analytics', label: 'Directory Analytics', icon: BarChart3 },
         { path: '/host/bookings', label: 'Reservations', icon: Calendar },
         { path: '/host/messages', label: 'Inbox', icon: Inbox },
     ];

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -29,6 +29,16 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
     const [showFullIntro, setShowFullIntro] = useState(false);
     const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
     const [selectedListing, setSelectedListing] = useState<DirectoryListingDB | null>(null);
+
+    const handleListingClick = useCallback((listing: DirectoryListingDB) => {
+        setSelectedListing(listing);
+
+        const sessionKey = `listing_view_${listing.id}_${new Date().toISOString().slice(0, 10)}`;
+        if (!sessionStorage.getItem(sessionKey)) {
+            sessionStorage.setItem(sessionKey, '1');
+            db.trackListingView(listing.id).catch(console.error);
+        }
+    }, []);
     const [viewMode, setViewMode] = useState<'list' | 'map'>('list');
 
     // Data State
@@ -364,7 +374,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                         <DirectoryListingCard
                                             key={listing.id}
                                             listing={listing}
-                                            onClick={setSelectedListing}
+                                            onClick={handleListingClick}
                                             userVote={userVotes[listing.id] ?? null}
                                             onVote={handleVote}
                                             isAuthenticated={isAuthenticated}
@@ -386,7 +396,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                         <DirectoryListingCard
                                             key={listing.id}
                                             listing={listing}
-                                            onClick={setSelectedListing}
+                                            onClick={handleListingClick}
                                             userVote={userVotes[listing.id] ?? null}
                                             onVote={handleVote}
                                             isAuthenticated={isAuthenticated}
@@ -406,7 +416,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                 ) : (
                     <DirectoryMapView
                         listings={filteredData}
-                        onListingClick={setSelectedListing}
+                        onListingClick={handleListingClick}
                     />
                 )}
 

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { db } from '../../api-services';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useSaveShortcut } from '../../hooks/useSaveShortcut';
+import { parseVideoEmbed } from '../../utils/videoEmbed';
 import toast from 'react-hot-toast';
 import { DirectoryListingDB } from '../../types/models';
 
@@ -33,6 +34,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
         website: '',
         whatsapp: '',
         google_map_url: '',
+        video_url: '',
         price_level: 2,
         reviews_average: 0.0,
         reviews_count: 0,
@@ -53,6 +55,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
                     website: listing.website || '',
                     whatsapp: listing.whatsapp || '',
                     google_map_url: listing.google_map_url || '',
+                    video_url: listing.video_url || '',
                     price_level: listing.price_level || 2,
                     reviews_average: listing.reviews_average || 0,
                     reviews_count: listing.reviews_count || 0,
@@ -131,6 +134,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
                 website: formData.website || undefined,
                 whatsapp: formData.whatsapp || undefined,
                 google_map_url: formData.google_map_url || undefined,
+                video_url: formData.video_url || undefined,
                 price_level: Number(formData.price_level) as 1 | 2 | 3 | 4,
                 reviews_average: Number(formData.reviews_average),
                 reviews_count: Number(formData.reviews_count),
@@ -223,6 +227,24 @@ export const AdminEditDirectoryPage: React.FC = () => {
                             onFilesChange={setFiles}
                             maxFiles={formData.tier === 'explorer' ? 5 : formData.tier === 'voyager' ? 50 : 100}
                         />
+
+                        <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-800/50">
+                            <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">Video</h2>
+                            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                                Video URL (YouTube or Vimeo)
+                            </label>
+                            <input
+                                type="url"
+                                name="video_url"
+                                value={formData.video_url}
+                                onChange={handleChange}
+                                className="w-full px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-900 focus:ring-2 focus:ring-teal-500 outline-none dark:text-white"
+                                placeholder="https://youtube.com/watch?v=..."
+                            />
+                            {formData.video_url && !parseVideoEmbed(formData.video_url) && (
+                                <p className="mt-2 text-xs text-red-500">Please enter a valid YouTube or Vimeo URL.</p>
+                            )}
+                        </div>
                     </div>
 
                     {/* Right Column - Status & Settings */}

--- a/pages/host/DirectoryAnalyticsPage.test.tsx
+++ b/pages/host/DirectoryAnalyticsPage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { DirectoryAnalyticsPage } from './DirectoryAnalyticsPage';
+import { ListingAnalyticsSummary } from '../../types/models';
+
+const { mockDb } = vi.hoisted(() => ({
+    mockDb: {
+        getDirectoryAnalyticsForOwner: vi.fn(),
+    }
+}));
+
+vi.mock('../../api-services', () => ({
+    db: mockDb
+}));
+
+const mockAnalytics: ListingAnalyticsSummary[] = [
+    {
+        listing_id: 'dir-1',
+        listing_name: 'Test Clinic',
+        total_views: 150,
+        total_whatsapp_clicks: 12,
+        total_website_clicks: 8,
+        total_map_clicks: 5,
+        daily_data: [
+            { date: '2026-05-23', views: 10, whatsapp_clicks: 1, website_clicks: 0, map_clicks: 0 },
+            { date: '2026-05-24', views: 20, whatsapp_clicks: 2, website_clicks: 1, map_clicks: 1 },
+        ]
+    }
+];
+
+describe('DirectoryAnalyticsPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows loading state initially', () => {
+        mockDb.getDirectoryAnalyticsForOwner.mockReturnValue(new Promise(() => {}));
+        render(<DirectoryAnalyticsPage />);
+        expect(screen.getByText('Loading analytics...')).toBeInTheDocument();
+    });
+
+    it('renders summary cards with correct totals', async () => {
+        mockDb.getDirectoryAnalyticsForOwner.mockResolvedValue(mockAnalytics);
+        render(<DirectoryAnalyticsPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText('150')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Views')).toBeInTheDocument();
+        expect(screen.getByText('12')).toBeInTheDocument();
+        expect(screen.getByText('WhatsApp')).toBeInTheDocument();
+        expect(screen.getByText('8')).toBeInTheDocument();
+        expect(screen.getByText('Website')).toBeInTheDocument();
+        expect(screen.getByText('5')).toBeInTheDocument();
+        expect(screen.getByText('Map')).toBeInTheDocument();
+    });
+
+    it('renders chart section when daily data exists', async () => {
+        mockDb.getDirectoryAnalyticsForOwner.mockResolvedValue(mockAnalytics);
+        render(<DirectoryAnalyticsPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Daily Activity')).toBeInTheDocument();
+        });
+
+        // Verify the chart container div is present (ResponsiveContainer needs real DOM dimensions)
+        const chartSection = screen.getByText('Daily Activity').closest('div')?.parentElement;
+        expect(chartSection).toBeInTheDocument();
+    });
+
+    it('shows empty state when no listings', async () => {
+        mockDb.getDirectoryAnalyticsForOwner.mockResolvedValue([]);
+        render(<DirectoryAnalyticsPage />);
+
+        await waitFor(() => {
+            expect(screen.getByText('No Analytics Yet')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText(/Upgrade to Voyager to start tracking performance/)).toBeInTheDocument();
+        expect(screen.getByText('List Your Business')).toHaveAttribute('href', '/list-business');
+    });
+
+    it('shows dropdown when multiple listings', async () => {
+        const multi = [
+            ...mockAnalytics,
+            {
+                listing_id: 'dir-2',
+                listing_name: 'Second Clinic',
+                total_views: 50,
+                total_whatsapp_clicks: 5,
+                total_website_clicks: 3,
+                total_map_clicks: 2,
+                daily_data: []
+            }
+        ];
+        mockDb.getDirectoryAnalyticsForOwner.mockResolvedValue(multi);
+        render(<DirectoryAnalyticsPage />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('combobox')).toBeInTheDocument();
+        });
+
+        expect(screen.getByRole('combobox')).toHaveValue('0');
+        expect(screen.getByText('Test Clinic')).toBeInTheDocument();
+        expect(screen.getByText('Second Clinic')).toBeInTheDocument();
+    });
+});

--- a/pages/host/DirectoryAnalyticsPage.tsx
+++ b/pages/host/DirectoryAnalyticsPage.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { BarChart3, Eye, MessageCircle, Globe, MapPin, ArrowRight } from 'lucide-react';
+import { db } from '../../api-services';
+import { ListingAnalyticsSummary } from '../../types/models';
+import toast from 'react-hot-toast';
+import {
+    ResponsiveContainer,
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    Tooltip,
+    Legend,
+    CartesianGrid
+} from 'recharts';
+
+export const DirectoryAnalyticsPage: React.FC = () => {
+    const [analytics, setAnalytics] = useState<ListingAnalyticsSummary[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    useEffect(() => {
+        db.getDirectoryAnalyticsForOwner(30)
+            .then(data => {
+                setAnalytics(data);
+                setSelectedIndex(0);
+            })
+            .catch(err => {
+                console.error(err);
+                toast.error('Failed to load analytics');
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    const selected = analytics[selectedIndex];
+
+    const chartData = useMemo(() => {
+        if (!selected) return [];
+        return selected.daily_data.map(day => ({
+            name: new Date(day.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+            views: day.views,
+            whatsapp: day.whatsapp_clicks,
+            website: day.website_clicks,
+            map: day.map_clicks,
+        }));
+    }, [selected]);
+
+    const summaryCards = selected ? [
+        { label: 'Views', value: selected.total_views, icon: Eye, color: 'text-teal-600', bg: 'bg-teal-50 dark:bg-teal-900/20' },
+        { label: 'WhatsApp', value: selected.total_whatsapp_clicks, icon: MessageCircle, color: 'text-green-600', bg: 'bg-green-50 dark:bg-green-900/20' },
+        { label: 'Website', value: selected.total_website_clicks, icon: Globe, color: 'text-blue-600', bg: 'bg-blue-50 dark:bg-blue-900/20' },
+        { label: 'Map', value: selected.total_map_clicks, icon: MapPin, color: 'text-slate-600', bg: 'bg-slate-50 dark:bg-slate-800' },
+    ] : [];
+
+    if (loading) {
+        return (
+            <div className="min-h-[60vh] flex items-center justify-center">
+                <div className="animate-pulse text-slate-400">Loading analytics...</div>
+            </div>
+        );
+    }
+
+    if (analytics.length === 0) {
+        return (
+            <div className="max-w-4xl mx-auto">
+                <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-100 dark:border-slate-800 p-12 text-center">
+                    <BarChart3 className="w-16 h-16 text-slate-300 dark:text-slate-600 mx-auto mb-4" />
+                    <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-2">No Analytics Yet</h2>
+                    <p className="text-slate-500 dark:text-slate-400 mb-6">
+                        You don't have any directory listings with active subscriptions. Upgrade to Voyager to start tracking performance.
+                    </p>
+                    <a
+                        href="/list-business"
+                        className="inline-flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-5 py-2.5 rounded-xl font-semibold transition-colors"
+                    >
+                        List Your Business <ArrowRight size={16} />
+                    </a>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-5xl mx-auto space-y-8">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Directory Analytics</h1>
+                    <p className="text-slate-500 dark:text-slate-400 mt-1">Last 30 days performance</p>
+                </div>
+                {analytics.length > 1 && (
+                    <select
+                        value={selectedIndex}
+                        onChange={e => setSelectedIndex(Number(e.target.value))}
+                        className="px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-900 dark:text-white focus:ring-2 focus:ring-teal-500 outline-none"
+                    >
+                        {analytics.map((item, idx) => (
+                            <option key={item.listing_id} value={idx}>{item.listing_name}</option>
+                        ))}
+                    </select>
+                )}
+            </div>
+
+            {selected && (
+                <>
+                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                        {summaryCards.map(card => {
+                            const Icon = card.icon;
+                            return (
+                                <div
+                                    key={card.label}
+                                    className="bg-white dark:bg-slate-800 rounded-2xl p-5 border border-slate-100 dark:border-slate-800 shadow-sm"
+                                >
+                                    <div className={`w-10 h-10 rounded-xl ${card.bg} flex items-center justify-center mb-3`}>
+                                        <Icon size={20} className={card.color} />
+                                    </div>
+                                    <div className="text-2xl font-bold text-slate-900 dark:text-white">
+                                        {card.value.toLocaleString()}
+                                    </div>
+                                    <div className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">{card.label}</div>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    <div className="bg-white dark:bg-slate-800 rounded-2xl p-6 border border-slate-100 dark:border-slate-800 shadow-sm">
+                        <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-6">Daily Activity</h2>
+                        {chartData.length > 0 ? (
+                            <div className="h-80">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <BarChart data={chartData}>
+                                        <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                                        <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                                        <YAxis tick={{ fontSize: 12 }} />
+                                        <Tooltip
+                                            contentStyle={{
+                                                backgroundColor: 'rgba(255,255,255,0.95)',
+                                                borderRadius: '12px',
+                                                border: '1px solid #e2e8f0',
+                                                boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)'
+                                            }}
+                                        />
+                                        <Legend />
+                                        <Bar dataKey="views" name="Views" fill="#0d9488" radius={[4, 4, 0, 0]} />
+                                        <Bar dataKey="whatsapp" name="WhatsApp" fill="#16a34a" radius={[4, 4, 0, 0]} />
+                                        <Bar dataKey="website" name="Website" fill="#2563eb" radius={[4, 4, 0, 0]} />
+                                        <Bar dataKey="map" name="Map" fill="#64748b" radius={[4, 4, 0, 0]} />
+                                    </BarChart>
+                                </ResponsiveContainer>
+                            </div>
+                        ) : (
+                            <div className="text-center py-12 text-slate-400">No activity recorded yet.</div>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -82,6 +82,7 @@ const HostEditServicePage = React.lazy(() => import('../pages/host/HostEditServi
 const HostBookingsPage = React.lazy(() => import('../pages/host/HostBookingsPage').then(module => ({ default: module.HostBookingsPage })));
 const HostCalendarPage = React.lazy(() => import('../pages/host/HostCalendarPage').then(module => ({ default: module.HostCalendarPage })));
 const HostMessagesPage = React.lazy(() => import('../pages/host/HostMessagesPage').then(module => ({ default: module.HostMessagesPage })));
+const DirectoryAnalyticsPage = React.lazy(() => import('../pages/host/DirectoryAnalyticsPage').then(module => ({ default: module.DirectoryAnalyticsPage })));
 
 
 export const AppRoutes: React.FC = () => {
@@ -233,6 +234,13 @@ export const AppRoutes: React.FC = () => {
                     <HostRoute>
                         <HostLayout>
                             <HostMessagesPage />
+                        </HostLayout>
+                    </HostRoute>
+                } />
+                <Route path="/host/directory-analytics" element={
+                    <HostRoute>
+                        <HostLayout>
+                            <DirectoryAnalyticsPage />
                         </HostLayout>
                     </HostRoute>
                 } />

--- a/supabase/migrations/20260525000000_voyager_tier_analytics.sql
+++ b/supabase/migrations/20260525000000_voyager_tier_analytics.sql
@@ -1,0 +1,152 @@
+-- LST-004: Voyager Tier Feature Set
+-- Adds video_url to directory_listings, creates listing_analytics table,
+-- and provides RPC functions for tracking views, clicks, and fetching owner analytics.
+
+-- ============================================================
+-- 1. Add video_url to directory_listings
+-- ============================================================
+ALTER TABLE public.directory_listings
+    ADD COLUMN IF NOT EXISTS video_url TEXT;
+
+-- ============================================================
+-- 2. Create listing_analytics table (daily aggregation)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.listing_analytics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    listing_id UUID NOT NULL REFERENCES public.directory_listings(id) ON DELETE CASCADE,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
+    views INT NOT NULL DEFAULT 0,
+    whatsapp_clicks INT NOT NULL DEFAULT 0,
+    website_clicks INT NOT NULL DEFAULT 0,
+    map_clicks INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE(listing_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_listing_analytics_listing_date
+    ON public.listing_analytics(listing_id, date DESC);
+
+ALTER TABLE public.listing_analytics ENABLE ROW LEVEL SECURITY;
+
+-- Owners can read analytics for their own listings (via subscription_id -> premium_subscriptions.user_id)
+-- Admins can read all analytics
+CREATE POLICY "listing_analytics: owner read via subscription"
+    ON public.listing_analytics FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.directory_listings dl
+            JOIN public.premium_subscriptions ps ON ps.id = dl.subscription_id
+            WHERE dl.id = listing_analytics.listing_id
+              AND ps.user_id = auth.uid()
+        )
+        OR
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = auth.uid() AND role = 'admin'
+        )
+    );
+
+-- ============================================================
+-- 3. RPC: track listing view (atomic increment)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.track_listing_view(p_listing_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO public.listing_analytics (listing_id, date, views, whatsapp_clicks, website_clicks, map_clicks)
+    VALUES (p_listing_id, CURRENT_DATE, 1, 0, 0, 0)
+    ON CONFLICT (listing_id, date) DO UPDATE
+    SET views = public.listing_analytics.views + 1;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.track_listing_view(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.track_listing_view(UUID) TO anon, authenticated;
+
+-- ============================================================
+-- 4. RPC: track listing click (atomic increment)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.track_listing_click(p_listing_id UUID, p_click_type TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF p_click_type NOT IN ('whatsapp', 'website', 'map') THEN
+        RAISE EXCEPTION 'Invalid click type: %', p_click_type;
+    END IF;
+
+    INSERT INTO public.listing_analytics (listing_id, date, views, whatsapp_clicks, website_clicks, map_clicks)
+    VALUES (p_listing_id, CURRENT_DATE, 0, 0, 0, 0)
+    ON CONFLICT (listing_id, date) DO NOTHING;
+
+    UPDATE public.listing_analytics
+    SET
+        whatsapp_clicks = whatsapp_clicks + CASE WHEN p_click_type = 'whatsapp' THEN 1 ELSE 0 END,
+        website_clicks = website_clicks + CASE WHEN p_click_type = 'website' THEN 1 ELSE 0 END,
+        map_clicks = map_clicks + CASE WHEN p_click_type = 'map' THEN 1 ELSE 0 END
+    WHERE listing_id = p_listing_id AND date = CURRENT_DATE;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.track_listing_click(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.track_listing_click(UUID, TEXT) TO anon, authenticated;
+
+-- ============================================================
+-- 5. RPC: get analytics for owner (aggregated, last N days)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_directory_analytics_for_owner(
+    p_owner_id UUID,
+    p_days INT DEFAULT 30
+)
+RETURNS TABLE (
+    listing_id UUID,
+    listing_name TEXT,
+    total_views BIGINT,
+    total_whatsapp_clicks BIGINT,
+    total_website_clicks BIGINT,
+    total_map_clicks BIGINT,
+    daily_data JSONB
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        dl.id AS listing_id,
+        dl.name AS listing_name,
+        COALESCE(SUM(la.views), 0)::BIGINT AS total_views,
+        COALESCE(SUM(la.whatsapp_clicks), 0)::BIGINT AS total_whatsapp_clicks,
+        COALESCE(SUM(la.website_clicks), 0)::BIGINT AS total_website_clicks,
+        COALESCE(SUM(la.map_clicks), 0)::BIGINT AS total_map_clicks,
+        COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'date', la.date,
+                    'views', la.views,
+                    'whatsapp_clicks', la.whatsapp_clicks,
+                    'website_clicks', la.website_clicks,
+                    'map_clicks', la.map_clicks
+                ) ORDER BY la.date
+            ) FILTER (WHERE la.date IS NOT NULL),
+            '[]'::jsonb
+        ) AS daily_data
+    FROM public.directory_listings dl
+    JOIN public.premium_subscriptions ps ON ps.id = dl.subscription_id
+    LEFT JOIN public.listing_analytics la
+        ON la.listing_id = dl.id AND la.date >= (CURRENT_DATE - p_days)
+    WHERE ps.user_id = p_owner_id
+    GROUP BY dl.id, dl.name
+    ORDER BY total_views DESC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_directory_analytics_for_owner(UUID, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_directory_analytics_for_owner(UUID, INT) TO authenticated;

--- a/types/models.ts
+++ b/types/models.ts
@@ -432,6 +432,7 @@ export interface DirectoryListingDB {
   certifications?: string[];
   location: string;
   google_map_url?: string;
+  video_url?: string;
   price_level?: 1 | 2 | 3 | 4;
   net_votes?: number;
   created_at?: string;
@@ -510,4 +511,26 @@ export interface BlogSubmission {
 
   // Virtual / joined
   user?: { full_name: string | null; email: string | null };
+}
+
+// ============================================================
+// Listing Analytics (LST-004)
+// ============================================================
+
+export interface ListingAnalyticsDaily {
+  date: string;
+  views: number;
+  whatsapp_clicks: number;
+  website_clicks: number;
+  map_clicks: number;
+}
+
+export interface ListingAnalyticsSummary {
+  listing_id: string;
+  listing_name: string;
+  total_views: number;
+  total_whatsapp_clicks: number;
+  total_website_clicks: number;
+  total_map_clicks: number;
+  daily_data: ListingAnalyticsDaily[];
 }


### PR DESCRIPTION
## Summary

Implements the complete Voyager tier feature set (LST-004), the final task from Phase 1.

### Changes

1. **Analytics infrastructure**
   - New migration: `listing_analytics` table with daily aggregation (views, whatsapp/website/map clicks)
   - 3 RPCs: `track_listing_view`, `track_listing_click`, `get_directory_analytics_for_owner`
   - RLS policy: owners read via `subscription_id -> premium_subscriptions.user_id` join
   - Session-deduplicated view tracking via `sessionStorage`

2. **Recommended badge**
   - Visible for all paid tiers (Voyager, Signature, Partner)
   - Rendered in card image overlay and modal subinfo row

3. **Video embed**
   - `video_url` column added to `directory_listings`
   - Reuses existing `parseVideoEmbed` utility (YouTube/Vimeo)
   - Rendered in modal between About and Certifications sections
   - Admin edit form includes video URL input with validation

4. **WhatsApp gating**
   - Hidden for Explorer tier; visible only for paid tiers with a WhatsApp number
   - Applied to both card CTAs and modal contact section

5. **Analytics dashboard**
   - New `DirectoryAnalyticsPage` at `/host/directory-analytics`
   - Summary cards (Views, WhatsApp, Website, Map) + recharts BarChart with 30-day daily breakdown
   - Empty state with CTA to `/list-business`
   - Added to `HostLayout` navigation

6. **Tests**
   - `DirectoryListingCard.test.tsx` (6 tests): tier-gated WhatsApp, Recommended badge, click tracking
   - `DirectoryListingModal.test.tsx` (10 tests): WhatsApp gating, badge, video iframe, click tracking
   - `DirectoryAnalyticsPage.test.tsx` (5 tests): loading, summary cards, chart section, empty state, multi-listing dropdown
   - `directory.test.ts` additions: `trackListingView`, `trackListingClick`, `getDirectoryAnalyticsForOwner`

## Key architectural decisions

- Owner lookup uses existing `subscription_id -> premium_subscriptions.user_id` relationship; no new `owner_id` column needed
- Click tracking is fire-and-forget (`console.error` on failure) to avoid blocking UX
- `video_url` is sanitized and truncated to 500 chars on create, passes through on update

## Testing notes

- `tsc --noEmit`: 0 errors
- `npm run lint`: 0 warnings
- `npm test`: 1,402 passed
- `npm run build`: passes

## Potential risks

- `listing_analytics` RPCs use `SECURITY DEFINER` with `SET search_path = public`
- `recharts` `ResponsiveContainer` needs parent dimensions; tested in real browser, jsdom skips SVG rendering