### PR TITLE
fix: rename health category to Medical & Health

### DIFF
--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -179,7 +179,7 @@ export const ar = {
     'services.adventure.land_desc': 'الأودية والكهوف والآثار القديمة.',
 
     'services.health.title': 'طب وصحة',
-    'services.health.subtitle': 'جدد جسدك وعقلك.',
+    'services.health.subtitle': 'خدمات طبية وتجميلية احترافية من متخصصين معتمدين.',
     'services.health.spa': 'حمام وسبا',
     'services.health.spa_desc': 'تجارب الحمام التركي التقليدي.',
     'services.health.dental': 'عيادة أسنان',

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -178,7 +178,7 @@ export const ar = {
     'services.adventure.land': 'جولات برية',
     'services.adventure.land_desc': 'الأودية والكهوف والآثار القديمة.',
 
-    'services.health.title': 'عافية وصحة',
+    'services.health.title': 'طب وصحة',
     'services.health.subtitle': 'جدد جسدك وعقلك.',
     'services.health.spa': 'حمام وسبا',
     'services.health.spa_desc': 'تجارب الحمام التركي التقليدي.',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -234,7 +234,7 @@ export const en = {
   'services.adventure.atv': 'ATV Quad Safari',
   'services.adventure.atv_desc': 'Off-road adrenaline through the Taurus Mountains.',
 
-  'services.health.title': 'Wellness & Health',
+  'services.health.title': 'Medical & Health',
   'services.health.subtitle': 'Rejuvenate your body and mind.',
   'services.health.spa': 'Hamam & Spa',
   'services.health.spa_desc': 'Traditional Turkish bath experiences.',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -235,7 +235,7 @@ export const en = {
   'services.adventure.atv_desc': 'Off-road adrenaline through the Taurus Mountains.',
 
   'services.health.title': 'Medical & Health',
-  'services.health.subtitle': 'Rejuvenate your body and mind.',
+  'services.health.subtitle': 'Professional medical and cosmetic services by certified specialists.',
   'services.health.spa': 'Hamam & Spa',
   'services.health.spa_desc': 'Traditional Turkish bath experiences.',
   'services.health.dental': 'Dental Clinic',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -229,7 +229,7 @@ export const ru = {
   'services.adventure.land': 'Наземные туры',
   'services.adventure.land_desc': 'Каньоны, пещеры и древние руины.',
 
-  'services.health.title': 'Здоровье и Красота',
+  'services.health.title': 'Медицина и Здоровье',
   'services.health.subtitle': 'Обновите тело и разум.',
   'services.health.spa': 'Хамам и СПА',
   'services.health.spa_desc': 'Традиционные турецкие бани.',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -230,7 +230,7 @@ export const ru = {
   'services.adventure.land_desc': 'Каньоны, пещеры и древние руины.',
 
   'services.health.title': 'Медицина и Здоровье',
-  'services.health.subtitle': 'Обновите тело и разум.',
+  'services.health.subtitle': 'Профессиональные медицинские и косметические услуги от сертифицированных специалистов.',
   'services.health.spa': 'Хамам и СПА',
   'services.health.spa_desc': 'Традиционные турецкие бани.',
   'services.health.dental': 'Стоматология',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -230,7 +230,7 @@ export const tr = {
     'services.adventure.land': 'Kara Turları',
     'services.adventure.land_desc': 'Kanyonlar, mağaralar ve antik kalıntılar.',
 
-    'services.health.title': 'Sağlık & Güzellik',
+    'services.health.title': 'Tıp & Sağlık',
     'services.health.subtitle': 'Bedeninizi ve zihninizi yenileyin.',
     'services.health.spa': 'Hamam & Spa',
     'services.health.spa_desc': 'Geleneksel Türk hamamı deneyimleri.',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -231,7 +231,7 @@ export const tr = {
     'services.adventure.land_desc': 'Kanyonlar, mağaralar ve antik kalıntılar.',
 
     'services.health.title': 'Tıp & Sağlık',
-    'services.health.subtitle': 'Bedeninizi ve zihninizi yenileyin.',
+    'services.health.subtitle': 'Sertifikalı uzmanlar tarafından profesyonel tıbbi ve estetik hizmetler.',
     'services.health.spa': 'Hamam & Spa',
     'services.health.spa_desc': 'Geleneksel Türk hamamı deneyimleri.',
     'services.health.dental': 'Diş Kliniği',


### PR DESCRIPTION
## Summary

- Renamed `health` service category from "Wellness & Health" → "Medical & Health" across all 4 locales (EN, RU, TR, AR)
- Updated subtitle from "Rejuvenate your body and mind" → "Professional medical and cosmetic services by certified specialists"
- Fixes confusing overlap between "Wellness & Health" and "Spa & Wellness" tabs on the Services page

## Why

The `health` category contains Dental Clinic, Hair Transplant, Cosmetic Surgery, Salt Cave Therapy — medical services, not wellness. The old name caused it to appear as a duplicate of "Spa & Wellness".

## Test plan

- [ ] Open `/services` → tabs show "Medical & Health" and "Spa & Wellness" (no duplicate "Wellness")
- [ ] Check subtitle on Medical & Health section reflects medical focus
- [ ] Switch language to RU/TR/AR — correct translations shown