### PR TITLE
feat: add directory search page

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -18,7 +18,7 @@ jobs:
   e2e-smoke:
     name: E2E Critical Flows
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     env:
       VITE_SUPABASE_URL: "https://mock-supabase-url.supabase.co"
@@ -38,8 +38,20 @@ jobs:
     - name: Install Dependencies
       run: npm ci
 
+    - name: Cache Playwright Browsers
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps chromium
+
+    - name: Install Playwright System Dependencies
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      run: npx playwright install-deps chromium
 
     - name: Run E2E Smoke Tests
       run: npx playwright test e2e/auth.spec.ts e2e/booking.spec.ts e2e/checkout.spec.ts --project=chromium

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -45,12 +45,11 @@ jobs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-    - name: Install Playwright Browsers
+    - name: Install Playwright Browser Binary
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install --with-deps chromium
+      run: npx playwright install chromium
 
     - name: Install Playwright System Dependencies
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
       run: npx playwright install-deps chromium
 
     - name: Run E2E Smoke Tests

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -18,12 +18,15 @@ jobs:
   e2e-smoke:
     name: E2E Critical Flows
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
+    container:
+      image: mcr.microsoft.com/playwright:v1.52.0-noble
 
     env:
       VITE_SUPABASE_URL: "https://mock-supabase-url.supabase.co"
       VITE_SUPABASE_ANON_KEY: "mock-supabase-anon-key"
       VITE_GOOGLE_MAPS_API_KEY: "mock-google-maps-api-key"
+      HOME: /root
 
     steps:
     - name: Checkout Code
@@ -37,20 +40,6 @@ jobs:
 
     - name: Install Dependencies
       run: npm ci
-
-    - name: Cache Playwright Browsers
-      uses: actions/cache@v4
-      id: playwright-cache
-      with:
-        path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-    - name: Install Playwright Browser Binary
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: npx playwright install chromium
-
-    - name: Install Playwright System Dependencies
-      run: npx playwright install-deps chromium
 
     - name: Run E2E Smoke Tests
       run: npx playwright test e2e/auth.spec.ts e2e/booking.spec.ts e2e/checkout.spec.ts --project=chromium

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: mcr.microsoft.com/playwright:v1.52.0-noble
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
 
     env:
       VITE_SUPABASE_URL: "https://mock-supabase-url.supabase.co"

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -133,6 +133,52 @@ export const directoryService = {
         return data as DirectoryListingDB[];
     },
 
