### PR TITLE
fix: host dashboard, listing analytics, payout security, admin UX

### DIFF
--- a/api-services/api/audit.ts
+++ b/api-services/api/audit.ts
@@ -21,7 +21,8 @@ export async function createAuditLog(
         | 'PROPERTY_DELETED'
         | 'SERVICE_APPROVED'
         | 'SERVICE_REJECTED'
-        | 'EMAIL_DELIVERY_FAILED',
+        | 'EMAIL_DELIVERY_FAILED'
+        | 'PAYOUT_STATUS_UPDATED',
     details: object,
     userId?: string
 ): Promise<void> {

--- a/api-services/api/bookings/index.ts
+++ b/api-services/api/bookings/index.ts
@@ -1,6 +1,6 @@
 import { Booking, UserProfile } from '../../../types/index';
 import { getBookings, getAdminBookings, getBookingsForHost } from './queries';
-import { createBooking, updateBookingStatus, cancelBooking, checkBookingConflict } from './mutations';
+import { createBooking, updateBookingStatus, updatePayoutStatus, cancelBooking, checkBookingConflict } from './mutations';
 
 export type { BookingCreateInput } from './mutations';
 export type { BookingConflictResult } from './mutations';
@@ -18,5 +18,6 @@ export const bookingsService = {
     getBookingsByStatus: (status: string) => getAdminBookings(status),
     getBookingsForHost,
     updateBookingStatus,
+    updatePayoutStatus,
     cancelBooking,
 };

--- a/api-services/api/bookings/mutations.ts
+++ b/api-services/api/bookings/mutations.ts
@@ -316,3 +316,18 @@ export async function cancelBooking(id: string) {
 
     return updateBookingStatus(id, 'cancelled', reason);
 }
+
+export async function updatePayoutStatus(id: string, payoutStatus: 'paid' | 'pending' | 'processing') {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error('Not authenticated');
+
+    // DB trigger (check_payout_status_update) enforces admin-only at the server level.
+    const { error } = await supabase
+        .from('bookings')
+        .update({ payout_status: payoutStatus })
+        .eq('id', id);
+
+    if (error) throw error;
+
+    await createAuditLog('PAYOUT_STATUS_UPDATED', { bookingId: id, payoutStatus }, user.id);
+}

--- a/api-services/api/forum.ts
+++ b/api-services/api/forum.ts
@@ -477,6 +477,19 @@ export const forumService = {
         if (error) throw error;
     },
 
+    /** Admin: list removed comments for moderation. */
+    async getRemovedComments(limit = 50): Promise<ForumComment[]> {
+        await requireAdmin();
+        const { data, error } = await supabase
+            .from('forum_comments')
+            .select('*, author:profiles!forum_comments_author_id_fkey(full_name, avatar_url)')
+            .eq('is_removed', true)
+            .order('created_at', { ascending: false })
+            .limit(limit);
+        if (error) throw error;
+        return data as ForumComment[];
+    },
+
     /** Admin: pin/unpin a post. */
     async setPinned(postId: string, pinned: boolean): Promise<void> {
         await requireAdmin();

--- a/components/admin/dashboard/StatCards.tsx
+++ b/components/admin/dashboard/StatCards.tsx
@@ -3,12 +3,17 @@ import { TrendingUp } from 'lucide-react';
 
 interface StatCardsProps {
     revenue: number;
+    revenueTrend: number | null;
     totalUsers: number;
     totalProperties: number;
     totalServices: number;
 }
 
-export const StatCards: React.FC<StatCardsProps> = ({ revenue, totalUsers, totalProperties, totalServices }) => {
+export const StatCards: React.FC<StatCardsProps> = ({ revenue, revenueTrend, totalUsers, totalProperties, totalServices }) => {
+    const trendColor = revenueTrend !== null && revenueTrend >= 0
+        ? 'text-teal-600 dark:text-teal-400'
+        : 'text-red-500 dark:text-red-400';
+
     return (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
             <div className="bg-white dark:bg-slate-800/80 p-6 rounded-2xl shadow-sm border border-slate-100 dark:border-slate-800/50 relative overflow-hidden group">
@@ -16,10 +21,16 @@ export const StatCards: React.FC<StatCardsProps> = ({ revenue, totalUsers, total
                 <div className="relative">
                     <p className="text-slate-500 font-medium mb-1">Total Revenue</p>
                     <h3 className="text-3xl font-bold text-slate-900 dark:text-white">€{revenue.toLocaleString()}</h3>
-                    <div className="flex items-center gap-1 text-teal-600 dark:text-cyan-400 dark:text-slate-200 text-sm font-medium mt-2">
-                        <TrendingUp size={16} />
-                        <span>+12.5%</span>
-                        <span className="text-slate-400 font-normal">vs last month</span>
+                    <div className="flex items-center gap-1 text-sm font-medium mt-2">
+                        {revenueTrend !== null ? (
+                            <>
+                                <TrendingUp size={16} className={trendColor} />
+                                <span className={trendColor}>{revenueTrend >= 0 ? '+' : ''}{revenueTrend}%</span>
+                                <span className="text-slate-400 font-normal">vs last month</span>
+                            </>
+                        ) : (
+                            <span className="text-slate-400 font-normal">No prior data</span>
+                        )}
                     </div>
                 </div>
             </div>

--- a/components/layouts/HostLayout.tsx
+++ b/components/layouts/HostLayout.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { NavLink, useNavigate, useLocation } from 'react-router-dom';
 import { LayoutDashboard, Home, Calendar, Inbox, LogOut, Menu, X, Plus, Car, Map as MapIcon, BarChart3 } from 'lucide-react';
 import { User } from '../../context/AuthContext';
-import { Button } from '../../components/ui/Button';
 import { ErrorBoundary } from '../ui/ErrorBoundary';
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 interface HostLayoutProps {
     children: React.ReactNode;
@@ -15,6 +15,9 @@ export const HostLayout: React.FC<HostLayoutProps> = ({ children, user, unreadCo
     const navigate = useNavigate();
     const location = useLocation();
     const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false);
+    const [isAddMenuOpen, setIsAddMenuOpen] = React.useState(false);
+    const addMenuRef = React.useRef<HTMLDivElement>(null);
+    useClickOutside(addMenuRef, () => setIsAddMenuOpen(false));
 
 
     // Handle Esc key to close mobile menu
@@ -63,14 +66,44 @@ export const HostLayout: React.FC<HostLayoutProps> = ({ children, user, unreadCo
                     </button>
                 </div>
 
-                <div className="p-4">
-                    <Button
-                        onClick={() => navigate('/list-property')}
-                        className="w-full justify-center gap-2 bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white shadow-lg shadow-indigo-500/20"
+                <div className="p-4 relative" ref={addMenuRef}>
+                    <button
+                        onClick={() => setIsAddMenuOpen(!isAddMenuOpen)}
+                        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white text-sm font-medium shadow-lg shadow-indigo-500/20 transition-all"
                     >
                         <Plus size={18} />
                         Add New Listing
-                    </Button>
+                    </button>
+                    {isAddMenuOpen && (
+                        <div className="absolute left-4 right-4 top-full mt-1 bg-white dark:bg-slate-900 rounded-xl shadow-xl border border-slate-100 dark:border-slate-800/50 overflow-hidden z-50 animate-in fade-in zoom-in-95 duration-150">
+                            <div className="p-1.5 space-y-0.5">
+                                <button
+                                    onClick={() => { navigate('/list-property'); setIsAddMenuOpen(false); }}
+                                    className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/90 transition-colors text-left group"
+                                >
+                                    <div className="w-8 h-8 rounded-lg bg-indigo-50 dark:bg-slate-800 text-indigo-600 dark:text-indigo-400 flex items-center justify-center">
+                                        <Home size={16} />
+                                    </div>
+                                    <div>
+                                        <span className="block text-sm font-medium text-slate-900 dark:text-white">List Property</span>
+                                        <span className="block text-xs text-slate-500">Villa or apartment</span>
+                                    </div>
+                                </button>
+                                <button
+                                    onClick={() => { navigate('/add-service'); setIsAddMenuOpen(false); }}
+                                    className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-800/90 transition-colors text-left group"
+                                >
+                                    <div className="w-8 h-8 rounded-lg bg-purple-50 dark:bg-slate-800 text-purple-600 dark:text-purple-400 flex items-center justify-center">
+                                        <Car size={16} />
+                                    </div>
+                                    <div>
+                                        <span className="block text-sm font-medium text-slate-900 dark:text-white">Add Service</span>
+                                        <span className="block text-xs text-slate-500">Fleet, tours, or other</span>
+                                    </div>
+                                </button>
+                            </div>
+                        </div>
+                    )}
                 </div>
 
                 <nav className="p-4 space-y-1 overflow-y-auto">

--- a/components/navbar/DesktopNav.tsx
+++ b/components/navbar/DesktopNav.tsx
@@ -36,7 +36,7 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({ mode = 'directory' }) =>
                 <>
                     <TabLink to="/" label={t('nav.directory') || 'Directory'} exact />
                     <TabLink to="/blog" label={t('nav.blog') || 'Blog'} />
-                    <TabLink to="/community" label={t('nav.forum') || 'Forum'} />
+                    <TabLink to="/forum" label={t('nav.forum') || 'Forum'} />
                     <TabLink to="/shop" label={t('shop') || 'Shop'} />
                 </>
             ) : (

--- a/components/navbar/MobileMenu.tsx
+++ b/components/navbar/MobileMenu.tsx
@@ -70,7 +70,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, mode, s
                             <BookOpen size={18} className="text-slate-400" />
                             {t('nav.blog') || 'Blog'}
                         </Link>
-                        <Link to="/community" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
+                        <Link to="/forum" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <MessageCircle size={18} className="text-slate-400" />
                             {t('nav.forum') || 'Forum'}
                         </Link>

--- a/hooks/useRemovedItems.ts
+++ b/hooks/useRemovedItems.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'react-hot-toast';
+import { db } from '../api-services';
+
+export function useRemovedItems<T extends { id: string }>(
+    targetType: 'post' | 'comment',
+    fetchFn: () => Promise<T[]>,
+) {
+    const [items, setItems] = useState<T[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [restoringId, setRestoringId] = useState<string | null>(null);
+
+    const fetchItems = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await fetchFn();
+            setItems(data);
+        } catch (e) {
+            toast.error((e as Error).message || `Failed to load removed ${targetType}s`);
+        } finally {
+            setLoading(false);
+        }
+    }, [fetchFn, targetType]);
+
+    const restoreItem = useCallback(async (id: string) => {
+        setRestoringId(id);
+        try {
+            await db.setRemoved(targetType, id, false);
+            toast.success(`${targetType === 'post' ? 'Post' : 'Comment'} restored`);
+            setItems(prev => prev.filter(item => item.id !== id));
+        } catch (e) {
+            toast.error((e as Error).message || 'Failed to restore');
+        } finally {
+            setRestoringId(null);
+        }
+    }, [targetType]);
+
+    return { items, loading, restoringId, fetchItems, restoreItem };
+}

--- a/pages/admin/AdminForumPage.tsx
+++ b/pages/admin/AdminForumPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
-import { Loader2, Plus, Trash2, Flag, Check, EyeOff, Eye } from 'lucide-react';
+import { Loader2, Plus, Trash2, Flag, Check, EyeOff, Eye, Pin, MessageSquareOff } from 'lucide-react';
 import { db } from '../../api-services';
-import { ForumCategory, ForumPost, ForumReport } from '../../types/models';
+import { ForumCategory, ForumPost, ForumComment, ForumReport } from '../../types/models';
+import { useRemovedItems } from '../../hooks/useRemovedItems';
 
 export const AdminForumPage: React.FC = () => {
     const [categories, setCategories] = useState<ForumCategory[]>([]);
@@ -12,9 +13,26 @@ export const AdminForumPage: React.FC = () => {
     const [newName, setNewName] = useState('');
     const [newDescription, setNewDescription] = useState('');
     const [creating, setCreating] = useState(false);
-    const [removedPosts, setRemovedPosts] = useState<ForumPost[]>([]);
-    const [loadingRemoved, setLoadingRemoved] = useState(false);
-    const [restoringId, setRestoringId] = useState<string | null>(null);
+    const {
+        items: removedPosts,
+        loading: loadingRemoved,
+        restoringId: restoringPostId,
+        fetchItems: fetchRemovedPosts,
+        restoreItem: restorePost,
+    } = useRemovedItems<ForumPost>('post', useCallback(async () => {
+        const { data } = await db.getForumPosts({ removedOnly: true, limit: 50 });
+        return data;
+    }, []));
+
+    const {
+        items: removedComments,
+        loading: loadingComments,
+        restoringId: restoringCommentId,
+        fetchItems: fetchRemovedComments,
+        restoreItem: restoreComment,
+    } = useRemovedItems<ForumComment>('comment', useCallback(async () => {
+        return db.getRemovedComments(50);
+    }, []));
 
     const fetchAll = useCallback(async () => {
         setLoading(true);
@@ -90,28 +108,12 @@ export const AdminForumPage: React.FC = () => {
         }
     };
 
-    const fetchRemovedPosts = useCallback(async () => {
-        setLoadingRemoved(true);
+    const handlePin = async (postId: string) => {
         try {
-            const { data } = await db.getForumPosts({ removedOnly: true, limit: 50 });
-            setRemovedPosts(data);
+            await db.setPinned(postId, true);
+            toast.success('Post pinned');
         } catch (e) {
-            toast.error((e as Error).message || 'Failed to load removed posts');
-        } finally {
-            setLoadingRemoved(false);
-        }
-    }, []);
-
-    const handleRestore = async (postId: string) => {
-        setRestoringId(postId);
-        try {
-            await db.setRemoved('post', postId, false);
-            toast.success('Post restored');
-            setRemovedPosts(prev => prev.filter(p => p.id !== postId));
-        } catch (e) {
-            toast.error((e as Error).message || 'Failed to restore post');
-        } finally {
-            setRestoringId(null);
+            toast.error((e as Error).message || 'Failed to pin');
         }
     };
 
@@ -216,6 +218,14 @@ export const AdminForumPage: React.FC = () => {
                                     >
                                         <EyeOff size={15} /> Hide content
                                     </button>
+                                    {r.target_type === 'post' && (
+                                        <button
+                                            onClick={() => handlePin(r.target_id)}
+                                            className="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-700 font-medium"
+                                        >
+                                            <Pin size={15} /> Pin
+                                        </button>
+                                    )}
                                     <button
                                         onClick={() => handleResolve(r)}
                                         className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-teal-600 font-medium"
@@ -263,12 +273,55 @@ export const AdminForumPage: React.FC = () => {
                                     </p>
                                 </div>
                                 <button
-                                    onClick={() => handleRestore(p.id)}
-                                    disabled={restoringId === p.id}
+                                    onClick={() => restorePost(p.id)}
+                                    disabled={restoringPostId === p.id}
                                     className="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 font-medium whitespace-nowrap disabled:opacity-50"
                                 >
-                                    {restoringId === p.id ? <Loader2 size={15} className="animate-spin" /> : <Eye size={15} />} Restore
+                                    {restoringPostId === p.id ? <Loader2 size={15} className="animate-spin" /> : <Eye size={15} />} Restore
                                 </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {/* Removed Comments */}
+            <section>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4 flex items-center gap-2">
+                    <MessageSquareOff size={18} className="text-slate-400" />
+                    Removed Comments
+                    {removedComments.length > 0 && (
+                        <span className="text-xs bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 px-2 py-0.5 rounded-full">
+                            {removedComments.length}
+                        </span>
+                    )}
+                </h2>
+
+                <button
+                    onClick={fetchRemovedComments}
+                    disabled={loadingComments}
+                    className="mb-4 px-4 py-2 text-sm bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors disabled:opacity-50"
+                >
+                    {loadingComments ? 'Loading...' : removedComments.length > 0 ? 'Refresh' : 'Load removed comments'}
+                </button>
+
+                {removedComments.length > 0 && (
+                    <div className="space-y-2 max-w-3xl">
+                        {removedComments.map(c => (
+                            <div key={c.id} className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 px-4 py-3">
+                                <p className="text-sm text-slate-700 dark:text-slate-300 mb-1 line-clamp-2">{c.body}</p>
+                                <p className="text-xs text-slate-500 dark:text-slate-400">
+                                    by {c.author?.full_name || 'Anonymous'} &middot; {c.created_at ? new Date(c.created_at).toLocaleDateString() : 'Unknown date'}
+                                </p>
+                                <div className="mt-2">
+                                    <button
+                                        onClick={() => restoreComment(c.id)}
+                                        disabled={restoringCommentId === c.id}
+                                        className="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 font-medium disabled:opacity-50"
+                                    >
+                                        {restoringCommentId === c.id ? <Loader2 size={15} className="animate-spin" /> : <Eye size={15} />} Restore
+                                    </button>
+                                </div>
                             </div>
                         ))}
                     </div>

--- a/pages/admin/BookingsPage.test.tsx
+++ b/pages/admin/BookingsPage.test.tsx
@@ -4,18 +4,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BookingsPage } from './BookingsPage';
 import { CurrencyProvider } from '../../context/CurrencyContext';
 import { db } from '../../api-services';
-import { supabase } from '../../api-services/supabase';
 
 vi.mock('../../api-services', () => ({
     db: {
         getAdminBookings: vi.fn(),
-        updateBookingStatus: vi.fn()
-    }
-}));
-
-vi.mock('../../api-services/supabase', () => ({
-    supabase: {
-        from: vi.fn()
+        updateBookingStatus: vi.fn(),
+        updatePayoutStatus: vi.fn(),
     }
 }));
 
@@ -71,46 +65,27 @@ describe('BookingsPage', () => {
         expect(screen.getByText('Payout')).toBeInTheDocument();
     });
 
-    // --- filterStatus ---
+    // --- filterStatus (server-side) ---
 
-    it('filtering by status: shows only pending bookings', async () => {
+    it('calls getAdminBookings without filter when status is "all"', async () => {
         renderPage();
 
         await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
-        // Both bookings visible initially
-        expect(screen.getByText('Bob')).toBeInTheDocument();
+        expect(db.getAdminBookings).toHaveBeenCalledWith(undefined);
+    });
+
+    it('calls getAdminBookings with status filter when a status tab is clicked', async () => {
+        (db.getAdminBookings as any).mockResolvedValue([mockBookings[0]]);
+
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
         fireEvent.click(screen.getByRole('button', { name: /^Pending$/i }));
 
         await waitFor(() => {
-            expect(screen.getByText('Alice')).toBeInTheDocument();
-            expect(screen.queryByText('Bob')).not.toBeInTheDocument();
-        });
-    });
-
-    it('filtering by status: shows only confirmed bookings', async () => {
-        renderPage();
-
-        await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument());
-
-        fireEvent.click(screen.getByRole('button', { name: /^Confirmed$/i }));
-
-        await waitFor(() => {
-            expect(screen.getByText('Bob')).toBeInTheDocument();
-            expect(screen.queryByText('Alice')).not.toBeInTheDocument();
-        });
-    });
-
-    it('filtering by status: shows no bookings when none match', async () => {
-        renderPage();
-
-        await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
-
-        fireEvent.click(screen.getByRole('button', { name: /^Completed$/i }));
-
-        await waitFor(() => {
-            expect(screen.getByText('No bookings found matching your filters.')).toBeInTheDocument();
+            expect(db.getAdminBookings).toHaveBeenCalledWith('pending');
         });
     });
 
@@ -151,7 +126,6 @@ describe('BookingsPage', () => {
 
         await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
-        // Search for id '2' — should show Bob, hide Alice
         fireEvent.change(screen.getByPlaceholderText('Search user, item, ID...'), {
             target: { value: '2' }
         });
@@ -169,9 +143,7 @@ describe('BookingsPage', () => {
 
         await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
-        // Date inputs have empty value initially
         const dateInputs = screen.getAllByDisplayValue('');
-        // First date input is start
         fireEvent.change(dateInputs[0], { target: { value: '2026-04-10' } });
 
         await waitFor(() => {
@@ -186,7 +158,6 @@ describe('BookingsPage', () => {
         await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument());
 
         const dateInputs = screen.getAllByDisplayValue('');
-        // Second date input is end
         fireEvent.change(dateInputs[1], { target: { value: '2026-04-05' } });
 
         await waitFor(() => {
@@ -205,7 +176,6 @@ describe('BookingsPage', () => {
 
         await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
-        // BookingTable renders a "Confirm" button (title="Confirm") only for pending bookings
         const confirmBtn = screen.getByTitle('Confirm');
         fireEvent.click(confirmBtn);
 
@@ -213,8 +183,6 @@ describe('BookingsPage', () => {
             expect(db.updateBookingStatus).toHaveBeenCalledWith('1', 'confirmed');
         });
 
-        // After update, the "Confirm" action button for booking '1' should no longer render
-        // because its status is now 'confirmed' (not 'pending')
         await waitFor(() => {
             expect(screen.queryByTitle('Confirm')).not.toBeInTheDocument();
         });
@@ -234,35 +202,27 @@ describe('BookingsPage', () => {
             expect(db.updateBookingStatus).not.toHaveBeenCalled();
         });
 
-        // Booking status remains unchanged — "Confirm" button still present for Alice's booking
         expect(screen.getByTitle('Confirm')).toBeInTheDocument();
     });
 
     // --- handlePayoutStatusChange ---
 
-    it('handlePayoutStatusChange: calls supabase.from("bookings").update when user confirms', async () => {
-        const mockEq = vi.fn().mockResolvedValue({ error: null });
-        const mockUpdate = vi.fn().mockReturnValue({ eq: mockEq });
-        (supabase.from as any).mockReturnValue({ update: mockUpdate });
-
+    it('handlePayoutStatusChange: calls db.updatePayoutStatus when user confirms', async () => {
+        (db.updatePayoutStatus as any).mockResolvedValue(undefined);
         vi.spyOn(window, 'confirm').mockReturnValue(true);
 
         renderPage();
 
         await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
-        // Open booking details modal for Alice's booking (id='1', payout_status='pending')
         const viewBtns = screen.getAllByTitle('View Details');
         fireEvent.click(viewBtns[0]);
 
-        // Modal should appear with "Mark Paid" button (rendered when payout_status === 'pending')
         const markPaidBtn = await screen.findByRole('button', { name: /Mark Paid/i });
         fireEvent.click(markPaidBtn);
 
         await waitFor(() => {
-            expect(supabase.from).toHaveBeenCalledWith('bookings');
-            expect(mockUpdate).toHaveBeenCalledWith({ payout_status: 'paid' });
-            expect(mockEq).toHaveBeenCalledWith('id', '1');
+            expect(db.updatePayoutStatus).toHaveBeenCalledWith('1', 'paid');
         });
     });
 
@@ -280,7 +240,7 @@ describe('BookingsPage', () => {
         fireEvent.click(markPaidBtn);
 
         await waitFor(() => {
-            expect(supabase.from).not.toHaveBeenCalled();
+            expect(db.updatePayoutStatus).not.toHaveBeenCalled();
         });
     });
 });

--- a/pages/admin/BookingsPage.tsx
+++ b/pages/admin/BookingsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { db } from '../../api-services';
-import { supabase } from '../../api-services/supabase';
 import { BookingToolbar } from '../../components/admin/bookings/BookingToolbar';
 import { BookingTable } from '../../components/admin/bookings/BookingTable';
 import { BookingDetailsModal } from '../../components/admin/bookings/BookingDetailsModal';
@@ -15,13 +14,14 @@ export const BookingsPage: React.FC = () => {
     const [dateRange, setDateRange] = useState({ start: '', end: '' });
 
     useEffect(() => {
-        loadBookings();
-    }, []);
+        loadBookings(filterStatus);
+    }, [filterStatus]);
 
-    const loadBookings = async () => {
+    const loadBookings = async (status?: string) => {
         try {
             setLoading(true);
-            const data = await db.getAdminBookings();
+            const filter = status && status !== 'all' ? status : undefined;
+            const data = await db.getAdminBookings(filter);
             setBookings(data || []);
         } catch (e) {
             console.error(e);
@@ -47,20 +47,17 @@ export const BookingsPage: React.FC = () => {
     const handlePayoutStatusChange = async (id: string, newStatus: 'paid' | 'pending' | 'processing') => {
         if (!confirm(`Mark payout as ${newStatus}?`)) return;
         try {
-            const { error } = await supabase.from('bookings').update({ payout_status: newStatus }).eq('id', id);
-            if (error) throw error;
-
+            await db.updatePayoutStatus(id, newStatus);
             setBookings(prev => prev.map(b => b.id === id ? { ...b, payout_status: newStatus } : b));
             if (selectedBooking?.id === id) {
                 setSelectedBooking((prev: any) => ({ ...prev, payout_status: newStatus }));
             }
-             } catch {
-                 toast.error('Failed to update payout status');
-             }
+        } catch {
+            toast.error('Failed to update payout status');
+        }
     };
 
     const filteredBookings = bookings.filter(b => {
-        const matchesStatus = filterStatus === 'all' || b.status === filterStatus;
         const matchesSearch =
             b.user?.full_name?.toLowerCase().includes(searchQuery.toLowerCase()) ||
             b.itemTitle?.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -74,7 +71,7 @@ export const BookingsPage: React.FC = () => {
             matchesDate = matchesDate && new Date(b.check_in) <= new Date(dateRange.end);
         }
 
-        return matchesStatus && matchesSearch && matchesDate;
+        return matchesSearch && matchesDate;
     });
 
     return (

--- a/pages/admin/Dashboard.tsx
+++ b/pages/admin/Dashboard.tsx
@@ -13,6 +13,7 @@ export const Dashboard: React.FC = () => {
         total_users: number;
         total_services: number;
         revenue: number;
+        revenueTrend: number | null;
         revenue_history: any[];
         booking_status_distribution: any[];
         recent_bookings: any[];
@@ -21,6 +22,7 @@ export const Dashboard: React.FC = () => {
         total_users: 0,
         total_services: 0,
         revenue: 0,
+        revenueTrend: null,
         revenue_history: [],
         booking_status_distribution: [],
         recent_bookings: []
@@ -75,12 +77,21 @@ export const Dashboard: React.FC = () => {
                 const recent = [...pendingBookings, ...allBookings, ...completedBookings, ...cancelledBookings]
                     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
                     .slice(0, 5);
+
+                // Compute revenue trend (current month vs previous month)
+                const currentMonthRev = revenueHistory[revenueHistory.length - 1]?.value ?? 0;
+                const previousMonthRev = revenueHistory.length >= 2 ? revenueHistory[revenueHistory.length - 2].value : 0;
+                const revenueTrend = previousMonthRev > 0
+                    ? Math.round(((currentMonthRev - previousMonthRev) / previousMonthRev) * 1000) / 10
+                    : null;
+
                 if (isMountedRef.current) {
                     setStats({
                         total_properties: totalProperties || 0,
                         total_users: users?.length || 0,
                         total_services: totalServices || 0,
                         revenue: totalRevenue,
+                        revenueTrend,
                         revenue_history: revenueHistory,
                         booking_status_distribution: bookingStatusDistribution,
                         recent_bookings: recent
@@ -104,11 +115,12 @@ export const Dashboard: React.FC = () => {
 
     return (
         <div className="space-y-8 animate-in fade-in duration-500">
-            <StatCards 
-                revenue={stats.revenue} 
-                totalUsers={stats.total_users} 
-                totalProperties={stats.total_properties} 
-                totalServices={stats.total_services} 
+            <StatCards
+                revenue={stats.revenue}
+                revenueTrend={stats.revenueTrend}
+                totalUsers={stats.total_users}
+                totalProperties={stats.total_properties}
+                totalServices={stats.total_services}
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/pages/admin/ServicesPage.test.tsx
+++ b/pages/admin/ServicesPage.test.tsx
@@ -145,17 +145,16 @@ describe('Admin ServicesPage', () => {
         (db.getAdminServices as any).mockResolvedValue({ data: mockServices });
         (db.getPendingServiceEdits as any).mockResolvedValue([]);
         (db.approveService as any).mockResolvedValue({});
-        
+
         renderServicesPage();
 
         await waitFor(() => expect(screen.getByText('Car Rental')).toBeInTheDocument());
 
         fireEvent.click(screen.getByText('Select All'));
-        
+
         const bulkApproveBtn = screen.getByText('Approve Selected');
         fireEvent.click(bulkApproveBtn);
 
-        expect(window.confirm).toHaveBeenCalled();
         await waitFor(() => {
             expect(db.approveService).toHaveBeenCalledTimes(2);
         });
@@ -179,21 +178,28 @@ describe('Admin ServicesPage', () => {
         (db.getAdminServices as any).mockResolvedValue({ data: mockServices });
         (db.getPendingServiceEdits as any).mockResolvedValue([]);
         (db.deleteService as any).mockResolvedValue({});
-        
+
         renderServicesPage();
 
         await waitFor(() => expect(screen.getByText('Car Rental')).toBeInTheDocument());
 
         fireEvent.click(screen.getByText('Select All'));
-        
-        // Use more specific selector for bulk action toolbar
+
         const deleteBtns = screen.getAllByText('Delete');
         const bulkDeleteBtn = deleteBtns.find(btn => btn.className.includes('bg-red-100')) || deleteBtns[0];
         fireEvent.click(bulkDeleteBtn);
 
-        expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('delete 2 services'));
+        // Bulk delete now opens ConfirmationModal instead of window.confirm
+        await waitFor(() => {
+            expect(screen.getByText(/Delete 2 Services/i)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Confirm'));
+
         await waitFor(() => {
             expect(db.deleteService).toHaveBeenCalledTimes(2);
+            expect(db.deleteService).toHaveBeenCalledWith('1', 'Test Reason');
+            expect(db.deleteService).toHaveBeenCalledWith('2', 'Test Reason');
         });
     });
 
@@ -201,20 +207,27 @@ describe('Admin ServicesPage', () => {
         (db.getAdminServices as any).mockResolvedValue({ data: mockServices });
         (db.getPendingServiceEdits as any).mockResolvedValue([]);
         (db.updateServiceStatus as any).mockResolvedValue({});
-        
+
         renderServicesPage();
 
         await waitFor(() => expect(screen.getByText('Car Rental')).toBeInTheDocument());
 
         fireEvent.click(screen.getByText('Select All'));
-        
+
         const bulkRejectBtn = screen.getByText('Reject Selected');
         fireEvent.click(bulkRejectBtn);
 
-        expect(window.confirm).toHaveBeenCalled();
+        // Bulk reject now opens ConfirmationModal instead of window.confirm
+        await waitFor(() => {
+            expect(screen.getByText(/Reject 2 Services/i)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Confirm'));
+
         await waitFor(() => {
             expect(db.updateServiceStatus).toHaveBeenCalledTimes(2);
-            expect(db.updateServiceStatus).toHaveBeenCalledWith(expect.any(String), 'rejected');
+            expect(db.updateServiceStatus).toHaveBeenCalledWith('1', 'rejected', 'Test Reason');
+            expect(db.updateServiceStatus).toHaveBeenCalledWith('2', 'rejected', 'Test Reason');
         });
     });
 

--- a/pages/admin/ServicesPage.tsx
+++ b/pages/admin/ServicesPage.tsx
@@ -10,6 +10,13 @@ interface AdminServicesPageProps {
     type?: 'fleet' | 'services';
 }
 
+const MODAL_META: Record<string, { label: string; placeholder: string }> = {
+    delete:      { label: 'Delete', placeholder: 'Why are you deleting this service?' },
+    bulk_delete: { label: 'Delete', placeholder: 'Why are you deleting these services?' },
+    reject:      { label: 'Reject', placeholder: 'Why are you rejecting this service?' },
+    bulk_reject: { label: 'Reject', placeholder: 'Why are you rejecting these services?' },
+};
+
 export const ServicesPage: React.FC<AdminServicesPageProps> = ({ type }) => {
     const [services, setServices] = useState<any[]>([]);
     const [pendingEdits, setPendingEdits] = useState<any[]>([]);
@@ -20,7 +27,7 @@ export const ServicesPage: React.FC<AdminServicesPageProps> = ({ type }) => {
 
     const [modalConfig, setModalConfig] = useState<{
         isOpen: boolean;
-        type: 'approve' | 'reject' | 'delete' | 'bulk_delete' | null;
+        type: 'approve' | 'reject' | 'delete' | 'bulk_delete' | 'bulk_reject' | null;
         itemId: string | null;
         title: string;
         message: string;
@@ -59,38 +66,47 @@ export const ServicesPage: React.FC<AdminServicesPageProps> = ({ type }) => {
         setSelectedIds(newSelected);
     };
 
-    const handleBulkAction = async (action: 'approve' | 'reject' | 'delete') => {
+    const executeBulk = async (
+        fns: Array<() => Promise<unknown>>,
+        successMsg: string,
+        failLabel: string,
+    ) => {
+        const results = await Promise.allSettled(fns.map(fn => fn()));
+        const failed = results.filter(r => r.status === 'rejected').length;
+        if (failed > 0) {
+            toast.error(`Failed to ${failLabel} ${failed} service${failed > 1 ? 's' : ''}`);
+        } else {
+            toast.success(successMsg);
+        }
+        loadServices();
+        setSelectedIds(new Set());
+    };
+
+    const bulkApprove = () => {
+        const fns = Array.from(selectedIds).map(id => () => db.approveService(id));
+        executeBulk(fns, `${selectedIds.size} service${selectedIds.size > 1 ? 's' : ''} approved`, 'approve');
+    };
+
+    const handleBulkAction = (action: 'approve' | 'reject' | 'delete') => {
         if (selectedIds.size === 0) return;
 
-        if (action === 'delete') {
-            if (confirm(`Are you sure you want to delete ${selectedIds.size} services? This cannot be undone.`)) {
-                try {
-                     await Promise.all(Array.from(selectedIds).map(id => db.deleteService(id)));
-                     setServices(prev => prev.filter(s => !selectedIds.has(s.id)));
-                     setSelectedIds(new Set());
-                 } catch (e) {
-                     console.error(e);
-                     toast.error('Failed to delete some services.');
-                 }
-            }
+        if (action === 'approve') {
+            bulkApprove();
             return;
         }
 
-        if (confirm(`Are you sure you want to ${action} ${selectedIds.size} services?`)) {
-            try {
-                const updates = Array.from(selectedIds).map(id => {
-                    if (action === 'approve') return db.approveService(id);
-                    if (action === 'reject') return db.updateServiceStatus(id, 'rejected');
-                    return Promise.resolve();
-                });
-                await Promise.all(updates);
-                loadServices();
-                setSelectedIds(new Set());
-            } catch (e) {
-             console.error(e);
-                 toast.error(`Failed to ${action} services.`);
-            }
-        }
+        const isBulkDelete = action === 'delete';
+        setModalConfig({
+            isOpen: true,
+            type: isBulkDelete ? 'bulk_delete' : 'bulk_reject',
+            itemId: null,
+            title: isBulkDelete ? `Delete ${selectedIds.size} Services` : `Reject ${selectedIds.size} Services`,
+            message: isBulkDelete
+                ? `Are you sure you want to delete ${selectedIds.size} services? This cannot be undone.`
+                : `Are you sure you want to reject ${selectedIds.size} services?`,
+            requireReason: true,
+            isDestructive: true,
+        });
     };
 
     const loadServices = async () => {
@@ -147,23 +163,28 @@ export const ServicesPage: React.FC<AdminServicesPageProps> = ({ type }) => {
 
     const handleConfirmAction = async (reason?: string) => {
         const { type, itemId } = modalConfig;
-        if (!type || !itemId) return;
+        if (!type) return;
 
         try {
-            if (type === 'approve') await db.approveService(itemId);
-            if (type === 'reject') {
-                await db.updateServiceStatus(itemId, 'rejected', reason);
-            }
-            if (type === 'delete') {
-                await db.deleteService(itemId, reason);
+            if (type === 'bulk_delete') {
+                const fns = Array.from(selectedIds).map(id => () => db.deleteService(id, reason));
+                await executeBulk(fns, 'Services deleted', 'delete');
+            } else if (type === 'bulk_reject') {
+                const fns = Array.from(selectedIds).map(id => () => db.updateServiceStatus(id, 'rejected', reason));
+                await executeBulk(fns, 'Services rejected', 'reject');
+            } else {
+                if (!itemId) return;
+                if (type === 'approve') await db.approveService(itemId);
+                if (type === 'reject') await db.updateServiceStatus(itemId, 'rejected', reason);
+                if (type === 'delete') await db.deleteService(itemId, reason);
+                loadServices();
             }
 
-            loadServices();
             setModalConfig({ ...modalConfig, isOpen: false });
-         } catch (e: any) {
-             console.error(e);
-             toast.error(`Failed to ${type} service: ${e.message || 'Unknown error'}`);
-         }
+        } catch (e: any) {
+            console.error(e);
+            toast.error(`Failed to ${type.replace('bulk_', '')} service: ${e.message || 'Unknown error'}`);
+        }
     };
 
     const filteredServices = services.filter(s => {
@@ -229,8 +250,8 @@ export const ServicesPage: React.FC<AdminServicesPageProps> = ({ type }) => {
                 message={modalConfig.message}
                 requireReason={modalConfig.requireReason}
                 isDestructive={modalConfig.isDestructive}
-                confirmLabel={modalConfig.type === 'delete' ? 'Delete' : modalConfig.type === 'reject' ? 'Reject' : 'Approve'}
-                reasonPlaceholder={modalConfig.type === 'delete' ? 'Why are you deleting this service?' : 'Why are you rejecting this service?'}
+                confirmLabel={MODAL_META[modalConfig.type ?? '']?.label ?? 'Approve'}
+                reasonPlaceholder={MODAL_META[modalConfig.type ?? '']?.placeholder}
             />
         </div>
     );

--- a/supabase/migrations/20260528000003_create_listing_analytics_table_and_track_rpcs.sql
+++ b/supabase/migrations/20260528000003_create_listing_analytics_table_and_track_rpcs.sql
@@ -1,0 +1,96 @@
+-- Purpose: Create listing_analytics table and tracking RPCs (missing from DB).
+-- The get_directory_analytics_for_owner and get_category_analytics_average functions
+-- already exist via 20260527085959_add_category_analytics_rpc; only the table
+-- and track_* helpers are missing.
+
+-- 1. Add video_url to directory_listings (was in original migration, not yet applied)
+ALTER TABLE public.directory_listings
+    ADD COLUMN IF NOT EXISTS video_url TEXT;
+
+-- 2. Create listing_analytics table (daily aggregation)
+CREATE TABLE IF NOT EXISTS public.listing_analytics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    listing_id UUID NOT NULL REFERENCES public.directory_listings(id) ON DELETE CASCADE,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
+    views INT NOT NULL DEFAULT 0,
+    whatsapp_clicks INT NOT NULL DEFAULT 0,
+    website_clicks INT NOT NULL DEFAULT 0,
+    map_clicks INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE(listing_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_listing_analytics_listing_date
+    ON public.listing_analytics(listing_id, date DESC);
+
+ALTER TABLE public.listing_analytics ENABLE ROW LEVEL SECURITY;
+
+-- Owners can read analytics for their own listings via owner_user_id; admins can read all
+CREATE POLICY "listing_analytics: owner read"
+    ON public.listing_analytics FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.directory_listings dl
+            WHERE dl.id = listing_analytics.listing_id
+              AND dl.owner_user_id = auth.uid()
+        )
+        OR
+        EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = auth.uid() AND role = 'admin'
+        )
+    );
+
+-- 3. RPC: track listing view (atomic upsert)
+CREATE OR REPLACE FUNCTION public.track_listing_view(p_listing_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO public.listing_analytics (listing_id, date, views, whatsapp_clicks, website_clicks, map_clicks)
+    VALUES (p_listing_id, CURRENT_DATE, 1, 0, 0, 0)
+    ON CONFLICT (listing_id, date) DO UPDATE
+    SET views = public.listing_analytics.views + 1;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.track_listing_view(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.track_listing_view(UUID) TO anon, authenticated;
+
+-- 4. RPC: track listing click (atomic update)
+CREATE OR REPLACE FUNCTION public.track_listing_click(p_listing_id UUID, p_click_type TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF p_click_type NOT IN ('whatsapp', 'website', 'map') THEN
+        RAISE EXCEPTION 'Invalid click type: %', p_click_type;
+    END IF;
+
+    INSERT INTO public.listing_analytics (listing_id, date, views, whatsapp_clicks, website_clicks, map_clicks)
+    VALUES (p_listing_id, CURRENT_DATE, 0, 0, 0, 0)
+    ON CONFLICT (listing_id, date) DO NOTHING;
+
+    UPDATE public.listing_analytics
+    SET
+        whatsapp_clicks = whatsapp_clicks + CASE WHEN p_click_type = 'whatsapp' THEN 1 ELSE 0 END,
+        website_clicks  = website_clicks  + CASE WHEN p_click_type = 'website'  THEN 1 ELSE 0 END,
+        map_clicks      = map_clicks      + CASE WHEN p_click_type = 'map'      THEN 1 ELSE 0 END
+    WHERE listing_id = p_listing_id AND date = CURRENT_DATE;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.track_listing_click(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.track_listing_click(UUID, TEXT) TO anon, authenticated;
+
+-- 5. Ensure grants on already-existing owner analytics RPCs
+REVOKE EXECUTE ON FUNCTION public.get_directory_analytics_for_owner(UUID, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_directory_analytics_for_owner(UUID, INT) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_category_analytics_average(TEXT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_category_analytics_average(TEXT, INT) TO authenticated;

--- a/supabase/migrations/20260528000004_guard_payout_status_admin_only.sql
+++ b/supabase/migrations/20260528000004_guard_payout_status_admin_only.sql
@@ -1,0 +1,27 @@
+-- Purpose: Enforce that payout_status on bookings can only be changed by admins.
+-- The client-side check in updatePayoutStatus() is insufficient — any authenticated
+-- user can bypass it with a direct Supabase JS call on a row they own.
+-- This trigger enforces the constraint at the DB level regardless of call origin.
+
+CREATE OR REPLACE FUNCTION public.check_payout_status_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    IF NEW.payout_status IS DISTINCT FROM OLD.payout_status THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin'
+        ) THEN
+            RAISE EXCEPTION 'Unauthorized: payout_status can only be changed by admins';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER bookings_payout_status_guard
+    BEFORE UPDATE ON public.bookings
+    FOR EACH ROW
+    EXECUTE FUNCTION public.check_payout_status_update();


### PR DESCRIPTION
## Summary

- **HostLayout**: "Add New Listing" button replaced with dropdown — List Property / Add Service
- **listing_analytics**: creates missing table + `track_listing_view` / `track_listing_click` RPCs; fixes `/host/directory-analytics` 404 error
- **Security fix**: DB trigger `bookings_payout_status_guard` enforces admin-only `payout_status` changes at the database level — previously only a bypassable client-side check
- **AdminForumPage**: refactored to `useRemovedItems` hook; adds removed comments section with inline restore
- **BookingsPage**: filter passed to API instead of client-side; payout update routed through service layer with audit log
- **ServicesPage**: bulk reject now opens confirmation modal with reason; `executeBulk` helper eliminates duplication; `MODAL_META` lookup replaces ternary chains
- **Dashboard**: real revenue trend computed from history (was hardcoded +12.5%)
- **StatCards**: accepts `revenueTrend` prop, renders directional color

## Key architectural decisions

- Payout status enforcement moved to a `BEFORE UPDATE` trigger (`check_payout_status_update`). This blocks any path — direct Supabase JS, RPC, or future code — without relying on client-side role checks.
- `useRemovedItems<T>` is a generic hook so it works for both posts and comments without duplication.
- `executeBulk` uses `Promise.allSettled` and inspects individual results, so partial failures are reported correctly (prior `try/catch` around `allSettled` was dead code).

## Migrations applied
- `20260528000003_create_listing_analytics_table_and_track_rpcs`
- `20260528000004_guard_payout_status_admin_only`

## Test plan
- [ ] `/host/directory-analytics` loads without 404 console errors
- [ ] Host sidebar "Add New Listing" opens dropdown with two options, each navigates correctly
- [ ] Admin Bookings page: filter by status fetches from API correctly
- [ ] Admin Bookings page: payout status change is blocked for non-admins at DB level
- [ ] Admin Services page: bulk reject opens modal with reason field
- [ ] Admin Forum page: removed comments section loads and restore works
- [ ] Dashboard revenue trend shows real % vs hardcoded value