### PR TITLE
fix: add missing unit tests and harden CSP policy

### DIFF
--- a/api-services/api/locations.test.ts
+++ b/api-services/api/locations.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { locationsService } from './locations';
+
+const { mockSupabase } = vi.hoisted(() => {
+  return {
+    mockSupabase: {
+      from: vi.fn(),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' } }, error: null }),
+      },
+      functions: {
+        invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+    },
+  };
+});
+
+vi.mock('../supabase', () => ({
+  supabase: mockSupabase,
+}));
+
+describe('locationsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createMockChain = (data: any = null, error: any = null) => {
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] : data, error }),
+      maybeSingle: vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] : data, error }),
+      then: (resolve: any) => resolve({ data, count: error ? 0 : 1, error }),
+    };
+    return chain;
+  };
+
+  describe('getLocations', () => {
+    it('returns array of active locations ordered by display_order', async () => {
+      const mockData = [
+        { id: '1', name: 'Alanya Center', is_active: true, display_order: 1, parent_region: 'Alanya' },
+        { id: '2', name: 'Mahmutlar', is_active: true, display_order: 2, parent_region: 'Alanya' },
+      ];
+      mockSupabase.from.mockReturnValue(createMockChain(mockData));
+      const result = await locationsService.getLocations();
+      expect(result).toEqual(mockData);
+      expect(mockSupabase.from).toHaveBeenCalledWith('locations');
+    });
+
+    it('returns empty array when no locations found', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain([]));
+      const result = await locationsService.getLocations();
+      expect(result).toEqual([]);
+    });
+
+    it('throws Failed to fetch locations on error', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain(null, new Error('DB connection lost')));
+      await expect(locationsService.getLocations()).rejects.toThrow('Failed to fetch locations');
+    });
+  });
+
+  describe('getLocationsByRegion', () => {
+    it('returns filtered locations for Antalya City', async () => {
+      const mockData = [{ id: '3', name: 'Konyaalti', is_active: true, display_order: 1, parent_region: 'Antalya City' }];
+      mockSupabase.from.mockReturnValue(createMockChain(mockData));
+      const result = await locationsService.getLocationsByRegion('Antalya City');
+      expect(result).toEqual(mockData);
+      expect(mockSupabase.from).toHaveBeenCalledWith('locations');
+    });
+
+    it('returns filtered locations for Alanya', async () => {
+      const mockData = [
+        { id: '1', name: 'Alanya Center', is_active: true, display_order: 1, parent_region: 'Alanya' },
+        { id: '2', name: 'Mahmutlar', is_active: true, display_order: 2, parent_region: 'Alanya' },
+      ];
+      mockSupabase.from.mockReturnValue(createMockChain(mockData));
+      const result = await locationsService.getLocationsByRegion('Alanya');
+      expect(result).toEqual(mockData);
+    });
+
+    it('returns filtered locations for Other', async () => {
+      const mockData = [{ id: '4', name: 'Side', is_active: true, display_order: 1, parent_region: 'Other' }];
+      mockSupabase.from.mockReturnValue(createMockChain(mockData));
+      const result = await locationsService.getLocationsByRegion('Other');
+      expect(result).toEqual(mockData);
+    });
+
+    it('throws Failed to fetch locations on error', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain(null, new Error('DB error')));
+      await expect(locationsService.getLocationsByRegion('Alanya')).rejects.toThrow('Failed to fetch locations');
+    });
+
+    it('returns empty array when no locations match region', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain([]));
+      const result = await locationsService.getLocationsByRegion('Antalya City');
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/api-services/api/subscriptions.test.ts
+++ b/api-services/api/subscriptions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { subscriptionsService } from './subscriptions';
+
+const { mockSupabase } = vi.hoisted(() => {
+  return {
+    mockSupabase: {
+      from: vi.fn(),
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' } }, error: null }),
+      },
+      functions: {
+        invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+    },
+  };
+});
+
+vi.mock('../supabase', () => ({
+  supabase: mockSupabase,
+}));
+
+describe('subscriptionsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' } }, error: null,
+    });
+  });
+
+  const createMockChain = (data: any = null, error: any = null) => {
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] : data, error }),
+      maybeSingle: vi.fn().mockResolvedValue({ data: Array.isArray(data) ? data[0] : data, error }),
+      then: (resolve: any) => resolve({ data, count: error ? 0 : 1, error }),
+    };
+    return chain;
+  };
+
+  describe('getPremiumStatus', () => {
+    it('returns default non-premium when user is not authenticated', async () => {
+      mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      const result = await subscriptionsService.getPremiumStatus();
+      expect(result.isPremium).toBe(false);
+      expect(result.tier).toBeNull();
+      expect(result.plan).toBeNull();
+      expect(result.currentPeriodEnd).toBeNull();
+      expect(result.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it('returns premium true for active status', async () => {
+      mockSupabase.from.mockReturnValue(
+        createMockChain({
+          tier: 'voyager',
+          plan: 'monthly',
+          status: 'active',
+          current_period_end: '2025-12-31',
+          cancel_at_period_end: false,
+        })
+      );
+      const result = await subscriptionsService.getPremiumStatus();
+      expect(result.isPremium).toBe(true);
+      expect(result.tier).toBe('voyager');
+      expect(result.plan).toBe('monthly');
+      expect(result.currentPeriodEnd).toBe('2025-12-31');
+      expect(result.cancelAtPeriodEnd).toBe(false);
+    });
+
+    it('returns premium true for trialing status', async () => {
+      mockSupabase.from.mockReturnValue(
+        createMockChain({
+          tier: 'signature',
+          plan: 'annual',
+          status: 'trialing',
+          current_period_end: '2025-06-30',
+          cancel_at_period_end: true,
+        })
+      );
+      const result = await subscriptionsService.getPremiumStatus();
+      expect(result.isPremium).toBe(true);
+      expect(result.tier).toBe('signature');
+      expect(result.plan).toBe('annual');
+      expect(result.cancelAtPeriodEnd).toBe(true);
+    });
+
+    it('returns non-premium when subscription query errors', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain(null, new Error('DB error')));
+      const result = await subscriptionsService.getPremiumStatus();
+      expect(result.isPremium).toBe(false);
+      expect(result.tier).toBeNull();
+    });
+
+    it('returns non-premium when no subscription record exists', async () => {
+      mockSupabase.from.mockReturnValue(createMockChain(null));
+      const result = await subscriptionsService.getPremiumStatus();
+      expect(result.isPremium).toBe(false);
+      expect(result.tier).toBeNull();
+    });
+  });
+
+  describe('createSubscriptionCheckout', () => {
+    it('throws Not authenticated when user is null', async () => {
+      mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: null });
+      await expect(subscriptionsService.createSubscriptionCheckout('monthly')).rejects.toThrow('Not authenticated');
+    });
+
+    it('returns url on successful invoke', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { url: 'https://checkout.stripe.com/test' }, error: null });
+      const result = await subscriptionsService.createSubscriptionCheckout('annual', 'voyager');
+      expect(result.url).toBe('https://checkout.stripe.com/test');
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('create-subscription-checkout', {
+        body: { plan: 'annual', tier: 'voyager' },
+      });
+    });
+
+    it('throws when invoke returns an error', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: null, error: new Error('Invoke failed') });
+      await expect(subscriptionsService.createSubscriptionCheckout('monthly')).rejects.toThrow('Invoke failed');
+    });
+
+    it('throws when data.error is present', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { error: 'Plan invalid' }, error: null });
+      await expect(subscriptionsService.createSubscriptionCheckout('monthly')).rejects.toThrow('Plan invalid');
+    });
+
+    it('throws when no url is returned', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: {}, error: null });
+      await expect(subscriptionsService.createSubscriptionCheckout('monthly')).rejects.toThrow('No checkout URL returned');
+    });
+  });
+
+  describe('cancelSubscription', () => {
+    it('returns success true on successful invoke', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { success: true }, error: null });
+      const result = await subscriptionsService.cancelSubscription();
+      expect(result.success).toBe(true);
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('cancel-subscription', { body: {} });
+    });
+
+    it('throws when invoke returns an error', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: null, error: new Error('Cancel failed') });
+      await expect(subscriptionsService.cancelSubscription()).rejects.toThrow('Cancel failed');
+    });
+
+    it('throws when data.error is present', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { error: 'No active subscription' }, error: null });
+      await expect(subscriptionsService.cancelSubscription()).rejects.toThrow('No active subscription');
+    });
+  });
+
+  describe('getSubscriptionPortalUrl', () => {
+    it('returns url on successful invoke', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { url: 'https://billing.stripe.com/portal' }, error: null });
+      const result = await subscriptionsService.getSubscriptionPortalUrl();
+      expect(result.url).toBe('https://billing.stripe.com/portal');
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('get-subscription-portal', { body: {} });
+    });
+
+    it('throws when invoke returns an error', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: null, error: new Error('Portal failed') });
+      await expect(subscriptionsService.getSubscriptionPortalUrl()).rejects.toThrow('Portal failed');
+    });
+
+    it('throws when data.error is present', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: { error: 'No customer' }, error: null });
+      await expect(subscriptionsService.getSubscriptionPortalUrl()).rejects.toThrow('No customer');
+    });
+
+    it('throws when no url is returned', async () => {
+      mockSupabase.functions.invoke.mockResolvedValueOnce({ data: {}, error: null });
+      await expect(subscriptionsService.getSubscriptionPortalUrl()).rejects.toThrow('No portal URL returned');
+    });
+  });
+});

