### PR TITLE
fix: harden MIME validation and add subscription recovery email (BUG-008, BUG-010)

### DIFF
--- a/api-services/api/storage.ts
+++ b/api-services/api/storage.ts
@@ -21,9 +21,9 @@ function validateFile(file: File) {
         throw new Error(`File type ".${ext}" is not allowed. Allowed types: ${Array.from(ALLOWED_EXTENSIONS).join(', ')}`);
     }
 
-    // Check MIME type (if available on client side)
+    // MIME type is required — empty type is treated as invalid
     if (!file.type || !ALLOWED_MIME_TYPES.includes(file.type)) {
-        throw new Error(`MIME type "${file.type}" is not allowed. Only image files are accepted`);
+        throw new Error(`MIME type "${file.type || 'unknown'}" is not allowed. Only image files are accepted`);
     }
 }
 
@@ -38,7 +38,7 @@ function validateBlogMedia(file: File) {
     }
 
     if (!file.type || !BLOG_ALLOWED_MIME_TYPES.includes(file.type)) {
-        throw new Error(`MIME type "${file.type}" is not allowed. Only JPEG, PNG, and WebP images are accepted`);
+        throw new Error(`MIME type "${file.type || 'unknown'}" is not allowed. Only JPEG, PNG, and WebP images are accepted`);
     }
 }
 

--- a/api-services/api/storage.ts
+++ b/api-services/api/storage.ts
@@ -22,7 +22,7 @@ function validateFile(file: File) {
     }
 
     // Check MIME type (if available on client side)
-    if (file.type && !ALLOWED_MIME_TYPES.includes(file.type)) {
+    if (!file.type || !ALLOWED_MIME_TYPES.includes(file.type)) {
         throw new Error(`MIME type "${file.type}" is not allowed. Only image files are accepted`);
     }
 }
@@ -37,7 +37,7 @@ function validateBlogMedia(file: File) {
         throw new Error(`File type ".${ext}" is not allowed. Allowed types: ${Array.from(BLOG_ALLOWED_EXTENSIONS).join(', ')}`);
     }
 
-    if (file.type && !BLOG_ALLOWED_MIME_TYPES.includes(file.type)) {
+    if (!file.type || !BLOG_ALLOWED_MIME_TYPES.includes(file.type)) {
         throw new Error(`MIME type "${file.type}" is not allowed. Only JPEG, PNG, and WebP images are accepted`);
     }
 }

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -50,6 +50,7 @@ const emailDataSchemas = {
   subscription_cancelled:  z.object({ name: sOpt, periodEnd: s, link: sOpt }),
   subscription_cancellation_scheduled: z.object({ name: sOpt, periodEnd: s, link: sOpt }),
   subscription_payment_failed: z.object({ name: sOpt, link: sOpt }),
+  subscription_restored: z.object({ name: sOpt, link: sOpt }),
 } as const
 
 type EmailType = keyof typeof emailDataSchemas
@@ -756,6 +757,23 @@ function generateEmailContent(type: string, data: any): { subject: string, html:
                     data.link,
                     'Update Payment Method',
                     true
+                )
+            };
+
+        case 'subscription_restored':
+            return {
+                subject: 'Your Premium Subscription Has Been Restored',
+                html: getHtmlTemplate(
+                    'Subscription Restored',
+                    `
+                    <p style="font-size: 16px;">Hi ${escapeHtml(data.name) || 'there'},</p>
+                    <p>Good news! Your Premium subscription has been successfully restored. You now have full access to AI Trip Planner and all Premium features.</p>
+                    <div class="card">
+                        <p style="text-align: center; margin: 0; color: #059669; font-weight: 600;">Your subscription is active again.</p>
+                    </div>
+                    `,
+                    data.link,
+                    'View Profile'
                 )
             };
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -184,6 +184,31 @@ Deno.serve(async (req: Request) => {
         type: 'success',
         link: '/profile',
       })
+
+      // Send recovery email
+      const { data: userProfile } = await supabase
+        .from('profiles')
+        .select('email, full_name')
+        .eq('id', subRecord.user_id)
+        .maybeSingle()
+
+      if (userProfile?.email) {
+        console.warn(`Sending subscription restored email to user ${subRecord.user_id} at ${userProfile.email}`)
+        try {
+          await supabase.functions.invoke('send-email', {
+            body: {
+              to: userProfile.email,
+              type: 'subscription_restored',
+              data: {
+                name: userProfile.full_name || 'there',
+                link: `${Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'}/profile`,
+              },
+            },
+          })
+        } catch (e) {
+          console.error('Failed to send subscription restored email:', e)
+        }
+      }
     }
 
     // Cancellation notification (Stripe sets cancel_at_period_end but status is still active until period ends)


### PR DESCRIPTION
## Summary

Closes BUG-008 and BUG-010 from the May 2026 security/quality audit.

### BUG-008 — MIME Validation Bypass
- **Problem:** `file.type && !ALLOWED_MIME_TYPES.includes(file.type)` skipped validation when `file.type` was empty string or falsy, allowing MIME bypass.
- **Fix:** Changed condition to `!file.type || !ALLOWED_MIME_TYPES.includes(file.type)` in both `validateFile()` and `validateBlogMedia()` (`api-services/api/storage.ts`).
- This now rejects empty, undefined, null, and non-allowed MIME types.

### BUG-010 — Missing Recovery Email on Subscription Restore
- **Problem:** When a subscription recovered from `past_due` to `active`, only an in-app notification was sent. No email informed the user.
- **Fix:**
  1. Added `subscription_restored` type to `send-email` Zod schema (`supabase/functions/send-email/index.ts`).
  2. Added `subscription_restored` email template with confirmation UI.
  3. Added email invoke in the `stripe-webhook` recovery block after the notification insert.

### Already Fixed (No Changes)
- BUG-004 — `updateDirectoryListing()` already validates gallery array.
- BUG-011 — `DirectoryAdminPage.tsx` already passes `sortBy: 'base_score'`.

## Testing
- TypeScript: 0 errors
- ESLint: 0 warnings
- Build: succeeds
- Vitest: 1427 tests passed (121 files)