### PR TITLE
feat: per-listing detail pages with silo URL structure [SEO-003]

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -70,6 +70,21 @@ export const directoryService = {
         return data as DirectoryListingDB | null;
     },
 
+    async getDirectoryListingBySlug(slug: string): Promise<DirectoryListingDB | null> {
+        const { data, error } = await supabase
+            .from('directory_listings')
+            .select('*')
+            .eq('slug', slug)
+            .single();
+
+        if (error && error.code !== 'PGRST116') {
+            console.error('Error fetching directory listing by slug:', error);
+            throw error;
+        }
+
+        return data as DirectoryListingDB | null;
+    },
+
     async getDirectoryListingsByCategory(categoryId: string): Promise<DirectoryListingDB[]> {
         const { data, error } = await supabase
             .from('directory_listings')

--- a/components/admin/directory/BasicDetailsForm.tsx
+++ b/components/admin/directory/BasicDetailsForm.tsx
@@ -4,10 +4,11 @@ import { Store } from 'lucide-react';
 interface BasicDetailsFormProps {
     name: string;
     description: string;
+    slug: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }
 
-export const BasicDetailsForm: React.FC<BasicDetailsFormProps> = ({ name, description, onChange }) => {
+export const BasicDetailsForm: React.FC<BasicDetailsFormProps> = ({ name, description, slug, onChange }) => {
     return (
         <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-slate-800/50">
             <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-6 flex items-center gap-2">
@@ -28,6 +29,22 @@ export const BasicDetailsForm: React.FC<BasicDetailsFormProps> = ({ name, descri
                             onChange={onChange}
                             className="w-full px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-900 focus:ring-2 focus:ring-teal-500 outline-none dark:text-white"
                             placeholder="e.g. Alanya Premium Dental"
+                        />
+                    </div>
+                    <div className="md:col-span-2">
+                        <label htmlFor="directory-slug" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                            URL Slug
+                            <span className="text-xs text-slate-500 ml-2 font-normal">(auto-generated, editable)</span>
+                        </label>
+                        <input
+                            id="directory-slug"
+                            type="text"
+                            name="slug"
+                            value={slug}
+                            onChange={onChange}
+                            pattern="[a-z0-9-]+"
+                            className="w-full px-4 py-2 rounded-xl border border-slate-200 dark:border-slate-700/50 bg-slate-50 dark:bg-slate-900 focus:ring-2 focus:ring-teal-500 outline-none dark:text-white font-mono text-sm"
+                            placeholder="e.g. alanya-premium-dental"
                         />
                     </div>
                     <div className="md:col-span-2">

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, ThumbsUp, ThumbsDown, Award } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { DirectoryListingDB } from '../../types/models';
 import { db } from '../../api-services';
+import { getListingUrl } from '../../constants/categoryPaths';
 
 interface DirectoryListingCardProps {
     listing: DirectoryListingDB;
@@ -191,6 +193,16 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                         <MapPin size={16} /> Map
                     </button>
                 </div>
+
+                {listing.slug && (
+                    <Link
+                        to={getListingUrl(listing.category_id, listing.slug)}
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-xs text-teal-600 dark:text-cyan-400 hover:underline mt-2 block text-center"
+                    >
+                        View full page →
+                    </Link>
+                )}
             </div>
         </div>
     );

--- a/components/directory/DirectoryListingModal.tsx
+++ b/components/directory/DirectoryListingModal.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, Info, Award } from 'lucide-react';
+import { Star, MapPin, Globe, MessageCircle, BadgeCheck, Check, Info, Award, ExternalLink } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { DirectoryListingDB } from '../../types/models';
 import { Modal } from '../ui/Modal';
 import { db } from '../../api-services';
 import { parseVideoEmbed } from '../../utils/videoEmbed';
 import { ListingReviewSection } from './ListingReviewSection';
+import { getListingUrl } from '../../constants/categoryPaths';
 
 interface DirectoryListingModalProps {
     listing: DirectoryListingDB | null;
@@ -21,7 +23,19 @@ export const DirectoryListingModal: React.FC<DirectoryListingModalProps> = ({ li
     return (
         <Modal isOpen={isOpen} onClose={onClose} maxWidth="2xl" title={listing.name} lockBodyScroll={false}>
             <div className="space-y-6">
-                
+
+                {listing.slug && (
+                    <div className="flex justify-end -mt-2">
+                        <Link
+                            to={getListingUrl(listing.category_id, listing.slug)}
+                            onClick={onClose}
+                            className="text-sm text-teal-600 dark:text-cyan-400 hover:underline flex items-center gap-1"
+                        >
+                            <ExternalLink size={14} /> View full listing page
+                        </Link>
+                    </div>
+                )}
+
                 {/* Header Image */}
                 {listing.gallery?.[0] && (
                     <div className="relative w-full h-48 sm:h-64 rounded-xl overflow-hidden shadow-sm border border-slate-100 dark:border-slate-800">

--- a/components/seo/Breadcrumb.tsx
+++ b/components/seo/Breadcrumb.tsx
@@ -19,7 +19,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items }) => {
             '@type': 'ListItem',
             position: index + 1,
             name: item.label,
-            item: item.href ? `https://alanyaholidays.com${item.href}` : undefined,
+            item: item.href ? `https://alanya-holidays.com${item.href}` : undefined,
         })),
     };
 

--- a/constants/categoryPaths.ts
+++ b/constants/categoryPaths.ts
@@ -1,0 +1,40 @@
+const SCHEMA_TYPE_MAP: Record<string, string> = {
+    'accommodations': 'LodgingBusiness',
+    'villas':         'LodgingBusiness',
+    'apartments':     'LodgingBusiness',
+    'restaurants':    'Restaurant',
+    'cafes':          'CafeOrCoffeeShop',
+    'medical':        'MedicalBusiness',
+    'spa-hamam':      'HealthAndBeautyBusiness',
+    'hair-beauty':    'HealthAndBeautyBusiness',
+    'tours':          'TouristAttraction',
+};
+
+export function getSchemaType(categoryId: string): string {
+    return SCHEMA_TYPE_MAP[categoryId] ?? 'LocalBusiness';
+}
+
+export const CATEGORY_PATHS: Record<string, string> = {
+    'medical':        '/medical-tourism-alanya',
+    'accommodations': '/alanya-hotels',
+    'villas':         '/alanya-villas',
+    'apartments':     '/alanya-apartments',
+    'tours':          '/things-to-do-in-alanya',
+    'transport':      '/airport-transfer',
+    'restaurants':    '/restaurants',
+    'cafes':          '/cafes',
+    'real-estate':    '/alanya-real-estate',
+    'visa':           '/alanya-residency-guide',
+    'shopping':       '/alanya-shopping-guide',
+    'nature':         '/alanya-nature-attractions',
+    'weather':        '/alanya-weather',
+    'nightlife':      '/nightlife',
+    'spa-hamam':      '/alanya-spa-hamam',
+    'hair-beauty':    '/alanya-hair-beauty',
+};
+
+export function getListingUrl(categoryId: string, slug: string): string {
+    const prefix = CATEGORY_PATHS[categoryId];
+    if (!prefix || !slug) return '/';
+    return `${prefix}/${slug}`;
+}

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -11,6 +11,7 @@ import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
 import { toast } from 'react-hot-toast';
+import { CATEGORY_PATHS } from '../constants/categoryPaths';
 
 export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categoryId: propCategoryId }) => {
     const params = useParams<{ categoryId: string }>();
@@ -205,7 +206,9 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
             "item": {
                 "@type": categoryId === 'accommodations' ? "LodgingBusiness" : categoryId === 'restaurants' ? "Restaurant" : "LocalBusiness",
                 "name": item.name,
-                "url": item.website || window.location.href,
+                "url": item.slug
+                        ? `https://alanya-holidays.com${CATEGORY_PATHS[categoryId] || ''}/${item.slug}`
+                        : item.website || `https://alanya-holidays.com${CATEGORY_PATHS[categoryId] || '/'}`,
                 "image": item.gallery?.[0] || ''
             }
         }))

--- a/pages/DirectoryListingPage.tsx
+++ b/pages/DirectoryListingPage.tsx
@@ -1,0 +1,398 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import {
+    Star, MapPin, Globe, MessageCircle, BadgeCheck, Check,
+    Info, Award, ArrowLeft, ExternalLink,
+} from 'lucide-react';
+import { SEOHead } from '../components/seo/SEOHead';
+import { Breadcrumb } from '../components/seo/Breadcrumb';
+import { db } from '../api-services';
+import { DirectoryListingDB } from '../types/models';
+import { directoryCategoryIntros } from '../data/directoryData';
+import { CATEGORY_PATHS, getListingUrl, getSchemaType } from '../constants/categoryPaths';
+import { parseVideoEmbed } from '../utils/videoEmbed';
+import { ListingReviewSection } from '../components/directory/ListingReviewSection';
+import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+
+interface DirectoryListingPageProps {
+    categoryId: string;
+}
+
+export const DirectoryListingPage: React.FC<DirectoryListingPageProps> = ({ categoryId }) => {
+    const { slug } = useParams<{ slug: string }>();
+    const navigate = useNavigate();
+
+    const [listing, setListing] = useState<DirectoryListingDB | null>(null);
+    const [related, setRelated] = useState<DirectoryListingDB[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const categoryIntro = directoryCategoryIntros[categoryId];
+    const categoryPath = CATEGORY_PATHS[categoryId] || '/';
+
+    useEffect(() => {
+        if (!slug) return;
+
+        let cancelled = false;
+
+        const load = async () => {
+            setLoading(true);
+            try {
+                const [found, allInCategory] = await Promise.all([
+                    db.getDirectoryListingBySlug(slug),
+                    db.getDirectoryListingsByCategory(categoryId),
+                ]);
+                if (cancelled) return;
+
+                if (found) {
+                    db.trackListingView(found.id).catch(console.error);
+                    setRelated(allInCategory.filter(l => l.id !== found.id).slice(0, 3));
+                }
+                setListing(found);
+            } catch (err) {
+                console.error('Failed to load listing page:', err);
+                if (!cancelled) setListing(null);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        load();
+        return () => { cancelled = true; };
+    }, [slug, categoryId]);
+
+    if (loading) {
+        return (
+            <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16 flex items-center justify-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-teal-500" />
+            </div>
+        );
+    }
+
+    if (!listing) {
+        return (
+            <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
+                <div className="max-w-3xl mx-auto px-4 py-16 text-center">
+                    <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-4">Listing not found</h1>
+                    <p className="text-slate-600 dark:text-slate-400 mb-8">
+                        This listing may have been removed or the URL has changed.
+                    </p>
+                    <Link
+                        to={categoryPath}
+                        className="inline-flex items-center gap-2 text-teal-600 dark:text-cyan-400 font-semibold hover:underline"
+                    >
+                        <ArrowLeft size={16} /> Back to {categoryIntro?.title || 'Directory'}
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    const isPaidTier = listing.tier && listing.tier !== 'explorer';
+    const videoEmbed = listing.video_url ? parseVideoEmbed(listing.video_url) : null;
+
+    const localBusinessSchema = {
+        '@context': 'https://schema.org',
+        '@type': getSchemaType(categoryId),
+        name: listing.name,
+        description: listing.short_description,
+        image: listing.gallery?.[0] || undefined,
+        url: `https://alanya-holidays.com${getListingUrl(categoryId, listing.slug!)}`,
+        address: {
+            '@type': 'PostalAddress',
+            addressLocality: listing.location,
+            addressCountry: 'TR',
+        },
+        ...(listing.reviews_average && listing.reviews_count ? {
+            aggregateRating: {
+                '@type': 'AggregateRating',
+                ratingValue: listing.reviews_average,
+                reviewCount: listing.reviews_count,
+                bestRating: 5,
+                worstRating: 1,
+            },
+        } : {}),
+        ...(listing.price_level ? { priceRange: '$$$$'.slice(0, listing.price_level) } : {}),
+    };
+
+    const categoryTitle = categoryIntro?.title || 'Directory';
+
+    return (
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
+            <SEOHead
+                title={`${listing.name} — ${categoryTitle}`}
+                description={listing.short_description}
+                image={listing.gallery?.[0]}
+                type="website"
+                jsonLd={localBusinessSchema}
+            />
+
+            <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+                {/* Breadcrumb */}
+                <div className="pt-6 pb-4">
+                    <Breadcrumb
+                        items={[
+                            { label: 'Home', href: '/' },
+                            { label: categoryTitle, href: categoryPath },
+                            { label: listing.name },
+                        ]}
+                    />
+                </div>
+
+                {/* Hero Gallery */}
+                {listing.gallery && listing.gallery.length > 0 && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-8 rounded-2xl overflow-hidden">
+                        <div className="sm:row-span-2 relative h-64 sm:h-auto">
+                            <img
+                                src={listing.gallery[0]}
+                                alt={listing.name}
+                                className="w-full h-full object-cover"
+                            />
+                            {listing.is_featured && (
+                                <div className="absolute top-4 left-4 bg-amber-500 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg flex items-center gap-1">
+                                    <Star size={12} className="fill-white" /> Featured
+                                </div>
+                            )}
+                        </div>
+                        {listing.gallery.slice(1, 3).map((img, i) => (
+                            <div key={i} className="relative h-48 sm:h-auto">
+                                <img src={img} alt={`${listing.name} ${i + 2}`} className="w-full h-full object-cover" />
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+
+                    {/* Main Content */}
+                    <div className="lg:col-span-2 space-y-8">
+
+                        {/* Title + Badges */}
+                        <div>
+                            <div className="flex flex-wrap items-center gap-3 mb-3">
+                                {listing.tier === 'signature' && (
+                                    <span className="inline-flex items-center gap-1 text-sm font-medium bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 px-3 py-1 rounded-full">
+                                        <BadgeCheck size={14} /> Verified Premium
+                                    </span>
+                                )}
+                                {(listing.tier === 'voyager' || listing.tier === 'partner') && (
+                                    <span className="inline-flex items-center gap-1 text-sm font-medium bg-teal-50 dark:bg-teal-900/20 text-teal-600 dark:text-teal-400 px-3 py-1 rounded-full">
+                                        <Award size={14} /> Recommended
+                                    </span>
+                                )}
+                                {listing.is_verified && (
+                                    <span className="inline-flex items-center gap-1 text-sm font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 px-3 py-1 rounded-full">
+                                        <BadgeCheck size={14} /> Verified
+                                    </span>
+                                )}
+                            </div>
+
+                            <h1 className="text-3xl font-bold text-slate-900 dark:text-white mb-2">{listing.name}</h1>
+
+                            <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600 dark:text-slate-400">
+                                <span className="flex items-center gap-1">
+                                    <MapPin size={14} /> {listing.location}
+                                </span>
+                                <span className="flex items-center gap-1">
+                                    <div className="flex text-amber-500">
+                                        {[1, 2, 3, 4, 5].map(star => (
+                                            <Star key={star} size={13} className={star <= Math.round(listing.reviews_average || 0) ? 'fill-amber-500' : 'fill-slate-200 text-slate-200'} />
+                                        ))}
+                                    </div>
+                                    <span className="font-bold text-slate-900 dark:text-white ml-1">
+                                        {listing.reviews_average?.toFixed(1) || 'New'}
+                                    </span>
+                                    <span className="text-slate-500">({listing.reviews_count || 0})</span>
+                                </span>
+                                {listing.price_level && (
+                                    <span className="font-medium text-slate-700 dark:text-slate-300">
+                                        {'$$$$'.slice(0, listing.price_level)}
+                                        <span className="text-slate-300 dark:text-slate-600">{'$$$$'.slice(listing.price_level)}</span>
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Description */}
+                        <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50">
+                            <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-3">About</h2>
+                            <p className="text-slate-600 dark:text-slate-400 leading-relaxed whitespace-pre-wrap">
+                                {listing.short_description}
+                            </p>
+                        </div>
+
+                        {/* Certifications & Languages */}
+                        {(listing.certifications?.length || listing.languages_spoken?.length) ? (
+                            <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50 space-y-5">
+                                {listing.certifications && listing.certifications.length > 0 && (
+                                    <div>
+                                        <h3 className="font-semibold text-slate-900 dark:text-white mb-3">Specialties</h3>
+                                        <div className="flex flex-wrap gap-2">
+                                            {listing.certifications.map(cert => (
+                                                <span key={cert} className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-teal-50 dark:bg-cyan-900/20 text-teal-700 dark:text-cyan-400 text-sm font-medium border border-teal-100 dark:border-cyan-800/30">
+                                                    <BadgeCheck size={13} /> {cert}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                {listing.languages_spoken && listing.languages_spoken.length > 0 && (
+                                    <div>
+                                        <h3 className="font-semibold text-slate-900 dark:text-white mb-3">Languages spoken</h3>
+                                        <div className="flex flex-wrap gap-2">
+                                            {listing.languages_spoken.map(lang => (
+                                                <span key={lang} className="inline-block px-2.5 py-1 bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 rounded-md text-sm border border-slate-200 dark:border-slate-700">
+                                                    {lang}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        ) : null}
+
+                        {/* Amenities */}
+                        <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50">
+                            <h3 className="font-semibold text-slate-900 dark:text-white mb-3">What's included</h3>
+                            <div className="grid grid-cols-2 gap-2 text-sm text-slate-600 dark:text-slate-400">
+                                <div className="flex items-center gap-1.5"><Check size={14} className="text-green-500" /> English Support</div>
+                                <div className="flex items-center gap-1.5"><Check size={14} className="text-green-500" /> Online Booking</div>
+                                {listing.is_verified && (
+                                    <div className="flex items-center gap-1.5"><Check size={14} className="text-green-500" /> Verified Partner</div>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Video */}
+                        {videoEmbed && (
+                            <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50">
+                                <h3 className="font-semibold text-slate-900 dark:text-white mb-4">Video</h3>
+                                <div className="relative w-full rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800 aspect-video">
+                                    <iframe
+                                        src={videoEmbed.embedUrl}
+                                        title="Listing video"
+                                        className="absolute inset-0 w-full h-full border-0"
+                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                        allowFullScreen
+                                        loading="lazy"
+                                    />
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Full gallery */}
+                        {listing.gallery && listing.gallery.length > 3 && (
+                            <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50">
+                                <h3 className="font-semibold text-slate-900 dark:text-white mb-4">Gallery</h3>
+                                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                                    {listing.gallery.slice(3).map((img, i) => (
+                                        <img key={i} src={img} alt={`${listing.name} photo ${i + 4}`} className="w-full h-32 object-cover rounded-xl" />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Reviews */}
+                        <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50">
+                            <ListingReviewSection listingId={listing.id} />
+                        </div>
+                    </div>
+
+                    {/* Sidebar */}
+                    <div className="space-y-5">
+
+                        {/* Contact Box */}
+                        <div className="bg-white dark:bg-slate-800/80 rounded-2xl p-6 border border-slate-100 dark:border-slate-800/50 sticky top-28">
+                            <h2 className="font-bold text-slate-900 dark:text-white mb-4 text-lg">Contact provider</h2>
+
+                            <div className="space-y-3">
+                                {isPaidTier && listing.whatsapp && (
+                                    <button
+                                        onClick={() => {
+                                            db.trackListingClick(listing.id, 'whatsapp').catch(console.error);
+                                            window.open(`https://wa.me/${listing.whatsapp?.replace(/\D/g, '')}`, '_blank');
+                                        }}
+                                        className="w-full flex items-center justify-center gap-2 py-3.5 px-4 font-semibold rounded-xl bg-green-500 hover:bg-green-600 text-white shadow-sm transition-all"
+                                    >
+                                        <MessageCircle size={18} /> Chat on WhatsApp
+                                    </button>
+                                )}
+
+                                <button
+                                    onClick={() => {
+                                        if (listing.website) {
+                                            db.trackListingClick(listing.id, 'website').catch(console.error);
+                                            window.open(listing.website, '_blank');
+                                        }
+                                    }}
+                                    disabled={!listing.website}
+                                    className={`w-full flex items-center justify-center gap-2 py-3 px-4 font-semibold rounded-xl border border-slate-200 dark:border-slate-700 transition-all ${listing.website ? 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800' : 'text-slate-400 cursor-not-allowed opacity-50'}`}
+                                >
+                                    <Globe size={18} /> Visit Website
+                                </button>
+
+                                <button
+                                    onClick={() => {
+                                        db.trackListingClick(listing.id, 'map').catch(console.error);
+                                        if (listing.google_map_url) {
+                                            window.open(listing.google_map_url, '_blank');
+                                        } else {
+                                            const q = encodeURIComponent(`${listing.name} ${listing.location}`);
+                                            window.open(`https://www.google.com/maps/search/?api=1&query=${q}`, '_blank');
+                                        }
+                                    }}
+                                    className="w-full flex items-center justify-center gap-2 py-3 px-4 font-semibold rounded-xl border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-all"
+                                >
+                                    <MapPin size={18} /> View on Map
+                                </button>
+                            </div>
+
+                            <div className="flex items-start gap-3 mt-4 p-4 bg-teal-50 dark:bg-cyan-900/10 rounded-xl text-teal-800 dark:text-cyan-300">
+                                <Info size={18} className="flex-shrink-0 mt-0.5" />
+                                <p className="text-xs leading-relaxed">
+                                    Please mention <strong>Alanya Holidays</strong> when contacting the provider.
+                                </p>
+                            </div>
+                        </div>
+
+                        {/* Back to category */}
+                        <Link
+                            to={categoryPath}
+                            className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 hover:text-teal-600 dark:hover:text-cyan-400 transition-colors"
+                        >
+                            <ArrowLeft size={14} /> Back to {categoryTitle}
+                        </Link>
+                    </div>
+                </div>
+
+                {/* Related Listings */}
+                {related.length > 0 && (
+                    <div className="mt-16">
+                        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-6">
+                            More in {categoryTitle}
+                        </h2>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {related.map(item => (
+                                <DirectoryListingCard
+                                    key={item.id}
+                                    listing={item}
+                                    isAuthenticated={false}
+                                    onClick={() => item.slug && navigate(getListingUrl(item.category_id, item.slug))}
+                                />
+                            ))}
+                        </div>
+
+                        <div className="mt-8 text-center">
+                            <Link
+                                to={categoryPath}
+                                className="inline-flex items-center gap-2 text-teal-600 dark:text-cyan-400 font-semibold hover:underline"
+                            >
+                                View all in {categoryTitle} <ExternalLink size={16} />
+                            </Link>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -7,6 +7,7 @@ import { useSaveShortcut } from '../../hooks/useSaveShortcut';
 import { parseVideoEmbed } from '../../utils/videoEmbed';
 import toast from 'react-hot-toast';
 import { DirectoryListingDB } from '../../types/models';
+import { slugify } from '../../utils/slugify';
 
 import { BasicDetailsForm } from '../../components/admin/directory/BasicDetailsForm';
 import { ContactLocationForm } from '../../components/admin/directory/ContactLocationForm';
@@ -29,6 +30,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
 
     const [formData, setFormData] = useState({
         name: '',
+        slug: '',
         short_description: '',
         category_id: 'medical',
         location: '',
@@ -53,6 +55,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
             if (listing) {
                 setFormData({
                     name: listing.name,
+                    slug: listing.slug || '',
                     short_description: listing.short_description,
                     category_id: listing.category_id,
                     location: listing.location,
@@ -84,6 +87,13 @@ export const AdminEditDirectoryPage: React.FC = () => {
             loadListing();
         }
     }, [isEditing, loadListing]);
+
+    // Auto-generate slug from name when creating a new listing
+    useEffect(() => {
+        if (!isEditing && formData.name && !formData.slug) {
+            setFormData(prev => ({ ...prev, slug: slugify(prev.name) }));
+        }
+    }, [formData.name, isEditing]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const { name, value, type } = e.target;
@@ -160,6 +170,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
 
             const listingData: Omit<DirectoryListingDB, 'id' | 'created_at' | 'updated_at'> = {
                 name: formData.name,
+                slug: formData.slug || undefined,
                 short_description: formData.short_description,
                 category_id: formData.category_id,
                 location: formData.location,
@@ -233,6 +244,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
                     <div className="lg:col-span-2 space-y-6">
                         <BasicDetailsForm
                             name={formData.name}
+                            slug={formData.slug}
                             description={formData.short_description}
                             onChange={handleChange}
                         />

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -55,6 +55,7 @@ const CreativeServices = React.lazy(() => import('../pages/CreativeServices').th
 const ListingTiersPage = React.lazy(() => import('../pages/ListingTiersPage').then(module => ({ default: module.ListingTiersPage })));
 const SubscribePage = React.lazy(() => import('../pages/SubscribePage').then(module => ({ default: module.SubscribePage })));
 const AddListingPage = React.lazy(() => import('../pages/AddListingPage').then(module => ({ default: module.AddListingPage })));
+const DirectoryListingPage = React.lazy(() => import('../pages/DirectoryListingPage').then(module => ({ default: module.DirectoryListingPage })));
 const HiddenGemsPage = React.lazy(() => import('../pages/blog/HiddenGemsPage').then(module => ({ default: module.HiddenGemsPage })));
 const BestBeachesPage = React.lazy(() => import('../pages/blog/BestBeachesPage').then(module => ({ default: module.BestBeachesPage })));
 const BlogCategoryPage = React.lazy(() => import('../pages/blog/BlogCategoryPage').then(module => ({ default: module.BlogCategoryPage })));
@@ -119,6 +120,25 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/nightlife" element={<DirectoryCategoryPage categoryId="nightlife" />} />
                 <Route path="/alanya-spa-hamam" element={<DirectoryCategoryPage categoryId="spa-hamam" />} />
                 <Route path="/alanya-hair-beauty" element={<DirectoryCategoryPage categoryId="hair-beauty" />} />
+
+                {/* SEO-003: Listing Detail Routes (silo sub-pages) */}
+                <Route path="/medical-tourism-alanya/:slug" element={<DirectoryListingPage categoryId="medical" />} />
+                <Route path="/alanya-hotels/:slug" element={<DirectoryListingPage categoryId="accommodations" />} />
+                <Route path="/alanya-villas/:slug" element={<DirectoryListingPage categoryId="villas" />} />
+                <Route path="/alanya-apartments/:slug" element={<DirectoryListingPage categoryId="apartments" />} />
+                <Route path="/things-to-do-in-alanya/:slug" element={<DirectoryListingPage categoryId="tours" />} />
+                <Route path="/airport-transfer/:slug" element={<DirectoryListingPage categoryId="transport" />} />
+                <Route path="/car-rental/:slug" element={<DirectoryListingPage categoryId="transport" />} />
+                <Route path="/restaurants/:slug" element={<DirectoryListingPage categoryId="restaurants" />} />
+                <Route path="/cafes/:slug" element={<DirectoryListingPage categoryId="cafes" />} />
+                <Route path="/alanya-real-estate/:slug" element={<DirectoryListingPage categoryId="real-estate" />} />
+                <Route path="/alanya-residency-guide/:slug" element={<DirectoryListingPage categoryId="visa" />} />
+                <Route path="/alanya-shopping-guide/:slug" element={<DirectoryListingPage categoryId="shopping" />} />
+                <Route path="/alanya-nature-attractions/:slug" element={<DirectoryListingPage categoryId="nature" />} />
+                <Route path="/alanya-weather/:slug" element={<DirectoryListingPage categoryId="weather" />} />
+                <Route path="/nightlife/:slug" element={<DirectoryListingPage categoryId="nightlife" />} />
+                <Route path="/alanya-spa-hamam/:slug" element={<DirectoryListingPage categoryId="spa-hamam" />} />
+                <Route path="/alanya-hair-beauty/:slug" element={<DirectoryListingPage categoryId="hair-beauty" />} />
 
                 <Route path="/list-property" element={<ListProperty />} />
                 <Route path="/list-business" element={<ListingTiersPage />} />

--- a/supabase/functions/generate-sitemap/index.ts
+++ b/supabase/functions/generate-sitemap/index.ts
@@ -7,7 +7,26 @@ const SUPABASE_URL = Deno.env.get('SUPABASE_URL')
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 const CRON_SECRET = Deno.env.get('CRON_SECRET')
 
-const BASE_URL = 'https://alanyaholidays.com'
+const BASE_URL = Deno.env.get('SITE_URL') ?? 'https://alanya-holidays.com'
+
+const CATEGORY_PATHS: Record<string, string> = {
+  'medical':        '/medical-tourism-alanya',
+  'accommodations': '/alanya-hotels',
+  'villas':         '/alanya-villas',
+  'apartments':     '/alanya-apartments',
+  'tours':          '/things-to-do-in-alanya',
+  'transport':      '/airport-transfer',
+  'restaurants':    '/restaurants',
+  'cafes':          '/cafes',
+  'real-estate':    '/alanya-real-estate',
+  'visa':           '/alanya-residency-guide',
+  'shopping':       '/alanya-shopping-guide',
+  'nature':         '/alanya-nature-attractions',
+  'weather':        '/alanya-weather',
+  'nightlife':      '/nightlife',
+  'spa-hamam':      '/alanya-spa-hamam',
+  'hair-beauty':    '/alanya-hair-beauty',
+}
 
 interface SitemapUrl {
   loc: string
@@ -172,12 +191,34 @@ Deno.serve(async (req: Request) => {
       }
     }
 
+    // Directory listing detail pages
+    const { data: listings, error: listingsError } = await supabase
+      .from('directory_listings')
+      .select('slug, category_id, updated_at')
+      .not('slug', 'is', null)
+      .order('updated_at', { ascending: false })
+
+    if (listingsError) {
+      console.error('Failed to fetch directory listings for sitemap:', listingsError)
+    } else if (listings) {
+      for (const listing of listings) {
+        if (!listing.slug || !listing.category_id) continue
+        const prefix = CATEGORY_PATHS[listing.category_id]
+        if (!prefix) continue
+        urls.push({
+          loc: `${BASE_URL}${prefix}/${listing.slug}`,
+          lastmod: listing.updated_at ? new Date(listing.updated_at).toISOString().split('T')[0] : undefined,
+          changefreq: 'weekly',
+          priority: '0.7',
+        })
+      }
+    }
+
     const sitemapXml = buildSitemap(urls)
 
     // Ping Google about the updated sitemap
-    const SITE_URL = Deno.env.get('SITE_URL') ?? 'https://alanyaholidays.com'
     try {
-      const pingUrl = `https://www.google.com/ping?sitemap=${encodeURIComponent(`${SITE_URL}/sitemap.xml`)}`
+      const pingUrl = `https://www.google.com/ping?sitemap=${encodeURIComponent(`${BASE_URL}/sitemap.xml`)}`
       await fetch(pingUrl)
       console.warn('Sitemap ping sent to Google')
     } catch (e) {

--- a/supabase/migrations/20260526060000_add_slug_to_directory_listings.sql
+++ b/supabase/migrations/20260526060000_add_slug_to_directory_listings.sql
@@ -1,0 +1,77 @@
+-- Purpose: Add slug column to directory_listings for SEO-003 silo URL structure
+-- Provides canonical per-listing URLs: /restaurants/listing-slug, /alanya-hotels/listing-slug, etc.
+
+ALTER TABLE public.directory_listings
+    ADD COLUMN IF NOT EXISTS slug TEXT;
+
+-- Backfill existing rows using Turkish-aware slugify logic
+DO $$
+DECLARE
+    rec RECORD;
+    base_slug TEXT;
+    candidate TEXT;
+    counter INT;
+BEGIN
+    FOR rec IN SELECT id, name FROM public.directory_listings WHERE slug IS NULL ORDER BY created_at LOOP
+        base_slug := lower(rec.name);
+        base_slug := replace(base_slug, 'ç', 'c');
+        base_slug := replace(base_slug, 'ğ', 'g');
+        base_slug := replace(base_slug, 'ı', 'i');
+        base_slug := replace(base_slug, 'ö', 'o');
+        base_slug := replace(base_slug, 'ş', 's');
+        base_slug := replace(base_slug, 'ü', 'u');
+        base_slug := regexp_replace(base_slug, '[^a-z0-9]+', '-', 'g');
+        base_slug := regexp_replace(base_slug, '^-+|-+$', '', 'g');
+
+        candidate := base_slug;
+        counter := 1;
+        WHILE EXISTS (SELECT 1 FROM public.directory_listings WHERE slug = candidate) LOOP
+            candidate := base_slug || '-' || counter;
+            counter := counter + 1;
+        END LOOP;
+
+        UPDATE public.directory_listings SET slug = candidate WHERE id = rec.id;
+    END LOOP;
+END $$;
+
+ALTER TABLE public.directory_listings
+    ALTER COLUMN slug SET NOT NULL,
+    ADD CONSTRAINT directory_listings_slug_unique UNIQUE (slug);
+
+CREATE INDEX IF NOT EXISTS idx_directory_listings_slug
+    ON public.directory_listings (slug);
+
+-- Auto-generate slug on INSERT if not provided
+CREATE OR REPLACE FUNCTION public.auto_slug_directory_listing()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+    base_slug TEXT;
+    candidate TEXT;
+    counter INT;
+BEGIN
+    IF NEW.slug IS NULL OR NEW.slug = '' THEN
+        base_slug := lower(NEW.name);
+        base_slug := replace(base_slug, 'ç', 'c');
+        base_slug := replace(base_slug, 'ğ', 'g');
+        base_slug := replace(base_slug, 'ı', 'i');
+        base_slug := replace(base_slug, 'ö', 'o');
+        base_slug := replace(base_slug, 'ş', 's');
+        base_slug := replace(base_slug, 'ü', 'u');
+        base_slug := regexp_replace(base_slug, '[^a-z0-9]+', '-', 'g');
+        base_slug := regexp_replace(base_slug, '^-+|-+$', '', 'g');
+        candidate := base_slug;
+        counter := 1;
+        WHILE EXISTS (SELECT 1 FROM public.directory_listings WHERE slug = candidate AND id != NEW.id) LOOP
+            candidate := base_slug || '-' || counter;
+            counter := counter + 1;
+        END LOOP;
+        NEW.slug := candidate;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_auto_slug_directory_listing ON public.directory_listings;
+CREATE TRIGGER trg_auto_slug_directory_listing
+    BEFORE INSERT ON public.directory_listings
+    FOR EACH ROW EXECUTE FUNCTION public.auto_slug_directory_listing();

--- a/types/models.ts
+++ b/types/models.ts
@@ -416,6 +416,7 @@ export interface DirectoryListingDB {
   id: string;
   category_id: string;
   name: string;
+  slug?: string;
   short_description: string;
   is_featured?: boolean;
   is_premium?: boolean;


### PR DESCRIPTION
## Summary

- Adds `slug` column to `directory_listings` via migration — backfills all existing rows with Turkish-aware slug generation, unique constraint, index, and BEFORE INSERT trigger for auto-generation
- Creates `pages/DirectoryListingPage.tsx` — full-width listing page with LocalBusiness JSON-LD, 3-level breadcrumbs, contact buttons, video embed, and related listings row
- Adds 17 `/:slug` child routes across all directory category URL prefixes (e.g. `/restaurants/:slug`, `/alanya-hotels/:slug`)
- Adds `constants/categoryPaths.ts` — single source of truth for category prefix map and `getSchemaType()` used for JSON-LD `@type`
- "View full listing page" link added to modal header; "View full page →" link added to listing cards
- Fixes Breadcrumb JSON-LD domain typo (`alanyaholidays.com` → `alanya-holidays.com`)
- Fixes ItemList JSON-LD `url` field in DirectoryCategoryPage to use canonical slug URLs
- Extends sitemap Edge Function to emit all listing detail page URLs
- Admin form (`AdminEditDirectoryPage` + `BasicDetailsForm`) now includes slug field with auto-generation from name

## Architectural decisions

- `CATEGORY_PATHS` intentionally duplicated in Edge Function — Deno runtime cannot import from client TS files
- `slug` stored in DB (not computed from name) for URL stability after renames
- 17 routes declared individually with hardcoded `categoryId` prop — keeps routing explicit and avoids a generic catch-all that could shadow other routes
- Migration applied via Supabase MCP (`apply_migration`) because local migration history diverged from remote

## Risks

- None identified. Security review found no high-confidence exploitable vulnerabilities. Existing RLS policies automatically cover the new `slug` column (public read, admin write).

## Testing

- `npm run build` passes (0 TS errors, 0 ESLint warnings)
- DB migration applied; slugs generated for all existing listings, zero duplicates
- Listing detail page renders at `/restaurants/<slug>` with correct title, breadcrumbs, and JSON-LD
- 404 state renders gracefully for unknown slugs