### PR TITLE
feat: add villa/apartment type filter to admin Properties page

### DIFF
--- a/components/admin/property/PropertyToolbar.tsx
+++ b/components/admin/property/PropertyToolbar.tsx
@@ -4,28 +4,47 @@ import { Search } from 'lucide-react';
 interface PropertyToolbarProps {
     filterStatus: string;
     onFilterStatus: (status: string) => void;
+    filterType: string;
+    onFilterType: (type: string) => void;
     searchQuery: string;
     onSearchQuery: (query: string) => void;
 }
 
 export const PropertyToolbar: React.FC<PropertyToolbarProps> = ({
-    filterStatus, onFilterStatus, searchQuery, onSearchQuery
+    filterStatus, onFilterStatus, filterType, onFilterType, searchQuery, onSearchQuery
 }) => {
     return (
         <div className="flex flex-col md:flex-row gap-4 justify-between items-center bg-white dark:bg-slate-800/80 p-4 rounded-2xl border border-slate-100 dark:border-slate-800/50 shadow-sm">
-            <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl">
-                {['all', 'pending', 'approved', 'rejected'].map(status => (
-                    <button
-                        key={status}
-                        onClick={() => onFilterStatus(status)}
-                        className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${filterStatus === status
-                            ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
-                            : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
-                            }`}
-                    >
-                        {status.charAt(0).toUpperCase() + status.slice(1)}
-                    </button>
-                ))}
+            <div className="flex flex-wrap gap-3">
+                <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl">
+                    {['all', 'pending', 'approved', 'rejected'].map(status => (
+                        <button
+                            key={status}
+                            onClick={() => onFilterStatus(status)}
+                            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${filterStatus === status
+                                ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                                : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                        >
+                            {status.charAt(0).toUpperCase() + status.slice(1)}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="flex gap-2 bg-slate-100 dark:bg-slate-800/50 p-1 rounded-xl">
+                    {['all', 'villa', 'apartment'].map(type => (
+                        <button
+                            key={type}
+                            onClick={() => onFilterType(type)}
+                            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${filterType === type
+                                ? 'bg-white dark:bg-slate-600 text-slate-900 dark:text-white shadow-sm'
+                                : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                        >
+                            {type.charAt(0).toUpperCase() + type.slice(1)}
+                        </button>
+                    ))}
+                </div>
             </div>
 
             <div className="relative w-full md:w-64">

--- a/pages/admin/PropertiesPage.tsx
+++ b/pages/admin/PropertiesPage.tsx
@@ -12,6 +12,7 @@ export const PropertiesPage: React.FC = () => {
     const [properties, setProperties] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [filterStatus, setFilterStatus] = useState<string>('all');
+    const [filterType, setFilterType] = useState<string>('all');
     const [searchQuery, setSearchQuery] = useState('');
 
     const [modalConfig, setModalConfig] = useState<{
@@ -96,10 +97,11 @@ export const PropertiesPage: React.FC = () => {
 
     const filteredProperties = properties.filter(p => {
         const matchesStatus = filterStatus === 'all' ? p.status !== 'rejected' : p.status === filterStatus;
+        const matchesType = filterType === 'all' || p.type === filterType;
         const matchesSearch =
             p.title?.toLowerCase().includes(searchQuery.toLowerCase()) ||
             p.location?.toLowerCase().includes(searchQuery.toLowerCase());
-        return matchesStatus && matchesSearch;
+        return matchesStatus && matchesType && matchesSearch;
     });
 
     return (
@@ -107,6 +109,8 @@ export const PropertiesPage: React.FC = () => {
             <PropertyToolbar
                 filterStatus={filterStatus}
                 onFilterStatus={setFilterStatus}
+                filterType={filterType}
+                onFilterType={setFilterType}
                 searchQuery={searchQuery}
                 onSearchQuery={setSearchQuery}
             />


### PR DESCRIPTION
## Summary
- Added type filter button group (All / Villa / Apartment) to PropertyToolbar
- Applied client-side type filtering in PropertiesPage alongside existing status and search filters
- Both filters work simultaneously (e.g. Pending + Villa)

## Test plan
- [ ] Open `/admin/properties` — two button groups visible in toolbar
- [ ] Click Villa → only villas shown
- [ ] Click Apartment → only apartments shown
- [ ] Combine with status filter — both apply
- [ ] Search works with type filter active