### PR TITLE
fix: critical access control security fixes

### DIFF
--- a/api-services/api/subscriptions.ts
+++ b/api-services/api/subscriptions.ts
@@ -31,7 +31,7 @@ export const subscriptionsService = {
     }
 
     return {
-      isPremium: data.status === 'active',
+      isPremium: data.status === 'active' || data.status === 'trialing',
       tier: (data.tier as SubscriptionTier | null) ?? null,
       plan: data.plan as 'monthly' | 'annual' | null,
       currentPeriodEnd: data.current_period_end,

--- a/pages/booking/Success.tsx
+++ b/pages/booking/Success.tsx
@@ -33,10 +33,17 @@ export const BookingSuccess: React.FC = () => {
             }
 
             try {
+                const { data: { user } } = await supabase.auth.getUser();
+                if (!user) {
+                    navigate('/');
+                    return;
+                }
+
                 const { data, error } = await supabase
                     .from('bookings')
                     .select('id, status, payment_status, check_in, check_out, total_price')
                     .eq('stripe_session_id', sessionId)
+                    .eq('user_id', user.id)
                     .single();
 
                 if (error || !data) {

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -119,7 +119,7 @@ export const AppRoutes: React.FC = () => {
 
                 <Route path="/search-results" element={<SearchResultsPage />} />
                 <Route path="/stays" element={<SearchResultsPage />} />
-                <Route path="/favorites" element={<FavoritesPage />} />
+                <Route path="/favorites" element={<AuthRoute><FavoritesPage /></AuthRoute>} />
                 <Route path="/property/:id" element={<PropertyDetails />} />
                 <Route path="/blog" element={<BlogPage />} />
                 <Route path="/blog/submit" element={<AuthRoute><BlogSubmitPage /></AuthRoute>} />
@@ -159,14 +159,14 @@ export const AppRoutes: React.FC = () => {
                         <AddService />
                     </HostRoute>
                 } />
-                <Route path="/bookmarks" element={<FavoritesPage />} />
+                <Route path="/bookmarks" element={<AuthRoute><FavoritesPage /></AuthRoute>} />
                 <Route path="/book-vehicle/:id" element={<AuthRoute><BookVehicle /></AuthRoute>} />
                 <Route path="/book-tour/:id" element={<AuthRoute><BookTour /></AuthRoute>} />
                 <Route path="/book-wellness/:id" element={<AuthRoute><BookWellness /></AuthRoute>} />
                 <Route path="/inbox" element={<AuthRoute><InboxPage /></AuthRoute>} />
 
                 {/* Host Routes - Protected */}
-                <Route path="/booking/success" element={<BookingSuccess />} />
+                <Route path="/booking/success" element={<AuthRoute><BookingSuccess /></AuthRoute>} />
                 <Route path="/host" element={
                     <HostRoute>
                         <HostLayout>

--- a/supabase/functions/generate-sitemap/index.ts
+++ b/supabase/functions/generate-sitemap/index.ts
@@ -5,8 +5,9 @@ declare const Deno: any
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const CRON_SECRET = Deno.env.get('CRON_SECRET')
 
-const BASE_URL = 'https://alanya-holidays.com'
+const BASE_URL = 'https://alanyaholidays.com'
 
 interface SitemapUrl {
   loc: string
@@ -43,6 +44,14 @@ Deno.serve(async (req: Request) => {
         'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
       },
     })
+  }
+
+  const reqSecret = req.headers.get('x-cron-secret')
+  if (!CRON_SECRET || reqSecret !== CRON_SECRET) {
+    return new Response(
+      JSON.stringify({ error: 'Unauthorized' }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } }
+    )
   }
 
   try {

--- a/supabase/migrations/20260524000001_fix_is_premium_trialing.sql
+++ b/supabase/migrations/20260524000001_fix_is_premium_trialing.sql
@@ -1,0 +1,23 @@
+-- Fix is_premium() to include trialing subscriptions so trial users can access premium features
+CREATE OR REPLACE FUNCTION public.is_premium(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    exists_result BOOLEAN;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM public.premium_subscriptions
+        WHERE user_id = p_user_id
+          AND (status = 'active' OR status = 'trialing')
+          AND current_period_end > NOW()
+    ) INTO exists_result;
+
+    RETURN COALESCE(exists_result, FALSE);
+END;
+$$;
+
+-- Re-apply grants (idempotent)
+GRANT EXECUTE ON FUNCTION public.is_premium(UUID) TO authenticated;

--- a/supabase/migrations/20260524000002_fix_testimonials_admin_policy.sql
+++ b/supabase/migrations/20260524000002_fix_testimonials_admin_policy.sql
@@ -1,0 +1,9 @@
+-- Replace the insecure platform_testimonials admin policy that trusts JWT claims
+-- with the canonical is_admin() function used everywhere else in the schema.
+DROP POLICY IF EXISTS "Admins have full access to testimonials" ON public.platform_testimonials;
+
+CREATE POLICY "Admins have full access to testimonials" ON public.platform_testimonials
+    AS PERMISSIVE FOR ALL
+    TO authenticated
+    USING ((SELECT public.is_admin()))
+    WITH CHECK ((SELECT public.is_admin()));


### PR DESCRIPTION
## Summary

Fixes 5 critical/high security audit items:

- **C1** — `is_premium()` now recognizes `trialing` status so trial users can access premium features (AI Planner). `getPremiumStatus()` in `subscriptions.ts` updated accordingly.
- **C2** — `platform_testimonials` admin RLS policy now uses `public.is_admin()` instead of trusting the `auth.jwt() ->> 'role'` claim.
- **C3** — `generate-sitemap` Edge Function now requires `x-cron-secret` header (matching other cron functions). Also corrected `BASE_URL` from `alanya-holidays.com` to `alanyaholidays.com`.
- **H2** — `/booking/success` is now wrapped in `AuthRoute` and the query filters by `user_id` to prevent data leaks.
- **H3** — `/favorites` and `/bookmarks` routes are now wrapped in `AuthRoute` for consistent auth behavior.

## Testing

- TypeScript: 0 errors
- Build: passes
- Manual verification: sitemap auth check tested via cURL pattern

## Risks

- C1 expands premium access to trialing users (intended behavior fix)
- C2 changes admin policy evaluation path — verify admin panel testimonials CRUD still works
- C3 requires `CRON_SECRET` to be set in Supabase Edge Function secrets before deploy
- H2 may break if Stripe redirect flow strips auth state (unlikely since Checkout is already behind AuthRoute)