### PR TITLE
fix: security hardening — slug injection, error handling, auth, input validation

### DIFF
--- a/api-services/api/blog.ts
+++ b/api-services/api/blog.ts
@@ -86,12 +86,18 @@ function generateExcerpt(content: string | null, maxLength: number = 200): strin
 // ============================================================
 // Helper: resolve slug conflicts
 // ============================================================
+function escapePostgREST(value: string): string {
+    return value.replace(/%/g, '\\%').replace(/\./g, '\\.').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
 async function resolveSlug(baseSlug: string): Promise<string> {
-    const { data } = await supabase
+    const { data, error } = await supabase
         .from('blog_posts')
         .select('slug')
         .eq('slug', baseSlug)
-        .or(`slug.like.${baseSlug}-%`);
+        .or(`slug.like.${escapePostgREST(baseSlug)}-%`);
+
+    if (error) throw new Error(`Failed to check slug uniqueness: ${error.message}`);
 
     const rows = toArray<{ slug: string }>(data);
     const existingSlugs = rows.map((row: { slug: string }) => row.slug);

--- a/api-services/api/bookings/mutations.ts
+++ b/api-services/api/bookings/mutations.ts
@@ -321,7 +321,16 @@ export async function updatePayoutStatus(id: string, payoutStatus: 'paid' | 'pen
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) throw new Error('Not authenticated');
 
-    // DB trigger (check_payout_status_update) enforces admin-only at the server level.
+    // Client-side check for fast rejection. DB trigger (check_payout_status_update) is the authoritative guard.
+    const { data: profile } = await supabase
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .single();
+    if (!profile || profile.role !== 'admin') {
+        throw new Error('Forbidden: admin access required');
+    }
+
     const { error } = await supabase
         .from('bookings')
         .update({ payout_status: payoutStatus })

--- a/api-services/api/forum.ts
+++ b/api-services/api/forum.ts
@@ -48,6 +48,9 @@ async function resolveSlug(baseSlug: string): Promise<string> {
         supabase.from('forum_posts').select('slug').like('slug', `${seed}-%`),
     ]);
 
+    if (exact.error) throw new Error(`Failed to check slug uniqueness: ${exact.error.message}`);
+    if (suffixed.error) throw new Error(`Failed to check slug uniqueness: ${suffixed.error.message}`);
+
     const existingSlugs = [
         ...toArray<{ slug: string }>(exact.data),
         ...toArray<{ slug: string }>(suffixed.data),
@@ -161,6 +164,10 @@ export const forumService = {
     // ---------- Posts ----------
 
     async getForumPosts(filters: ForumPostFilters = {}): Promise<{ data: ForumPost[]; total: number }> {
+        if (filters.removedOnly && filters.includeRemoved) {
+            throw new Error('Cannot specify both removedOnly and includeRemoved');
+        }
+
         const { data: { user } } = await supabase.auth.getUser();
         const limit = filters.limit ?? 20;
         const offset = filters.offset ?? 0;

--- a/api-services/api/schemas.ts
+++ b/api-services/api/schemas.ts
@@ -70,7 +70,7 @@ export const reviewSchema = z.object({
 
 export const blogPostSchema = z.object({
     title: z.string().min(3, "Title must be at least 3 characters"),
-    slug: z.string().min(3, "Slug must be at least 3 characters").optional(),
+    slug: z.string().min(3, "Slug must be at least 3 characters").regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase alphanumeric with hyphens").optional(),
     content: z.string().optional(),
     excerpt: z.string().max(500).optional(),
     video_url: z.string().url().optional().or(z.literal('')),

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from 'react-router-dom';
 import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star, Home, Car } from 'lucide-react';
 import { useClickOutside } from '../hooks/useClickOutside';
 import { useLanguage } from '../context/LanguageContext';
+import { toast } from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
 import { db } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
@@ -58,6 +59,7 @@ export const DirectoryHome: React.FC = () => {
                 }
             } catch (err) {
                 console.error('Failed to load landing listings:', err);
+                toast.error('Failed to load data. Please try refreshing the page.');
             } finally {
                 if (!cancelled) setListingsLoading(false);
             }


### PR DESCRIPTION
## Summary

- **PostgREST injection fix (HIGH):** Add regex constraint `^[a-z0-9]+(?:-[a-z0-9]+)*$` to `blogPostSchema.slug` and `escapePostgREST()` helper to prevent filter injection via custom slugs in `.or()` queries
- **resolveSlug error handling (MEDIUM):** Add `.error` checks in both `blog.ts` and `forum.ts` — previously `toArray(null)` silently returned `[]`, masking query failures and risking duplicate slugs
- **updatePayoutStatus auth (MEDIUM):** Add client-side admin role check as fast rejection before DB trigger (trigger remains authoritative guard)
- **Contradictory filter validation (LOW):** Throw on `removedOnly + includeRemoved` in `getForumPosts` instead of silently ignoring one
- **User-facing error toast (LOW):** Show `toast.error()` in DirectoryHome when data loading fails instead of silently swallowing errors

## Test plan

- [ ] Create a blog post with slug `test%25.or(1=1)` — should be rejected by Zod validation
- [ ] Create a blog post with valid slug `my-valid-slug` — should work normally
- [ ] Verify `updatePayoutStatus` as non-admin returns "Forbidden" immediately
- [ ] Verify `getForumPosts({ removedOnly: true, includeRemoved: true })` throws descriptive error
- [ ] Build passes: `npm run build`
- [ ] Lint passes: `npm run lint`