### PR TITLE
feat: directory listing moderation flow

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -1,15 +1,13 @@
 import { supabase } from '../supabase';
-import { DirectoryListingDB, ListingAnalyticsSummary } from '../../types/models';
+import { DirectoryListingDB, DirectoryListingCreateInput, ListingAnalyticsSummary } from '../../types/models';
 import { retry } from '../../utils/retry';
-
-// eslint-disable-next-line no-control-regex
-const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
+import { sanitizeString } from '../../utils/sanitize';
 
 const sanitize = <T extends Record<string, unknown>>(obj: T): T => {
     const result: Record<string, unknown> = { ...obj };
     for (const [key, value] of Object.entries(result)) {
         if (typeof value === 'string') {
-            result[key] = value.replace(STRIP_CONTROL, '').trim();
+            result[key] = sanitizeString(value);
         }
     }
     return result as T;
@@ -219,7 +217,7 @@ export const directoryService = {
         return { netVotes: data[0].net_votes };
     },
 
-    async createDirectoryListing(listing: Omit<DirectoryListingDB, 'id' | 'created_at' | 'updated_at'>): Promise<DirectoryListingDB> {
+    async createDirectoryListing(listing: DirectoryListingCreateInput): Promise<DirectoryListingDB> {
         const { data: { user } } = await supabase.auth.getUser();
         if (!user) throw new Error('Not authenticated');
 
@@ -378,9 +376,11 @@ export const directoryService = {
     },
 
     async rejectDirectoryListing(id: string, reason: string): Promise<void> {
+        if (reason.length > 1000) throw new Error('Rejection reason must be 1000 characters or fewer');
+        const sanitizedReason = sanitizeString(reason);
         const { data: listing, error } = await supabase
             .from('directory_listings')
-            .update({ status: 'rejected', rejection_reason: reason })
+            .update({ status: 'rejected', rejection_reason: sanitizedReason })
             .eq('id', id)
             .select('name, owner_user_id')
             .single();
@@ -390,7 +390,7 @@ export const directoryService = {
         }
         if (listing?.owner_user_id) {
             await retry(() => supabase.functions.invoke('send-email', {
-                body: { type: 'listing_rejected', userId: listing.owner_user_id, data: { title: listing.name, reason } },
+                body: { type: 'listing_rejected', userId: listing.owner_user_id, data: { title: listing.name, reason: sanitizedReason } },
             })).catch(console.error);
         }
     },

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -242,8 +242,11 @@ export const directoryService = {
             video_url: listing.video_url?.slice(0, 500) || null,
             is_featured: false,
             is_verified: false,
+            is_premium: false,
             tier,
             base_score: listing.base_score ?? 0,
+            status: 'pending' as const,
+            owner_user_id: user.id,
             ...(listing.slug ? { slug: listing.slug.slice(0, 200) } : {}),
             ...(listing.price_level !== undefined ? { price_level: listing.price_level } : {}),
             ...(listing.certifications?.length ? { certifications: listing.certifications } : {}),
@@ -278,6 +281,9 @@ export const directoryService = {
         delete safeUpdates.is_featured;
         delete safeUpdates.base_score;
         delete safeUpdates.subscription_id;
+        delete safeUpdates.status;
+        delete safeUpdates.owner_user_id;
+        delete safeUpdates.rejection_reason;
 
         // Validate gallery length against tier limit
         if (safeUpdates.gallery && Array.isArray(safeUpdates.gallery)) {
@@ -318,6 +324,55 @@ export const directoryService = {
         if (error) {
             console.error('Error deleting directory listing:', error);
             throw error;
+        }
+    },
+
+    async getPendingDirectoryListings(): Promise<DirectoryListingDB[]> {
+        const { data, error } = await supabase
+            .from('directory_listings')
+            .select('*')
+            .eq('status', 'pending')
+            .order('created_at', { ascending: true });
+        if (error) {
+            console.error('Error fetching pending listings:', error);
+            throw error;
+        }
+        return data as DirectoryListingDB[];
+    },
+
+    async approveDirectoryListing(id: string): Promise<void> {
+        const { data: listing, error } = await supabase
+            .from('directory_listings')
+            .update({ status: 'approved' })
+            .eq('id', id)
+            .select('name, owner_user_id')
+            .single();
+        if (error) {
+            console.error('Error approving listing:', error);
+            throw error;
+        }
+        if (listing?.owner_user_id) {
+            await supabase.functions.invoke('send-email', {
+                body: { type: 'listing_approved', userId: listing.owner_user_id, data: { title: listing.name } },
+            }).catch(console.error);
+        }
+    },
+
+    async rejectDirectoryListing(id: string, reason: string): Promise<void> {
+        const { data: listing, error } = await supabase
+            .from('directory_listings')
+            .update({ status: 'rejected', rejection_reason: reason })
+            .eq('id', id)
+            .select('name, owner_user_id')
+            .single();
+        if (error) {
+            console.error('Error rejecting listing:', error);
+            throw error;
+        }
+        if (listing?.owner_user_id) {
+            await supabase.functions.invoke('send-email', {
+                body: { type: 'listing_rejected', userId: listing.owner_user_id, data: { title: listing.name, reason } },
+            }).catch(console.error);
         }
     },
 

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../supabase';
 import { DirectoryListingDB, ListingAnalyticsSummary } from '../../types/models';
+import { retry } from '../../utils/retry';
 
 // eslint-disable-next-line no-control-regex
 const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
@@ -327,6 +328,24 @@ export const directoryService = {
         }
     },
 
+    async getDirectoryListingsByStatus(
+        status: 'approved' | 'rejected',
+        category?: string
+    ): Promise<DirectoryListingDB[]> {
+        let query = supabase
+            .from('directory_listings')
+            .select('*')
+            .eq('status', status)
+            .order('base_score', { ascending: false });
+        if (category) query = query.eq('category_id', category);
+        const { data, error } = await query;
+        if (error) {
+            console.error(`Error fetching ${status} listings:`, error);
+            throw error;
+        }
+        return data as DirectoryListingDB[];
+    },
+
     async getPendingDirectoryListings(): Promise<DirectoryListingDB[]> {
         const { data, error } = await supabase
             .from('directory_listings')
@@ -352,9 +371,9 @@ export const directoryService = {
             throw error;
         }
         if (listing?.owner_user_id) {
-            await supabase.functions.invoke('send-email', {
+            await retry(() => supabase.functions.invoke('send-email', {
                 body: { type: 'listing_approved', userId: listing.owner_user_id, data: { title: listing.name } },
-            }).catch(console.error);
+            })).catch(console.error);
         }
     },
 
@@ -370,9 +389,9 @@ export const directoryService = {
             throw error;
         }
         if (listing?.owner_user_id) {
-            await supabase.functions.invoke('send-email', {
+            await retry(() => supabase.functions.invoke('send-email', {
                 body: { type: 'listing_rejected', userId: listing.owner_user_id, data: { title: listing.name, reason } },
-            }).catch(console.error);
+            })).catch(console.error);
         }
     },
 

--- a/api-services/api/misc.ts
+++ b/api-services/api/misc.ts
@@ -1,19 +1,14 @@
 import { supabase } from '../supabase';
 import { Message } from '../../types/index';
 import { retry } from '../../utils/retry';
-
-// eslint-disable-next-line no-control-regex
-const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
-
-const sanitizeHeaderField = (value: string): string =>
-    value.replace(STRIP_CONTROL, '').trim();
+import { sanitizeString } from '../../utils/sanitize';
 
 const sanitizeMessage = (data: Message): Message => ({
     ...data,
-    name: sanitizeHeaderField(data.name).slice(0, 200),
-    email: sanitizeHeaderField(data.email).slice(0, 320),
-    subject: data.subject ? sanitizeHeaderField(data.subject).slice(0, 500) : data.subject,
-    message: sanitizeHeaderField(data.message).slice(0, 10000),
+    name: sanitizeString(data.name).slice(0, 200),
+    email: sanitizeString(data.email).slice(0, 320),
+    subject: data.subject ? sanitizeString(data.subject).slice(0, 500) : data.subject,
+    message: sanitizeString(data.message).slice(0, 10000),
 });
 
 export const messagesService = {

--- a/components/directory/DirectoryListingCard.test.tsx
+++ b/components/directory/DirectoryListingCard.test.tsx
@@ -27,6 +27,9 @@ const baseListing: DirectoryListingDB = {
     whatsapp: '+905551234567',
     website: 'https://example.com',
     google_map_url: 'https://maps.google.com',
+    status: 'approved',
+    owner_user_id: null,
+    rejection_reason: null,
 };
 
 describe('DirectoryListingCard', () => {

--- a/components/directory/DirectoryListingModal.test.tsx
+++ b/components/directory/DirectoryListingModal.test.tsx
@@ -45,6 +45,9 @@ const baseListing: DirectoryListingDB = {
     whatsapp: '+905551234567',
     website: 'https://example.com',
     google_map_url: 'https://maps.google.com',
+    status: 'approved',
+    owner_user_id: null,
+    rejection_reason: null,
 };
 
 describe('DirectoryListingModal', () => {

--- a/pages/AddListingPage.tsx
+++ b/pages/AddListingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams, Link, Navigate } from 'react-router-dom';
 import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
@@ -7,6 +7,7 @@ import { StepsIndicator } from '../components/ui/StepsIndicator';
 import { PhotoUploader } from '../components/ui/PhotoUploader';
 import { db } from '../api-services';
 import { useLanguage } from '../context/LanguageContext';
+import { useAuth } from '../context/AuthContext';
 
 interface FormData {
     name: string;
@@ -42,6 +43,7 @@ const TIER_LIMITS: Record<string, number> = {
 
 export const AddListingPage: React.FC = () => {
     const { t: _t } = useLanguage();
+    const { user } = useAuth();
     const [searchParams] = useSearchParams();
     const subscribed = searchParams.get('subscribed') === 'true';
 
@@ -137,6 +139,8 @@ export const AddListingPage: React.FC = () => {
             setIsSubmitting(false);
         }
     };
+
+    if (!user) return <Navigate to="/login" replace />;
 
     if (submitted) {
         return (

--- a/pages/AddListingPage.tsx
+++ b/pages/AddListingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSearchParams, Link, Navigate } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
@@ -7,7 +7,6 @@ import { StepsIndicator } from '../components/ui/StepsIndicator';
 import { PhotoUploader } from '../components/ui/PhotoUploader';
 import { db } from '../api-services';
 import { useLanguage } from '../context/LanguageContext';
-import { useAuth } from '../context/AuthContext';
 
 interface FormData {
     name: string;
@@ -43,7 +42,6 @@ const TIER_LIMITS: Record<string, number> = {
 
 export const AddListingPage: React.FC = () => {
     const { t: _t } = useLanguage();
-    const { user } = useAuth();
     const [searchParams] = useSearchParams();
     const subscribed = searchParams.get('subscribed') === 'true';
 
@@ -139,8 +137,6 @@ export const AddListingPage: React.FC = () => {
             setIsSubmitting(false);
         }
     };
-
-    if (!user) return <Navigate to="/login" replace />;
 
     if (submitted) {
         return (

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft, Save, Sparkles } from 'lucide-react';
 import { useSaveShortcut } from '../../hooks/useSaveShortcut';
 import { parseVideoEmbed } from '../../utils/videoEmbed';
 import toast from 'react-hot-toast';
-import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingDB, DirectoryListingCreateInput } from '../../types/models';
 import { slugify } from '../../utils/slugify';
 
 import { BasicDetailsForm } from '../../components/admin/directory/BasicDetailsForm';
@@ -168,7 +168,7 @@ export const AdminEditDirectoryPage: React.FC = () => {
 
             const finalImages = [...existingImages, ...uploadedUrls];
 
-            const listingData: Omit<DirectoryListingDB, 'id' | 'created_at' | 'updated_at'> = {
+            const listingData: DirectoryListingCreateInput = {
                 name: formData.name,
                 slug: formData.slug || undefined,
                 short_description: formData.short_description,

--- a/pages/admin/DirectoryAdminPage.test.tsx
+++ b/pages/admin/DirectoryAdminPage.test.tsx
@@ -20,9 +20,12 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 vi.mock('../../api-services', () => ({
     db: {
-        getDirectoryListings: vi.fn(),
+        getDirectoryListingsByStatus: vi.fn(),
+        getPendingDirectoryListings: vi.fn(),
         deleteDirectoryListing: vi.fn(),
-        createDirectoryListing: vi.fn()
+        createDirectoryListing: vi.fn(),
+        approveDirectoryListing: vi.fn(),
+        rejectDirectoryListing: vi.fn(),
     }
 }));
 
@@ -38,11 +41,10 @@ const mockListings = [
 ];
 
 describe('DirectoryAdminPage', () => {
-    const mockPagination = { page: 1, limit: 100, total: 2, totalPages: 1 };
-
     beforeEach(() => {
         vi.clearAllMocks();
-        (db.getDirectoryListings as any).mockResolvedValue({ data: mockListings, pagination: mockPagination });
+        (db.getDirectoryListingsByStatus as any).mockResolvedValue(mockListings);
+        (db.getPendingDirectoryListings as any).mockResolvedValue([]);
         vi.stubGlobal('confirm', vi.fn(() => true));
     });
 
@@ -58,7 +60,7 @@ describe('DirectoryAdminPage', () => {
         );
 
         await waitFor(() => {
-            expect(db.getDirectoryListings).toHaveBeenCalled();
+            expect(db.getDirectoryListingsByStatus).toHaveBeenCalledWith('approved', undefined);
             expect(screen.getByText('Test Medical')).toBeInTheDocument();
             expect(screen.getByText('Alanya Resort')).toBeInTheDocument();
         });
@@ -146,7 +148,8 @@ describe('DirectoryAdminPage', () => {
 
         await waitFor(() => {
             expect(db.deleteDirectoryListing).toHaveBeenCalledWith('1');
-            expect(db.getDirectoryListings).toHaveBeenCalledTimes(2); 
+            // loadListings calls getDirectoryListingsByStatus twice (approved + rejected) per invocation
+            expect(db.getDirectoryListingsByStatus).toHaveBeenCalledTimes(4);
         });
     });
 
@@ -176,7 +179,8 @@ describe('DirectoryAdminPage', () => {
     });
 
     it('handles mock data migration', async () => {
-        (db.getDirectoryListings as any).mockResolvedValueOnce({ data: [], pagination: mockPagination }).mockResolvedValue({ data: mockListings, pagination: mockPagination });
+        (db.getDirectoryListingsByStatus as any).mockResolvedValueOnce([]).mockResolvedValue(mockListings);
+        (db.getPendingDirectoryListings as any).mockResolvedValue([]);
         (db.createDirectoryListing as any).mockResolvedValue({ id: 'new' });
 
         render(
@@ -200,7 +204,7 @@ describe('DirectoryAdminPage', () => {
 
     it('handles API error when loading listings', async () => {
         const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-        (db.getDirectoryListings as any).mockRejectedValue(new Error('Fetch failed'));
+        (db.getDirectoryListingsByStatus as any).mockRejectedValue(new Error('Fetch failed'));
         
         render(
             <BrowserRouter>

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -7,13 +7,21 @@ import { MOCK_DIRECTORY_DATA } from '../../data/directoryData';
 import { DirectoryToolbar } from '../../components/admin/directory/DirectoryToolbar';
 import { DirectoryTable } from '../../components/admin/directory/DirectoryTable';
 import { toast } from 'react-hot-toast';
+import { CheckCircle, XCircle, Clock } from 'lucide-react';
+
+type AdminTab = 'approved' | 'pending' | 'rejected';
 
 export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ defaultCategory }) => {
     const navigate = useNavigate();
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
+    const [pendingListings, setPendingListings] = useState<DirectoryListingDB[]>([]);
+    const [rejectedListings, setRejectedListings] = useState<DirectoryListingDB[]>([]);
+    const [activeTab, setActiveTab] = useState<AdminTab>('approved');
     const [loading, setLoading] = useState(true);
     const [filterCategory, setFilterCategory] = useState<string>(defaultCategory || 'all');
     const [searchQuery, setSearchQuery] = useState('');
+    const [rejectingId, setRejectingId] = useState<string | null>(null);
+    const [rejectReason, setRejectReason] = useState('');
 
     const isCategoryLocked = !!defaultCategory;
 
@@ -35,8 +43,15 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         setLoading(true);
         try {
             const category = isCategoryLocked ? defaultCategory : undefined;
-            const response = await db.getDirectoryListings(1, 100, category, 'base_score');
-            setListings(response.data || []);
+            const [approvedResponse, pending] = await Promise.all([
+                db.getDirectoryListings(1, 100, category, 'base_score'),
+                db.getPendingDirectoryListings(),
+            ]);
+            const approved = (approvedResponse.data || []).filter(l => l.status === 'approved' || !l.status);
+            const rejected = (approvedResponse.data || []).filter(l => l.status === 'rejected');
+            setListings(approved);
+            setPendingListings(pending);
+            setRejectedListings(rejected);
         } catch (e) {
             console.error('Failed to load listings', e);
         } finally {
@@ -47,6 +62,32 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
     useEffect(() => {
         loadListings();
     }, [loadListings]);
+
+    const handleApprove = async (id: string) => {
+        try {
+            await db.approveDirectoryListing(id);
+            toast.success('Listing approved and published');
+            loadListings();
+        } catch (e: any) {
+            toast.error(`Failed to approve: ${e.message}`);
+        }
+    };
+
+    const handleRejectSubmit = async (id: string) => {
+        if (!rejectReason.trim()) {
+            toast.error('Please provide a rejection reason');
+            return;
+        }
+        try {
+            await db.rejectDirectoryListing(id, rejectReason.trim());
+            toast.success('Listing rejected');
+            setRejectingId(null);
+            setRejectReason('');
+            loadListings();
+        } catch (e: any) {
+            toast.error(`Failed to reject: ${e.message}`);
+        }
+    };
 
     const openActionModal = (action: 'delete', id: string, title: string) => {
         setModalConfig({
@@ -70,13 +111,13 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
             setModalConfig({ ...modalConfig, isOpen: false });
         } catch (e: any) {
             console.error(e);
-             toast.error(`Failed to delete listing: ${e.message || 'Unknown error'}`);
+            toast.error(`Failed to delete listing: ${e.message || 'Unknown error'}`);
         }
     };
 
     const handleMigrateMockData = async () => {
         if (!window.confirm("Are you sure? This will insert all local mock data into Supabase (useful for initial setup).")) return;
-        
+
         setLoading(true);
         try {
             let count = 0;
@@ -99,11 +140,11 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                 });
                 count++;
             }
-             toast.success(`Successfully migrated ${count} listings to Supabase!`);
+            toast.success(`Successfully migrated ${count} listings to Supabase!`);
             loadListings();
         } catch (error: any) {
             console.error(error);
-             toast.error('Migration failed: ' + error.message);
+            toast.error('Migration failed: ' + error.message);
         } finally {
             setLoading(false);
         }
@@ -112,7 +153,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
     const filteredListings = listings.filter(l => {
         const matchesCategory = isCategoryLocked || filterCategory === 'all' || l.category_id === filterCategory;
         const matchesSearch = l.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                              l.location.toLowerCase().includes(searchQuery.toLowerCase());
+            l.location.toLowerCase().includes(searchQuery.toLowerCase());
         return matchesCategory && matchesSearch;
     });
 
@@ -120,7 +161,6 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
 
     return (
         <div className="space-y-6 animate-in fade-in duration-500">
-            {/* Header & Stats */}
             <div className="flex flex-col md:flex-row gap-4 justify-between items-start md:items-center">
                 <div>
                     <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Directory Management</h1>
@@ -128,24 +168,147 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                 </div>
             </div>
 
-            <DirectoryToolbar
-                categories={categories}
-                filterCategory={filterCategory}
-                onFilterCategory={setFilterCategory}
-                searchQuery={searchQuery}
-                onSearchQuery={setSearchQuery}
-                showMigrateButton={listings.length === 0}
-                onMigrate={handleMigrateMockData}
-                onAddListing={() => navigate('/admin/directory/new')}
-                hideCategories={isCategoryLocked}
-            />
+            {/* Tabs */}
+            <div className="flex gap-2 border-b border-slate-200 dark:border-slate-700">
+                {([
+                    { key: 'approved', label: 'Approved', icon: CheckCircle, count: listings.length },
+                    { key: 'pending', label: 'Pending', icon: Clock, count: pendingListings.length },
+                    { key: 'rejected', label: 'Rejected', icon: XCircle, count: rejectedListings.length },
+                ] as const).map(({ key, label, icon: Icon, count }) => (
+                    <button
+                        key={key}
+                        onClick={() => setActiveTab(key)}
+                        className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                            activeTab === key
+                                ? 'border-teal-500 text-teal-600 dark:text-teal-400'
+                                : 'border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                        }`}
+                    >
+                        <Icon size={15} />
+                        {label}
+                        {count > 0 && (
+                            <span className={`text-xs px-1.5 py-0.5 rounded-full font-semibold ${
+                                key === 'pending'
+                                    ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                                    : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                            }`}>
+                                {count}
+                            </span>
+                        )}
+                    </button>
+                ))}
+            </div>
 
-            <DirectoryTable
-                loading={loading}
-                listings={filteredListings}
-                onEdit={(id) => navigate(`/admin/directory/${id}`)}
-                onDelete={(id, name) => openActionModal('delete', id, name)}
-            />
+            {/* Pending moderation queue */}
+            {activeTab === 'pending' && (
+                <div className="space-y-4">
+                    {loading ? (
+                        <p className="text-slate-500 text-sm">Loading...</p>
+                    ) : pendingListings.length === 0 ? (
+                        <div className="text-center py-12 text-slate-500">
+                            <Clock size={40} className="mx-auto mb-3 opacity-30" />
+                            <p>No pending submissions</p>
+                        </div>
+                    ) : pendingListings.map(listing => (
+                        <div key={listing.id} className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-5">
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="min-w-0">
+                                    <p className="font-semibold text-slate-900 dark:text-white truncate">{listing.name}</p>
+                                    <p className="text-sm text-slate-500 mt-0.5">{listing.category_id} · {listing.location}</p>
+                                    {listing.short_description && (
+                                        <p className="text-sm text-slate-600 dark:text-slate-400 mt-2 line-clamp-2">{listing.short_description}</p>
+                                    )}
+                                    <p className="text-xs text-slate-400 mt-2">
+                                        Submitted {listing.created_at ? new Date(listing.created_at).toLocaleDateString() : '—'}
+                                    </p>
+                                </div>
+                                {listing.gallery?.[0] && (
+                                    <img src={listing.gallery[0]} alt="" className="w-20 h-16 object-cover rounded-lg flex-shrink-0" />
+                                )}
+                            </div>
+
+                            {rejectingId === listing.id ? (
+                                <div className="mt-4 space-y-2">
+                                    <textarea
+                                        value={rejectReason}
+                                        onChange={e => setRejectReason(e.target.value)}
+                                        placeholder="Rejection reason (sent to the owner)..."
+                                        rows={2}
+                                        className="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-white resize-none focus:ring-2 focus:ring-red-400 outline-none"
+                                    />
+                                    <div className="flex gap-2">
+                                        <button
+                                            onClick={() => handleRejectSubmit(listing.id)}
+                                            className="px-4 py-1.5 text-sm font-medium bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors"
+                                        >
+                                            Confirm Reject
+                                        </button>
+                                        <button
+                                            onClick={() => { setRejectingId(null); setRejectReason(''); }}
+                                            className="px-4 py-1.5 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                                        >
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="flex gap-2 mt-4">
+                                    <button
+                                        onClick={() => handleApprove(listing.id)}
+                                        className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors"
+                                    >
+                                        <CheckCircle size={14} /> Approve
+                                    </button>
+                                    <button
+                                        onClick={() => setRejectingId(listing.id)}
+                                        className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium bg-red-50 hover:bg-red-100 text-red-600 dark:bg-red-900/20 dark:hover:bg-red-900/40 dark:text-red-400 rounded-lg transition-colors"
+                                    >
+                                        <XCircle size={14} /> Reject
+                                    </button>
+                                    <button
+                                        onClick={() => navigate(`/admin/directory/${listing.id}`)}
+                                        className="px-4 py-1.5 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                                    >
+                                        View
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Approved / Rejected tabs use the existing table */}
+            {activeTab === 'approved' && (
+                <>
+                    <DirectoryToolbar
+                        categories={categories}
+                        filterCategory={filterCategory}
+                        onFilterCategory={setFilterCategory}
+                        searchQuery={searchQuery}
+                        onSearchQuery={setSearchQuery}
+                        showMigrateButton={listings.length === 0}
+                        onMigrate={handleMigrateMockData}
+                        onAddListing={() => navigate('/admin/directory/new')}
+                        hideCategories={isCategoryLocked}
+                    />
+                    <DirectoryTable
+                        loading={loading}
+                        listings={filteredListings}
+                        onEdit={(id) => navigate(`/admin/directory/${id}`)}
+                        onDelete={(id, name) => openActionModal('delete', id, name)}
+                    />
+                </>
+            )}
+
+            {activeTab === 'rejected' && (
+                <DirectoryTable
+                    loading={loading}
+                    listings={rejectedListings}
+                    onEdit={(id) => navigate(`/admin/directory/${id}`)}
+                    onDelete={(id, name) => openActionModal('delete', id, name)}
+                />
+            )}
 
             <ConfirmationModal
                 isOpen={modalConfig.isOpen}

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -20,8 +20,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
     const [loading, setLoading] = useState(true);
     const [filterCategory, setFilterCategory] = useState<string>(defaultCategory || 'all');
     const [searchQuery, setSearchQuery] = useState('');
-    const [rejectingId, setRejectingId] = useState<string | null>(null);
-    const [rejectReason, setRejectReason] = useState('');
+    const [rejectState, setRejectState] = useState<{ id: string; reason: string } | null>(null);
 
     const isCategoryLocked = !!defaultCategory;
 
@@ -43,12 +42,11 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         setLoading(true);
         try {
             const category = isCategoryLocked ? defaultCategory : undefined;
-            const [approvedResponse, pending] = await Promise.all([
-                db.getDirectoryListings(1, 100, category, 'base_score'),
+            const [approved, pending, rejected] = await Promise.all([
+                db.getDirectoryListingsByStatus('approved', category),
                 db.getPendingDirectoryListings(),
+                db.getDirectoryListingsByStatus('rejected', category),
             ]);
-            const approved = (approvedResponse.data || []).filter(l => l.status === 'approved' || !l.status);
-            const rejected = (approvedResponse.data || []).filter(l => l.status === 'rejected');
             setListings(approved);
             setPendingListings(pending);
             setRejectedListings(rejected);
@@ -67,23 +65,22 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         try {
             await db.approveDirectoryListing(id);
             toast.success('Listing approved and published');
-            loadListings();
+            await loadListings();
         } catch (e: any) {
             toast.error(`Failed to approve: ${e.message}`);
         }
     };
 
     const handleRejectSubmit = async (id: string) => {
-        if (!rejectReason.trim()) {
+        if (!rejectState?.reason.trim()) {
             toast.error('Please provide a rejection reason');
             return;
         }
         try {
-            await db.rejectDirectoryListing(id, rejectReason.trim());
+            await db.rejectDirectoryListing(id, rejectState.reason.trim());
             toast.success('Listing rejected');
-            setRejectingId(null);
-            setRejectReason('');
-            loadListings();
+            setRejectState(null);
+            await loadListings();
         } catch (e: any) {
             toast.error(`Failed to reject: ${e.message}`);
         }
@@ -107,11 +104,12 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
             if (type === 'delete') {
                 await db.deleteDirectoryListing(itemId);
             }
-            loadListings();
-            setModalConfig({ ...modalConfig, isOpen: false });
+            await loadListings();
         } catch (e: any) {
             console.error(e);
             toast.error(`Failed to delete listing: ${e.message || 'Unknown error'}`);
+        } finally {
+            setModalConfig({ ...modalConfig, isOpen: false });
         }
     };
 
@@ -199,7 +197,6 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                 ))}
             </div>
 
-            {/* Pending moderation queue */}
             {activeTab === 'pending' && (
                 <div className="space-y-4">
                     {loading ? (
@@ -227,11 +224,11 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                                 )}
                             </div>
 
-                            {rejectingId === listing.id ? (
+                            {rejectState?.id === listing.id ? (
                                 <div className="mt-4 space-y-2">
                                     <textarea
-                                        value={rejectReason}
-                                        onChange={e => setRejectReason(e.target.value)}
+                                        value={rejectState.reason}
+                                        onChange={e => setRejectState({ id: listing.id, reason: e.target.value })}
                                         placeholder="Rejection reason (sent to the owner)..."
                                         rows={2}
                                         className="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-white resize-none focus:ring-2 focus:ring-red-400 outline-none"
@@ -244,7 +241,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                                             Confirm Reject
                                         </button>
                                         <button
-                                            onClick={() => { setRejectingId(null); setRejectReason(''); }}
+                                            onClick={() => setRejectState(null)}
                                             className="px-4 py-1.5 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
                                         >
                                             Cancel
@@ -260,7 +257,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                                         <CheckCircle size={14} /> Approve
                                     </button>
                                     <button
-                                        onClick={() => setRejectingId(listing.id)}
+                                        onClick={() => setRejectState({ id: listing.id, reason: '' })}
                                         className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium bg-red-50 hover:bg-red-100 text-red-600 dark:bg-red-900/20 dark:hover:bg-red-900/40 dark:text-red-400 rounded-lg transition-colors"
                                     >
                                         <XCircle size={14} /> Reject
@@ -278,7 +275,6 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                 </div>
             )}
 
-            {/* Approved / Rejected tabs use the existing table */}
             {activeTab === 'approved' && (
                 <>
                     <DirectoryToolbar

--- a/supabase/migrations/20260526120000_add_status_owner_to_directory_listings.sql
+++ b/supabase/migrations/20260526120000_add_status_owner_to_directory_listings.sql
@@ -1,0 +1,33 @@
+-- Add moderation status and ownership to directory_listings
+-- Enables self-service listing submissions with admin review workflow
+
+ALTER TABLE public.directory_listings
+    ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'approved', 'rejected')),
+    ADD COLUMN IF NOT EXISTS owner_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+
+-- All existing admin-created listings are already live
+UPDATE public.directory_listings SET status = 'approved' WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_directory_listings_status ON public.directory_listings (status);
+
+-- Public sees approved listings; owners see their own submissions; admins see all
+DROP POLICY IF EXISTS "directory_listings_select" ON public.directory_listings;
+CREATE POLICY "directory_listings_select" ON public.directory_listings
+    FOR SELECT USING (
+        status = 'approved'
+        OR owner_user_id = (SELECT auth.uid())
+        OR public.is_admin()
+    );
+
+-- Any authenticated user can submit a listing (pending, not featured/verified/premium)
+CREATE POLICY "directory_listings_insert_authenticated" ON public.directory_listings
+    FOR INSERT WITH CHECK (
+        (SELECT auth.role()) = 'authenticated'
+        AND owner_user_id = (SELECT auth.uid())
+        AND status = 'pending'
+        AND is_featured = false
+        AND is_verified = false
+        AND is_premium = false
+    );

--- a/supabase/migrations/20260527000000_fix_directory_listings_rls.sql
+++ b/supabase/migrations/20260527000000_fix_directory_listings_rls.sql
@@ -1,0 +1,57 @@
+-- Fix directory_listings RLS: add owner UPDATE/DELETE policies, length constraint, cleanup
+-- Owners can now edit and withdraw their own pending submissions.
+-- WITH CHECK prevents privilege escalation (self-approval, self-featuring, ranking manipulation, etc.).
+
+-- Safety-drop stale policies from early migrations (may persist in some environments)
+DROP POLICY IF EXISTS "directory_listings: public read approved" ON public.directory_listings;
+DROP POLICY IF EXISTS "directory_listings: admin manage" ON public.directory_listings;
+
+-- Recreate INSERT policy with base_score and tier restrictions
+-- (original in 20260526120000 didn't restrict these — allowed ranking/tier bypass via direct API)
+DROP POLICY IF EXISTS "directory_listings_insert_authenticated" ON public.directory_listings;
+CREATE POLICY "directory_listings_insert_authenticated" ON public.directory_listings
+    FOR INSERT WITH CHECK (
+        (SELECT auth.role()) = 'authenticated'
+        AND owner_user_id = (SELECT auth.uid())
+        AND status = 'pending'
+        AND is_featured = false
+        AND is_verified = false
+        AND is_premium = false
+        AND base_score = 0
+        AND tier = 'explorer'
+    );
+
+-- Owners can update their own pending listings (content fields only).
+-- WITH CHECK enforces at the DB level that protected fields cannot change,
+-- matching the client-side stripping in updateDirectoryListing().
+CREATE POLICY "directory_listings_update_owner" ON public.directory_listings
+    FOR UPDATE
+    USING (
+        owner_user_id = (SELECT auth.uid())
+        AND status = 'pending'
+    )
+    WITH CHECK (
+        owner_user_id = (SELECT auth.uid())
+        AND status = 'pending'
+        AND is_featured = false
+        AND is_verified = false
+        AND is_premium = false
+        AND base_score = 0
+        AND rejection_reason IS NULL
+    );
+
+-- Owners can delete (withdraw) their own pending submissions
+CREATE POLICY "directory_listings_delete_owner" ON public.directory_listings
+    FOR DELETE USING (
+        owner_user_id = (SELECT auth.uid())
+        AND status = 'pending'
+    );
+
+-- Limit rejection_reason to 1000 characters
+ALTER TABLE public.directory_listings
+    ADD CONSTRAINT directory_listings_rejection_reason_length
+    CHECK (rejection_reason IS NULL OR char_length(rejection_reason) <= 1000);
+
+-- Ensure only authenticated role can call is_admin() (not anon via PUBLIC inheritance)
+REVOKE EXECUTE ON FUNCTION public.is_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_admin() TO authenticated;

--- a/types/models.ts
+++ b/types/models.ts
@@ -437,6 +437,9 @@ export interface DirectoryListingDB {
   price_level?: 1 | 2 | 3 | 4;
   newsletter_featured?: boolean;
   net_votes?: number;
+  status?: 'pending' | 'approved' | 'rejected';
+  owner_user_id?: string;
+  rejection_reason?: string;
   created_at?: string;
   updated_at?: string;
 }

--- a/types/models.ts
+++ b/types/models.ts
@@ -437,12 +437,17 @@ export interface DirectoryListingDB {
   price_level?: 1 | 2 | 3 | 4;
   newsletter_featured?: boolean;
   net_votes?: number;
-  status?: 'pending' | 'approved' | 'rejected';
-  owner_user_id?: string;
-  rejection_reason?: string;
+  status: 'pending' | 'approved' | 'rejected';
+  owner_user_id: string | null;
+  rejection_reason: string | null;
   created_at?: string;
   updated_at?: string;
 }
+
+export type DirectoryListingCreateInput = Omit<
+  DirectoryListingDB,
+  'id' | 'created_at' | 'updated_at' | 'status' | 'owner_user_id' | 'rejection_reason'
+>;
 
 // ============================================================
 // Locations (LST-001)

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-control-regex
+const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
+
+export const sanitizeString = (value: string): string =>
+    value.replace(STRIP_CONTROL, '').trim();


### PR DESCRIPTION
## Summary
- Any authenticated user can submit a listing → stored as `status=pending`, invisible to public
- Admin panel gains Approved / Pending / Rejected tabs with approve/reject actions and inline rejection reason textarea
- Approve/reject triggers email via `send-email` Edge Function with 3-attempt retry
- New `getDirectoryListingsByStatus()` replaces 100-row mixed fetch + client-side split

## Key decisions
- Migration backfills all existing listings to `status=approved`; new RLS: public sees `approved`, owner sees own submissions, admin sees all
- `updateDirectoryListing` strips `status`, `owner_user_id`, `rejection_reason` — self-approval impossible
- Email wrapped in `retry()` consistent with `blog.ts` and `chat.ts` patterns
- Auth guard removed from `AddListingPage` — route already protected by `AuthRoute` in router
- `rejectState: { id, reason } | null` replaces two separate state vars to avoid torn state

## Testing
- Build: ✓ 0 TS errors
- Migration applied via Supabase MCP, backfill verified (0 non-approved rows)
- Submit listing as non-admin → `status=pending` in DB, not visible in directory
- Admin Pending tab → Approve → listing goes live + email sent
- Admin Pending tab → Reject with reason → owner gets rejection email
- `updateDirectoryListing` cannot change status (stripped in service layer)