### PR TITLE
fix: remove unused STRIP_CONTROL regex that broke CI on main

### DIFF
--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -3,9 +3,6 @@ import { DirectoryListingDB, DirectoryListingCreateInput, ListingAnalyticsSummar
 import { retry } from '../../utils/retry';
 import { sanitizeString } from '../../utils/sanitize';
 
-// eslint-disable-next-line no-control-regex
-const STRIP_CONTROL = /[\r\n\x00-\x1f\x7f]/g;
-
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function validateUUIDs(ids: string[]) {


### PR DESCRIPTION
## Summary
- Removes unused `STRIP_CONTROL` regex constant from `api-services/api/directory.ts`
- This constant was never referenced — `sanitizeString()` from `utils/sanitize.ts` already handles control character stripping
- Fixes broken CI on `main` (ESLint `@typescript-eslint/no-unused-vars` warning with `--max-warnings=0`)

## Root cause
PR #124 merged this constant without using it, causing CI to fail on `main` immediately after merge.