--- a/components/ai/TripItinerary.tsx
+++ b/components/ai/TripItinerary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Clock, MapPin, ExternalLink, Star, ChevronRight, Share2, Download } from 'lucide-react';
 import { useLanguage } from '../../context/LanguageContext';
+import '../../print-itinerary.css';
 
 export interface ItineraryItem {
     time: string;
@@ -46,50 +47,6 @@ export const TripItinerary: React.FC<Props> = ({ itinerary }) => {
 
     return (
         <div className="max-w-4xl mx-auto py-12 px-4 print:py-0 print:px-0">
-            {/* Print-only CSS */}
-            <style dangerouslySetInnerHTML={{ __html: `
-                @media print {
-                    nav, footer, .no-print, button, .print-hidden {
-                        display: none !important;
-                    }
-                    body {
-                        background: white !important;
-                        color: black !important;
-                        -webkit-print-color-adjust: exact;
-                        print-color-adjust: exact;
-                    }
-                    .print-header {
-                        display: flex !important;
-                        align-items: center;
-                        justify-content: space-between;
-                        padding: 40px 0;
-                        border-bottom: 2px solid #f1f5f9;
-                        margin-bottom: 40px;
-                    }
-                    .print-footer {
-                        display: block !important;
-                        text-align: center;
-                        padding: 40px 0;
-                        border-top: 1px solid #f1f5f9;
-                        margin-top: 60px;
-                        font-size: 12px;
-                        color: #64748b;
-                    }
-                    .itinerary-card {
-                        break-inside: avoid;
-                        border: 1px solid #e2e8f0 !important;
-                        box-shadow: none !important;
-                        background: #f8fafc !important;
-                    }
-                    .day-marker {
-                        background: #0f172a !important;
-                        color: white !important;
-                        -webkit-print-color-adjust: exact;
-                    }
-                }
-                .print-header, .print-footer { display: none; }
-            `}} />
-            
             {/* Print Header */}
             <div className="print-header">
                 <div className="flex items-center gap-3">

--- a/print-itinerary.css
+++ b/print-itinerary.css
@@ -1,0 +1,49 @@
+@media print {
+  nav, footer, .no-print, button, .print-hidden {
+    display: none !important;
+  }
+
+  body {
+    background: white !important;
+    color: black !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .print-header {
+    display: flex !important;
+    align-items: center;
+    justify-content: space-between;
+    padding: 40px 0;
+    border-bottom: 2px solid #f1f5f9;
+    margin-bottom: 40px;
+  }
+
+  .print-footer {
+    display: block !important;
+    text-align: center;
+    padding: 40px 0;
+    border-top: 1px solid #f1f5f9;
+    margin-top: 60px;
+    font-size: 12px;
+    color: #64748b;
+  }
+
+  .itinerary-card {
+    break-inside: avoid;
+    border: 1px solid #e2e8f0 !important;
+    box-shadow: none !important;
+    background: #f8fafc !important;
+  }
+
+  .day-marker {
+    background: #0f172a !important;
+    color: white !important;
+    -webkit-print-color-adjust: exact;
+  }
+}
+
+.print-header,
+.print-footer {
+  display: none;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     {
       "source": "/(.*)",
       "headers": {
-        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.supabase.co https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://checkout.stripe.com https://cdn.mapbox.com https://api.mapbox.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.mapbox.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.supabase.co; connect-src 'self' wss://*.supabase.co https://*.supabase.co https://api.mapbox.com https://maps.googleapis.com https://api.stripe.com; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; worker-src 'self';",
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' https://*.supabase.co https://cdn.jsdelivr.net https://maps.googleapis.com https://js.stripe.com https://checkout.stripe.com https://cdn.mapbox.com https://api.mapbox.com https://cdnjs.cloudflare.com; style-src 'self' https://fonts.googleapis.com https://cdn.mapbox.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://api.mapbox.com https://*.supabase.co; connect-src 'self' wss://*.supabase.co https://*.supabase.co https://api.mapbox.com https://maps.googleapis.com https://api.stripe.com; frame-src 'self' https://js.stripe.com https://checkout.stripe.com; worker-src 'self';",
         "X-Frame-Options": "SAMEORIGIN",
         "X-Content-Type-Options": "nosniff",
         "Referrer-Policy": "strict-origin-when-cross-origin",


### PR DESCRIPTION
## Summary

- **BUG-012**: Added unit tests for `subscriptions.ts` (17 tests) and `locations.ts` (8 tests) following existing Vitest mock patterns.
- **BUG-013**: Hardened CSP by removing `unsafe-inline` and `unsafe-eval` from `script-src` and `style-src` directives. Inline print styles from `TripItinerary.tsx` were moved to an external `print-itinerary.css` file.

## Key architectural decisions

- External CSS is imported directly in `TripItinerary.tsx`; Vite extracts it into the page-specific CSS chunk (`pages-aiplanner-*.css`).
- `unsafe-eval` was removed from `script-src` because the app does not rely on `eval()` or `new Function()` in its own code. Mapbox GL JS was verified to work without it in the current version.

## Potential risks

- Mapbox GL JS historically required `unsafe-eval` in older versions. If any map rendering issues surface in production, `unsafe-eval` may need to be re-added with a comment explaining the Mapbox dependency.

## Testing notes

- `npm run test`: 1427 tests passed (including 25 new ones).
- `npm run build`: succeeded without errors.
- Print styles verified in build output (`pages-aiplanner-*.css` contains `@media print` rules).