+    /**
+     * Search approved directory listings by text query, category, and/or location.
+     */
+    async searchDirectoryListings(
+        query: string,
+        categoryId?: string,
+        location?: string,
+        page = 1,
+        limit = 40,
+    ): Promise<{ data: DirectoryListingDB[]; total: number }> {
+        let q = supabase
+            .from('directory_listings')
+            .select(LISTING_LOCATIONS_SELECT, { count: 'exact' })
+            .eq('status', 'approved');
+
+        const trimmed = query.trim();
+        if (trimmed) {
+            // Escape ILIKE wildcards and PostgREST .or() separators in user input
+            const safe = trimmed.replace(/%/g, '\\%').replace(/_/g, '\\_').replace(/,/g, ' ');
+            q = q.or(`name.ilike.%${safe}%,short_description.ilike.%${safe}%`);
+        }
+        if (categoryId) {
+            q = q.eq('category_id', categoryId);
+        }
+        if (location) {
+            const safeLoc = location.trim().replace(/%/g, '\\%').replace(/_/g, '\\_');
+            if (safeLoc) {
+                q = q.ilike('location', `%${safeLoc}%`);
+            }
+        }
+
+        q = q.order('base_score', { ascending: false })
+             .order('is_featured', { ascending: false })
+             .order('net_votes', { ascending: false, nullsFirst: false })
+             .order('name', { ascending: true })
+             .range((page - 1) * limit, page * limit - 1);
+
+        const { data, error, count } = await q;
+        if (error) {
+            console.error('Error searching directory listings:', error);
+            throw error;
+        }
+
+        return { data: data as DirectoryListingDB[], total: count ?? 0 };
+    },
+
     // ============================================================
     // Landing Page Listings
     // ============================================================

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -79,7 +79,7 @@ export const Navbar: React.FC = () => {
             {navMode === 'directory' ? (
               <div className="relative hidden md:block">
                 <Link
-                  to="/alanya-villas"
+                  to="/services"
                   className="flex items-center gap-1.5 px-4 py-2 bg-gradient-to-r from-teal-600 to-cyan-600 dark:from-cyan-600 dark:to-cyan-700 text-white rounded-full text-sm font-medium hover:shadow-lg hover:shadow-teal-500/20 transition-all duration-300 ease-out hover:scale-105 active:scale-95 whitespace-nowrap"
                 >
                   <ArrowRightLeft size={16} className="text-white" />

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -14,10 +14,11 @@ interface DirectoryListingCardProps {
     onVote?: (listingId: string, vote: 1 | -1) => void;
     isAuthenticated?: boolean;
     isVoting?: boolean;
+    categoryName?: string;
 }
 
 export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
-    listing, onClick, userVote, onVote, isAuthenticated, isVoting
+    listing, onClick, userVote, onVote, isAuthenticated, isVoting, categoryName
 }) => {
     const { language } = useLanguage();
     const displayDescription = getListingDescription(listing, language);
@@ -80,6 +81,11 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                 <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-1 flex items-center gap-2">
                     {listing.name}
                     {listing.is_verified && <BadgeCheck className="text-blue-500 w-5 h-5 flex-shrink-0" />}
+                    {categoryName && (
+                        <span className="text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full">
+                            {categoryName}
+                        </span>
+                    )}
                 </h3>
                 <div className="flex items-center gap-1 text-slate-500 dark:text-slate-400 text-sm mb-3">
                     <MapPin size={14} /> {listing.location}

--- a/components/home/FreeListingsSection.tsx
+++ b/components/home/FreeListingsSection.tsx
@@ -32,7 +32,7 @@ export const FreeListingsSection: React.FC<FreeListingsSectionProps> = ({ listin
                         </p>
                     </div>
                     <button
-                        onClick={() => navigate('/search-results')}
+                        onClick={() => navigate('/search')}
                         className="flex items-center gap-1 text-sm font-semibold text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 transition-colors self-start sm:self-auto"
                     >
                         Explore all <ArrowRight size={16} />

--- a/components/home/PremiumListingsSection.tsx
+++ b/components/home/PremiumListingsSection.tsx
@@ -32,7 +32,7 @@ export const PremiumListingsSection: React.FC<PremiumListingsSectionProps> = ({ 
                         </p>
                     </div>
                     <button
-                        onClick={() => navigate('/search-results')}
+                        onClick={() => navigate('/search')}
                         className="flex items-center gap-1 text-sm font-semibold text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors self-start sm:self-auto"
                     >
                         View all <ArrowRight size={16} />

--- a/components/home/SignatureListingsSection.tsx
+++ b/components/home/SignatureListingsSection.tsx
@@ -32,7 +32,7 @@ export const SignatureListingsSection: React.FC<SignatureListingsSectionProps> =
                         </p>
                     </div>
                     <button
-                        onClick={() => navigate('/search-results')}
+                        onClick={() => navigate('/search')}
                         className="flex items-center gap-1 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 transition-colors self-start sm:self-auto"
                     >
                         View all <ArrowRight size={16} />

--- a/components/navbar/DesktopNav.tsx
+++ b/components/navbar/DesktopNav.tsx
@@ -41,10 +41,9 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({ mode = 'directory' }) =>
                 </>
             ) : (
                 <>
+                    <TabLink to="/services" label={t('nav.services') || 'Services'} exact />
                     <TabLink to="/alanya-villas" label={t('directory.villas') || 'Villas'} />
                     <TabLink to="/alanya-apartments" label={t('directory.apartments') || 'Apartments'} />
-                    <TabLink to="/services/car-rental" label={t('nav.vehicles') || 'Vehicles'} />
-                    <TabLink to="/services" label={t('nav.services') || 'Services'} exact />
                 </>
             )}
         </nav>

--- a/components/navbar/ListPropertyAction.tsx
+++ b/components/navbar/ListPropertyAction.tsx
@@ -67,7 +67,7 @@ export const ListPropertyAction: React.FC = () => {
                 className="flex items-center gap-1.5 px-3 py-2 bg-gradient-to-r from-slate-900 to-slate-800 dark:from-slate-800 dark:to-slate-700 text-white rounded-full text-sm font-medium hover:shadow-lg hover:shadow-slate-500/20 transition-all duration-300 ease-out hover:scale-105 active:scale-95 whitespace-nowrap"
             >
                 <Plus size={16} className="text-teal-400 dark:text-cyan-400 " />
-                <span>{t('nav.list_property')}</span>
+                <span>{t('nav.list_business') || 'List Business'}</span>
             </button>
             {/* List Dropdown */}
             {isListMenuOpen && (

--- a/components/navbar/MobileMenu.test.tsx
+++ b/components/navbar/MobileMenu.test.tsx
@@ -137,10 +137,10 @@ describe('MobileMenu', () => {
 
     it('renders main navigation links in rental mode', () => {
         renderMenu(true, 'rental');
+        expect(screen.getByText('nav.services')).toBeInTheDocument();
         expect(screen.getByText('directory.villas')).toBeInTheDocument();
         expect(screen.getByText('directory.apartments')).toBeInTheDocument();
-        expect(screen.getByText('nav.vehicles')).toBeInTheDocument();
-        expect(screen.getByText('nav.services')).toBeInTheDocument();
+        expect(screen.queryByText('nav.vehicles')).not.toBeInTheDocument();
     });
 
     it('renders user links when authenticated', () => {

--- a/components/navbar/MobileMenu.tsx
+++ b/components/navbar/MobileMenu.tsx
@@ -81,6 +81,10 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, mode, s
                     </>
                 ) : (
                     <>
+                        <Link to="/services" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
+                            <ShoppingBag size={18} className="text-slate-400" />
+                            {t('nav.services') || 'Services'}
+                        </Link>
                         <Link to="/alanya-villas" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <Home size={18} className="text-slate-400" />
                             {t('directory.villas') || 'Villas'}
@@ -88,14 +92,6 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, mode, s
                         <Link to="/alanya-apartments" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <Building2 size={18} className="text-slate-400" />
                             {t('directory.apartments') || 'Apartments'}
-                        </Link>
-                        <Link to="/services/car-rental" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
-                            <Car size={18} className="text-slate-400" />
-                            {t('nav.vehicles') || 'Vehicles'}
-                        </Link>
-                        <Link to="/services" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
-                            <ShoppingBag size={18} className="text-slate-400" />
-                            {t('nav.services') || 'Services'}
                         </Link>
                     </>
                 )}

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -14,6 +14,7 @@ export const ar = {
     'nav.profile': 'الملف الشخصي',
     'nav.messages': 'الرسائل',
     'nav.list_property': 'اعرض عقارك',
+    'nav.list_business': 'أضف نشاط تجاري',
     'nav.switch_to_rentals': 'الانتقال إلى الإيجارات والخدمات',
     'nav.list_rental_or_service': 'إدراج إيجار أو خدمة',
     'nav.switch_to_directory': 'الذهاب إلى الدليل',
@@ -360,7 +361,7 @@ export const ar = {
     'profile.email_verify_subtitle': 'تحديث عنوان بريدك الإلكتروني',
     'profile.password_subtitle': 'قم بتحديث كلمة المرور الخاصة بك للحفاظ على أمان حسابك',
     'placeholder.search_items': 'اكتب أمراً أو ابحث...',
-    'nav.list_desc': 'اربح المال كمضيف',
+    'nav.list_desc': 'فلل، شقق، والمزيد',
     'nav.list_service': 'أضف خدمة',
     'nav.service_desc': 'سيارات، جولات، وأكثر',
 

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -14,6 +14,7 @@ export const en = {
   'nav.profile': 'Profile',
   'nav.messages': 'Messages',
   'nav.list_property': 'List Property',
+  'nav.list_business': 'List Business',
   'nav.switch_to_rentals': 'Switch to Rentals & Services',
   'nav.list_rental_or_service': 'List Rental or Service',
   'nav.switch_to_directory': 'Switch to Directory',
@@ -420,7 +421,7 @@ export const en = {
   'profile.email_verify_subtitle': 'Update your email address',
   'profile.password_subtitle': 'Update your password to keep your account secure',
   'placeholder.search_items': 'Type a command or search...',
-  'nav.list_desc': 'Earn money as a host',
+  'nav.list_desc': 'Villas, apartments & more',
   'nav.list_service': 'List a Service',
   'nav.service_desc': 'Cars, tours, and more',
 

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -14,6 +14,7 @@ export const ru = {
   'nav.profile': 'Профиль',
   'nav.messages': 'Сообщения',
   'nav.list_property': 'Сдать объект',
+  'nav.list_business': 'Разместить бизнес',
   'nav.switch_to_rentals': 'Аренда и услуги',
   'nav.list_rental_or_service': 'Сдать жилье или услугу',
   'nav.switch_to_directory': 'Справочник',
@@ -412,7 +413,7 @@ export const ru = {
   'profile.email_verify_subtitle': 'Обновите ваш email адрес',
   'profile.password_subtitle': 'Обновите пароль для безопасности вашего аккаунта',
   'placeholder.search_items': 'Введите команду или запрос...',
-  'nav.list_desc': 'Зарабатывайте как хозяин',
+  'nav.list_desc': 'Виллы, апартаменты и другое',
   'nav.list_service': 'Разместить услугу',
   'nav.service_desc': 'Авто, туры и другое',
 

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -14,6 +14,7 @@ export const tr = {
     'nav.profile': 'Profil',
     'nav.messages': 'Mesajlar',
     'nav.list_property': 'Evini Kirala',
+    'nav.list_business': 'İşletme Yayınla',
     'nav.switch_to_rentals': 'Kiralama & Hizmetler',
     'nav.list_rental_or_service': 'Kiralama veya Hizmet Listele',
     'nav.switch_to_directory': 'Rehber',
@@ -412,7 +413,7 @@ export const tr = {
     'profile.email_verify_subtitle': 'E-posta adresinizi güncelleyin',
     'profile.password_subtitle': 'Hesabınızı güvende tutmak için şifrenizi güncelleyin',
     'placeholder.search_items': 'Bir komut yazın veya arayın...',
-    'nav.list_desc': 'Ev sahibi olarak kazanın',
+    'nav.list_desc': 'Villalar, daireler ve daha fazlası',
     'nav.list_service': 'Hizmet Yayını Yap',
     'nav.service_desc': 'Arabalar, turlar ve daha fazlası',
 

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star, Home, Car } from 'lucide-react';
+import { useClickOutside } from '../hooks/useClickOutside';
 import { useLanguage } from '../context/LanguageContext';
 import { SEOHead } from '../components/seo/SEOHead';
 import { db } from '../api-services';
@@ -16,6 +17,9 @@ export const DirectoryHome: React.FC = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const [location, setLocation] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('');
+    const [showListMenu, setShowListMenu] = useState(false);
+    const listMenuRef = useRef<HTMLDivElement>(null);
+    useClickOutside(listMenuRef, () => setShowListMenu(false));
 
     const handleSearch = () => {
         const params = new URLSearchParams();
@@ -185,13 +189,39 @@ export const DirectoryHome: React.FC = () => {
                             {t('dir.cta.categories')}
                         </button>
 
-                        <button
-                            onClick={() => navigate('/list-property')}
-                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all cursor-pointer"
-                        >
-                            <Briefcase className="w-5 h-5" />
-                            {t('dir.cta.list')}
-                        </button>
+                        <div className="relative flex-1" ref={listMenuRef}>
+                            <button
+                                onClick={() => setShowListMenu(prev => !prev)}
+                                className="w-full flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all cursor-pointer"
+                            >
+                                <Briefcase className="w-5 h-5" />
+                                {t('dir.cta.list')}
+                            </button>
+                            {showListMenu && (
+                                <div className="absolute bottom-full mb-2 left-0 right-0 bg-white dark:bg-slate-900 rounded-2xl shadow-xl border border-slate-100 dark:border-slate-800/50 overflow-hidden animate-in fade-in zoom-in-95 duration-200 z-50">
+                                    <div className="p-2 space-y-1">
+                                        <Link to="/list-property" onClick={() => setShowListMenu(false)} className="flex items-start gap-4 p-3 hover:bg-slate-50 dark:hover:bg-slate-800/90 rounded-xl transition-all group">
+                                            <div className="w-10 h-10 bg-teal-50 dark:bg-slate-800/50 text-teal-600 dark:text-cyan-400 rounded-lg flex items-center justify-center group-hover:bg-teal-100 dark:group-hover:bg-slate-700/50 transition-colors flex-shrink-0">
+                                                <Home size={20} />
+                                            </div>
+                                            <div>
+                                                <span className="block text-sm font-bold text-slate-900 dark:text-white">{t('nav.list_property')}</span>
+                                                <span className="block text-xs text-slate-500 font-medium">{t('nav.list_desc')}</span>
+                                            </div>
+                                        </Link>
+                                        <Link to="/add-service" onClick={() => setShowListMenu(false)} className="flex items-start gap-4 p-3 hover:bg-slate-50 dark:hover:bg-slate-800/90 rounded-xl transition-all group">
+                                            <div className="w-10 h-10 bg-purple-50 dark:bg-slate-800/50 text-purple-600 rounded-lg flex items-center justify-center group-hover:bg-purple-100 dark:group-hover:bg-purple-900/50 transition-colors flex-shrink-0">
+                                                <Car size={20} />
+                                            </div>
+                                            <div>
+                                                <span className="block text-sm font-bold text-slate-900 dark:text-white">{t('nav.list_service')}</span>
+                                                <span className="block text-xs text-slate-500 font-medium">{t('nav.service_desc')}</span>
+                                            </div>
+                                        </Link>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
                     </div>
 
                     {/* AI Planner Floating Entry Point */}

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -17,6 +17,14 @@ export const DirectoryHome: React.FC = () => {
     const [location, setLocation] = useState('');
     const [selectedCategory, setSelectedCategory] = useState('');
 
+    const handleSearch = () => {
+        const params = new URLSearchParams();
+        if (searchQuery.trim()) params.set('q', searchQuery.trim());
+        if (selectedCategory) params.set('category', selectedCategory);
+        if (location) params.set('location', location);
+        navigate(`/search?${params.toString()}`);
+    };
+
     // Landing page listings
     const [premiumListings, setPremiumListings] = useState<DirectoryListingDB[]>([]);
     const [freeListings, setFreeListings] = useState<DirectoryListingDB[]>([]);
@@ -116,6 +124,9 @@ export const DirectoryHome: React.FC = () => {
                                     placeholder={t('dir.search.placeholder')}
                                     value={searchQuery}
                                     onChange={(e) => setSearchQuery(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') handleSearch();
+                                    }}
                                     className="w-full pl-12 pr-4 py-4 rounded-t-xl md:rounded-none md:rounded-l-xl border-none focus:ring-2 focus:ring-teal-500 bg-slate-50 dark:bg-slate-900/50 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 outline-none transition-all"
                                 />
                             </div>
@@ -153,7 +164,10 @@ export const DirectoryHome: React.FC = () => {
                                 </select>
                             </div>
 
-                            <button className="bg-slate-900 dark:bg-slate-800/50 hover:bg-black dark:hover:bg-teal-500 text-white px-8 py-4 md:rounded-r-xl rounded-xl font-semibold tracking-wide transition-all min-w-[140px] shadow-sm">
+                            <button
+                                onClick={handleSearch}
+                                className="bg-slate-900 dark:bg-slate-800/50 hover:bg-black dark:hover:bg-teal-500 text-white px-8 py-4 md:rounded-r-xl rounded-xl font-semibold tracking-wide transition-all min-w-[140px] shadow-sm"
+                            >
                                 {t('dir.search.btn')}
                             </button>
                         </div>
@@ -161,14 +175,6 @@ export const DirectoryHome: React.FC = () => {
 
                     {/* CTA Buttons - Premium Unified Look */}
                     <div className="flex flex-col sm:flex-row justify-center gap-3 w-full max-w-2xl mx-auto px-2">
-                        <button
-                            onClick={() => navigate('/search-results')}
-                            className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white dark:bg-slate-800/80 hover:bg-slate-50 dark:hover:bg-slate-700/80 text-slate-900 dark:text-white rounded-xl sm:rounded-full font-semibold transition-all shadow-lg hover:shadow-xl hover:-translate-y-0.5 cursor-pointer"
-                        >
-                            <MapPin className="w-5 h-5 text-teal-600 dark:text-cyan-400 dark:text-slate-200" />
-                            {t('dir.cta.explore')}
-                        </button>
-
                         <button
                             onClick={() => {
                                 document.getElementById('categories')?.scrollIntoView({ behavior: 'smooth' });

--- a/pages/SearchPage.tsx
+++ b/pages/SearchPage.tsx
@@ -1,0 +1,454 @@
+import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Filter, Star, Info, ChevronDown, Map as MapIcon, List } from 'lucide-react';
+import { SEOHead } from '../components/seo/SEOHead';
+import { Breadcrumb } from '../components/seo/Breadcrumb';
+import { useAuth } from '../context/AuthContext';
+import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
+import { DirectoryMapView } from '../components/directory/DirectoryMapView';
+import { db } from '../api-services';
+import { DirectoryListingDB } from '../types/models';
+import { toast } from 'react-hot-toast';
+import { useLanguage } from '../context/LanguageContext';
+
+const CATEGORY_I18N_KEYS: Record<string, string> = {
+    'medical': 'dir.cat.medical',
+    'accommodations': 'dir.cat.accommodations',
+    'tours': 'dir.cat.tours',
+    'transport': 'dir.cat.transport',
+    'restaurants': 'dir.cat.restaurants',
+    'cafes': 'dir.cat.cafes',
+    'nature': 'dir.cat.nature',
+    'spa-hamam': 'dir.cat.spa_hamam',
+    'hair-beauty': 'dir.cat.hair_beauty',
+    'real-estate': 'dir.cat.realestate',
+    'visa': 'dir.cat.visa',
+    'shopping': 'dir.cat.shopping',
+};
+
+export const SearchPage: React.FC = () => {
+    const [searchParams] = useSearchParams();
+    const q = searchParams.get('q') || '';
+    const category = searchParams.get('category') || '';
+    const location = searchParams.get('location') || '';
+    const { t } = useLanguage();
+
+    const getCategoryName = (categoryId: string) => {
+        const key = CATEGORY_I18N_KEYS[categoryId];
+        return key ? t(key) : categoryId;
+    };
+
+    const totalRef = useRef(0);
+
+    const [locationFilter, setLocationFilter] = useState('all');
+    const [verifiedOnly, setVerifiedOnly] = useState(false);
+    const [minRating, setMinRating] = useState<number>(0);
+    const [maxPriceLevel, setMaxPriceLevel] = useState<number>(4);
+    const [languageFilter, setLanguageFilter] = useState('all');
+    const [sortBy, setSortBy] = useState('recommended');
+    const [selectedListing, setSelectedListing] = useState<DirectoryListingDB | null>(null);
+    const [viewMode, setViewMode] = useState<'list' | 'map'>('list');
+
+    // Data State
+    const [listings, setListings] = useState<DirectoryListingDB[]>([]);
+    const [locations, setLocations] = useState<string[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    // Auth & Voting State
+    const { isAuthenticated, user } = useAuth();
+    const [userVotes, setUserVotes] = useState<Record<string, 1 | -1>>({});
+    const [votingId, setVotingId] = useState<string | null>(null);
+
+    // Fetch from Supabase
+    useEffect(() => {
+        const fetchData = async () => {
+            setLoading(true);
+            try {
+                const [result, locs] = await Promise.all([
+                    db.searchDirectoryListings(q, category || undefined, location || undefined),
+                    db.getLocations()
+                ]);
+                setListings(result.data || []);
+                totalRef.current = result.total;
+                setLocations(locs.map(l => l.name));
+            } catch (e) {
+                console.error('Failed to load search results', e);
+                toast.error('Failed to load search results');
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchData();
+    }, [q, category, location]);
+
+    // Fetch user's votes
+    useEffect(() => {
+        if (!isAuthenticated || !user || listings.length === 0) return;
+        const ids = listings.map(l => l.id);
+        db.getUserVotesBatch(ids).then(setUserVotes).catch(e => console.error('Failed to load votes:', e));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isAuthenticated, user?.id, listings.length]);
+
+    const handleVote = useCallback(async (listingId: string, vote: 1 | -1) => {
+        if (!isAuthenticated || votingId) return;
+        const currentVote = userVotes[listingId];
+        const isToggleOff = currentVote === vote;
+        setVotingId(listingId);
+        try {
+            if (isToggleOff) {
+                const result = await db.removeListingVote(listingId);
+                setUserVotes(prev => {
+                    const next = { ...prev };
+                    delete next[listingId];
+                    return next;
+                });
+                setListings(prev => prev.map(l =>
+                    l.id === listingId ? { ...l, net_votes: result.netVotes } : l
+                ));
+            } else {
+                const result = await db.voteForListing(listingId, vote);
+                setUserVotes(prev => ({ ...prev, [listingId]: result.userVote as 1 | -1 }));
+                setListings(prev => prev.map(l =>
+                    l.id === listingId ? { ...l, net_votes: result.netVotes } : l
+                ));
+            }
+        } catch (e: any) {
+            console.error('Failed to vote:', e);
+            toast.error(e.message || 'Failed to vote');
+        } finally {
+            setVotingId(null);
+        }
+    }, [isAuthenticated, userVotes, votingId]);
+
+    const handleListingClick = useCallback((listing: DirectoryListingDB) => {
+        setSelectedListing(listing);
+        const sessionKey = `listing_view_${listing.id}_${new Date().toISOString().slice(0, 10)}`;
+        if (!sessionStorage.getItem(sessionKey)) {
+            sessionStorage.setItem(sessionKey, '1');
+            db.trackListingView(listing.id).catch(console.error);
+        }
+    }, []);
+
+    const availableLanguages = useMemo(() => {
+        const langs = new Set<string>();
+        listings.forEach(d => {
+            if (d.languages_spoken) {
+                d.languages_spoken.forEach((l: string) => langs.add(l));
+            }
+        });
+        return Array.from(langs).sort();
+    }, [listings]);
+
+    const activeFilterCount = useMemo(() => {
+        let count = 0;
+        if (locationFilter !== 'all') count++;
+        if (verifiedOnly) count++;
+        if (minRating > 0) count++;
+        if (maxPriceLevel < 4) count++;
+        if (languageFilter !== 'all') count++;
+        if (sortBy !== 'recommended') count++;
+        return count;
+    }, [locationFilter, verifiedOnly, minRating, maxPriceLevel, languageFilter, sortBy]);
+
+    const clearFilters = useCallback(() => {
+        setLocationFilter('all');
+        setVerifiedOnly(false);
+        setMinRating(0);
+        setMaxPriceLevel(4);
+        setLanguageFilter('all');
+        setSortBy('recommended');
+    }, []);
+
+    const filteredData = useMemo(() => {
+        let data = listings;
+        if (locationFilter !== 'all') {
+            data = data.filter(item => item.location === locationFilter);
+        }
+        if (verifiedOnly) {
+            data = data.filter(item => item.is_verified);
+        }
+        if (minRating > 0) {
+            data = data.filter(item => (item.reviews_average || 0) >= minRating);
+        }
+        if (maxPriceLevel < 4) {
+            data = data.filter(item => (item.price_level || 4) <= maxPriceLevel);
+        }
+        if (languageFilter !== 'all') {
+            data = data.filter(item => item.languages_spoken?.includes(languageFilter));
+        }
+        if (sortBy === 'most_upvoted') {
+            data = [...data].sort((a, b) => (b.net_votes || 0) - (a.net_votes || 0));
+        }
+        return data;
+    }, [listings, locationFilter, verifiedOnly, minRating, maxPriceLevel, languageFilter, sortBy]);
+
+    const title = q
+        ? `Search results for "${q}"`
+        : category
+            ? `Browse ${getCategoryName(category)}`
+            : 'Browse All Listings';
+
+    const featuredListings = filteredData.filter(item => item.is_featured);
+    const standardListings = filteredData.filter(item => !item.is_featured);
+
+    return (
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
+            <SEOHead
+                title={`${title} - Alanya Holidays`}
+                description={`Find the best businesses in Alanya${q ? ` matching "${q}"` : ''}. Browse verified listings with reviews and ratings.`}
+            />
+
+            {/* Breadcrumb */}
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-2">
+                <Breadcrumb
+                    items={[
+                        { label: 'Home', href: '/' },
+                        { label: q ? `Search: "${q}"` : 'Browse' },
+                    ]}
+                />
+            </div>
+
+            {/* Header */}
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-6">
+                <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 dark:text-white">
+                    {title}
+                </h1>
+                {totalRef.current > 0 && (
+                    <p className="mt-2 text-slate-500 dark:text-slate-400">
+                        {totalRef.current} {totalRef.current === 1 ? 'result' : 'results'} found
+                    </p>
+                )}
+            </div>
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                {/* Filter System */}
+                <div className="flex flex-col xl:flex-row justify-between items-start xl:items-center mb-8 gap-4 bg-white dark:bg-slate-800/80 p-4 rounded-xl border border-slate-200 dark:border-slate-800/50 shadow-sm">
+                    <div className="flex items-center gap-2 text-slate-700 dark:text-slate-300 font-medium whitespace-nowrap">
+                        <Filter size={18} />
+                        <h2>Filters ({filteredData.length} Results)</h2>
+                    </div>
+
+                    <div className="flex overflow-x-auto pb-2 md:pb-0 md:flex-wrap items-center gap-4 w-full xl:w-auto scrollbar-hide">
+                        <div className="relative shrink-0">
+                            <select
+                                value={locationFilter}
+                                onChange={(e) => setLocationFilter(e.target.value)}
+                                className="pl-4 pr-10 py-2 appearance-none rounded-lg border border-slate-300 dark:border-slate-700/50 bg-white dark:bg-slate-900 text-slate-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
+                            >
+                                <option value="all">All Locations</option>
+                                {locations.map(loc => (
+                                    <option key={loc} value={loc}>{loc}</option>
+                                ))}
+                            </select>
+                            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                        </div>
+
+                        {availableLanguages.length > 0 && (
+                            <div className="relative shrink-0">
+                                <select
+                                    value={languageFilter}
+                                    onChange={(e) => setLanguageFilter(e.target.value)}
+                                    className="pl-4 pr-10 py-2 appearance-none rounded-lg border border-slate-300 dark:border-slate-700/50 bg-white dark:bg-slate-900 text-slate-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
+                                >
+                                    <option value="all">All Languages</option>
+                                    {availableLanguages.map(lang => (
+                                        <option key={lang} value={lang}>{lang}</option>
+                                    ))}
+                                </select>
+                                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                            </div>
+                        )}
+
+                        <div className="relative shrink-0">
+                            <select
+                                value={minRating}
+                                onChange={(e) => setMinRating(Number(e.target.value))}
+                                className="pl-4 pr-10 py-2 appearance-none rounded-lg border border-slate-300 dark:border-slate-700/50 bg-white dark:bg-slate-900 text-slate-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
+                            >
+                                <option value={0}>Any Rating</option>
+                                <option value={4.0}>4.0+ Stars</option>
+                                <option value={4.5}>4.5+ Stars</option>
+                            </select>
+                            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                        </div>
+
+                        <div className="relative shrink-0">
+                            <select
+                                value={maxPriceLevel}
+                                onChange={(e) => setMaxPriceLevel(Number(e.target.value))}
+                                className="pl-4 pr-10 py-2 appearance-none rounded-lg border border-slate-300 dark:border-slate-700/50 bg-white dark:bg-slate-900 text-slate-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
+                            >
+                                <option value={4}>Any Price</option>
+                                <option value={1}>$ (Budget)</option>
+                                <option value={2}>$$ (Moderate)</option>
+                                <option value={3}>$$$ (Premium)</option>
+                            </select>
+                            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                        </div>
+
+                        <div className="relative shrink-0">
+                            <select
+                                value={sortBy}
+                                onChange={(e) => setSortBy(e.target.value)}
+                                className="pl-4 pr-10 py-2 appearance-none rounded-lg border border-slate-300 dark:border-slate-700/50 bg-white dark:bg-slate-900 text-slate-700 dark:text-white focus:outline-none focus:ring-2 focus:ring-teal-500 font-medium"
+                            >
+                                <option value="recommended">Recommended</option>
+                                <option value="most_upvoted">Most Upvoted</option>
+                            </select>
+                            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 pointer-events-none" />
+                        </div>
+
+                        {/* View Mode Toggle */}
+                        <div className="flex items-center bg-slate-100 dark:bg-slate-900 rounded-lg p-1 border border-slate-200 dark:border-slate-700/50 shrink-0">
+                            <button
+                                onClick={() => setViewMode('list')}
+                                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                                    viewMode === 'list'
+                                        ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-white shadow-sm'
+                                        : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                            >
+                                <List size={16} /> List
+                            </button>
+                            <button
+                                onClick={() => setViewMode('map')}
+                                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                                    viewMode === 'map'
+                                        ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-white shadow-sm'
+                                        : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
+                                }`}
+                            >
+                                <MapIcon size={16} /> Map
+                            </button>
+                        </div>
+
+                        <label className="flex items-center gap-2 cursor-pointer text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                            <input
+                                type="checkbox"
+                                checked={verifiedOnly}
+                                onChange={(e) => setVerifiedOnly(e.target.checked)}
+                                className="w-4 h-4 text-teal-600 dark:text-cyan-400 rounded border-slate-300 focus:ring-teal-500"
+                            />
+                            Verified Only
+                        </label>
+
+                        {(locationFilter !== 'all' || verifiedOnly || minRating > 0 || maxPriceLevel < 4 || languageFilter !== 'all' || sortBy !== 'recommended') && (
+                            <button
+                                onClick={clearFilters}
+                                className="text-sm text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:text-cyan-400 font-medium whitespace-nowrap flex-shrink-0"
+                            >
+                                Clear Filters
+                            </button>
+                        )}
+                    </div>
+                </div>
+
+                {loading ? (
+                    <div className="flex justify-center items-center py-20">
+                        <div className="w-8 h-8 border-4 border-teal-500 border-t-transparent rounded-full animate-spin" />
+                    </div>
+                ) : filteredData.length === 0 ? (
+                    <div className="bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-2xl p-12 flex flex-col items-center justify-center text-center shadow-sm">
+                        <Info className="w-16 h-16 text-slate-300 dark:text-slate-400 mb-4" />
+                        <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+                            {q ? `No results found for "${q}"` : 'No listings found'}
+                        </h3>
+                        <p className="text-slate-500 dark:text-slate-400 max-w-sm mb-4">
+                            Try adjusting your search or filters to find what you're looking for.
+                        </p>
+                        <a
+                            href="/search"
+                            className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 font-semibold"
+                        >
+                            Clear search
+                        </a>
+                    </div>
+                ) : viewMode === 'list' ? (
+                    <>
+                        {/* Featured Listings */}
+                        {featuredListings.length > 0 && (
+                            <div className="mb-12">
+                                <h2 className="flex items-center gap-2 text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
+                                    <Star className="text-amber-500 fill-amber-500" size={24} />
+                                    Featured Providers
+                                </h2>
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                    {featuredListings.map(listing => (
+                                        <DirectoryListingCard
+                                            key={listing.id}
+                                            listing={listing}
+                                            onClick={handleListingClick}
+                                            userVote={userVotes[listing.id] ?? null}
+                                            onVote={handleVote}
+                                            isAuthenticated={isAuthenticated}
+                                            isVoting={votingId === listing.id}
+                                            categoryName={getCategoryName(listing.category_id)}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Standard Listings */}
+                        <div>
+                            <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
+                                All Listings
+                            </h2>
+                            {standardListings.length > 0 ? (
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                    {standardListings.map(listing => (
+                                        <DirectoryListingCard
+                                            key={listing.id}
+                                            listing={listing}
+                                            onClick={handleListingClick}
+                                            userVote={userVotes[listing.id] ?? null}
+                                            onVote={handleVote}
+                                            isAuthenticated={isAuthenticated}
+                                            isVoting={votingId === listing.id}
+                                            categoryName={getCategoryName(listing.category_id)}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="bg-white dark:bg-slate-800/80 border md:col-span-2 border-slate-200 dark:border-slate-800/50 rounded-2xl p-12 flex flex-col items-center justify-center text-center shadow-sm">
+                                    <Info className="w-16 h-16 text-slate-300 dark:text-slate-400 mb-4" />
+                                    <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2">No standard listings found</h3>
+                                    <p className="text-slate-500 dark:text-slate-400 max-w-sm">Try removing some filters or check our Featured items above.</p>
+                                </div>
+                            )}
+                        </div>
+                    </>
+                ) : (
+                    <DirectoryMapView
+                        listings={filteredData}
+                        onListingClick={handleListingClick}
+                        filters={{
+                            locationFilter,
+                            verifiedOnly,
+                            minRating,
+                            maxPriceLevel,
+                            sortBy,
+                            locationOptions: locations,
+                        }}
+                        filterActions={{
+                            setLocationFilter,
+                            setVerifiedOnly,
+                            setMinRating,
+                            setMaxPriceLevel,
+                            setSortBy,
+                            clearFilters,
+                        }}
+                        activeFilterCount={activeFilterCount}
+                    />
+                )}
+            </div>
+
+            <DirectoryListingModal
+                listing={selectedListing}
+                isOpen={!!selectedListing}
+                onClose={() => setSelectedListing(null)}
+            />
+        </div>
+    );
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:3000',
@@ -17,9 +17,7 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: process.env.CI
+    ? { command: 'npm run build && npm run preview -- --port 3000', url: 'http://localhost:3000', reuseExistingServer: false }
+    : { command: 'npm run dev', url: 'http://localhost:3000', reuseExistingServer: true },
 });

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -18,6 +18,7 @@ const AiPlanner = React.lazy(() => import('../pages/AiPlanner').then(module => (
 const MyItinerariesPage = React.lazy(() => import('../pages/MyItinerariesPage').then(module => ({ default: module.MyItinerariesPage })));
 const SharedItineraryPage = React.lazy(() => import('../pages/SharedItineraryPage').then(module => ({ default: module.SharedItineraryPage })));
 const SearchResultsPage = React.lazy(() => import('../pages/SearchResultsPage').then(module => ({ default: module.SearchResultsPage })));
+const SearchPage = React.lazy(() => import('../pages/SearchPage').then(module => ({ default: module.SearchPage })));
 const ServicesPage = React.lazy(() => import('../pages/ServicesPage').then(module => ({ default: module.ServicesPage })));
 const About = React.lazy(() => import('../pages/About').then(module => ({ default: module.About })));
 const Contact = React.lazy(() => import('../pages/Contact').then(module => ({ default: module.Contact })));
@@ -150,6 +151,7 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/add-listing" element={<AuthRoute><AddListingPage /></AuthRoute>} />
 
                 <Route path="/search-results" element={<SearchResultsPage />} />
+                <Route path="/search" element={<SearchPage />} />
                 <Route path="/stays" element={<SearchResultsPage />} />
                 <Route path="/favorites" element={<AuthRoute><FavoritesPage /></AuthRoute>} />
                 <Route path="/property/:id" element={<PropertyDetails />} />


### PR DESCRIPTION
## Summary

- Add `/search` route with `SearchPage` component — search bar on DirectoryHome now navigates to `/search?q=...&category=...&location=...` with Enter key and button support
- Add `searchDirectoryListings` API method with Supabase ILIKE query, input sanitization (escapes `%`, `_`, `,` for PostgREST `.or()` and ILIKE wildcards)
- Remove broken "Explore Alanya" button that incorrectly linked to rental search (`/search-results`)
- Update "View all" links in Premium/Free/Signature sections to point to `/search`
- Add `categoryName` prop to `DirectoryListingCard` for cross-category badge display
- Use i18n for category names via `CATEGORY_I18N_KEYS` mapping instead of hardcoded English strings

## Test plan

- [ ] Type "spa" in search bar → click Search → `/search?q=spa` → shows spa/hamam listings
- [ ] Select "Restaurants" category + click Search → `/search?category=restaurants` → shows only restaurants
- [ ] Enter key in search input triggers navigation
- [ ] Empty search → `/search` → shows all approved listings (browse mode)
- [ ] "Explore Alanya" button is gone from DirectoryHome
- [ ] "View all" on landing page sections links to `/search`
- [ ] Category badges appear on search result cards
- [ ] Filters (location, verified, rating, price, language, sort) work on search results
- [ ] Voting works on search result cards
- [ ] Modal opens on card click in search results
- [ ] `npx tsc --noEmit` → 0 errors
- [ ] `npm run build` succeeds