### PR TITLE
feat(navigation): add symmetrical Switch to Directory button in Rental mode

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -87,7 +87,18 @@ export const Navbar: React.FC = () => {
                 </Link>
               </div>
             ) : (
-              <ListPropertyAction />
+              <div className="flex items-center gap-3">
+                <div className="relative hidden md:block">
+                  <Link
+                    to="/"
+                    className="flex items-center gap-1.5 px-4 py-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700/80 text-slate-700 dark:text-slate-200 rounded-full text-sm font-medium transition-all duration-200 ease-out hover:scale-105 active:scale-95 whitespace-nowrap"
+                  >
+                    <ArrowRightLeft size={16} className="text-slate-500 dark:text-slate-400" />
+                    <span>{t('nav.switch_to_directory') || 'Switch to Directory'}</span>
+                  </Link>
+                </div>
+                <ListPropertyAction />
+              </div>
             )}
 
             {/* User Actions */}

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -16,6 +16,7 @@ export const ar = {
     'nav.list_property': 'اعرض عقارك',
     'nav.switch_to_rentals': 'الانتقال إلى الإيجارات والخدمات',
     'nav.list_rental_or_service': 'إدراج إيجار أو خدمة',
+    'nav.switch_to_directory': 'الذهاب إلى الدليل',
     'nav.community': 'المجتمع',
     'nav.login': 'تسجيل الدخول',
     'nav.signup': 'تسجيل',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -16,6 +16,7 @@ export const en = {
   'nav.list_property': 'List Property',
   'nav.switch_to_rentals': 'Switch to Rentals & Services',
   'nav.list_rental_or_service': 'List Rental or Service',
+  'nav.switch_to_directory': 'Switch to Directory',
   'nav.community': 'Community',
   'nav.login': 'Log in',
   'nav.signup': 'Sign up',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -16,6 +16,7 @@ export const ru = {
   'nav.list_property': 'Сдать объект',
   'nav.switch_to_rentals': 'Аренда и услуги',
   'nav.list_rental_or_service': 'Сдать жилье или услугу',
+  'nav.switch_to_directory': 'Справочник',
   'nav.community': 'Сообщество',
   'nav.login': 'Войти',
   'nav.signup': 'Зарегистрироваться',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -16,6 +16,7 @@ export const tr = {
     'nav.list_property': 'Evini Kirala',
     'nav.switch_to_rentals': 'Kiralama & Hizmetler',
     'nav.list_rental_or_service': 'Kiralama veya Hizmet Listele',
+    'nav.switch_to_directory': 'Rehber',
     'nav.community': 'Topluluk',
     'nav.login': 'Giriş yap',
     'nav.signup': 'Kaydol',


### PR DESCRIPTION
This Pull Request fixes the bi-directional switching bug on desktop where users could switch from Directory mode to Rental mode but had no clear header CTA to switch back. It introduces a symmetrical, beautifully styled 'Switch to Directory' button in Rental mode next to the 'List Property' button.