### PR TITLE
fix: include slug, certifications, languages_spoken and newsletter_featured in createDirectoryListing

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -244,7 +244,11 @@ export const directoryService = {
             is_verified: false,
             tier,
             base_score: listing.base_score ?? 0,
+            ...(listing.slug ? { slug: listing.slug.slice(0, 200) } : {}),
             ...(listing.price_level !== undefined ? { price_level: listing.price_level } : {}),
+            ...(listing.certifications?.length ? { certifications: listing.certifications } : {}),
+            ...(listing.languages_spoken?.length ? { languages_spoken: listing.languages_spoken } : {}),
+            ...(listing.newsletter_featured !== undefined ? { newsletter_featured: listing.newsletter_featured } : {}),
         });
 
         const { data, error } = await supabase


### PR DESCRIPTION
## Summary

- `createDirectoryListing()` was silently dropping `slug`, `certifications`, `languages_spoken`, and `newsletter_featured` fields on listing creation
- These fields were correctly preserved on update but never persisted on the initial INSERT
- For `slug` specifically: the DB trigger would auto-generate one from the name, so the admin-entered slug was always ignored at creation time
- All four fields are now conditionally included in `safeData`

## Impact

- New listings now get the admin-specified slug instead of a trigger-generated one
- Certifications, languages and newsletter flag set at creation are no longer lost
- No breaking changes — fields remain optional (spread only when present)