### PR TITLE
feat: SEO roadmap Phase 1-2 — technical SEO, excursion pages, site-wide markup

### DIFF
--- a/components/Navbar.test.tsx
+++ b/components/Navbar.test.tsx
@@ -71,6 +71,21 @@ vi.mock('./navbar/NavModeToggle', () => ({
 
 import { useAuth } from '../context/AuthContext';
 
+// Mock window.matchMedia for jsdom
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    })),
+});
+
 describe('Navbar', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -169,5 +184,19 @@ describe('Navbar', () => {
 
         fireEvent.click(ruBtn);
         expect(mockSetLanguage).toHaveBeenCalledWith('ru');
+    });
+
+    it('selects Turkish language', () => {
+        render(
+            <BrowserRouter>
+                <Navbar />
+            </BrowserRouter>
+        );
+
+        fireEvent.click(screen.getByTestId('profile-button'));
+
+        const trBtn = screen.getByText('TR');
+        fireEvent.click(trBtn);
+        expect(mockSetLanguage).toHaveBeenCalledWith('tr');
     });
 });

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -97,7 +97,7 @@ export const Navbar: React.FC = () => {
                 <img src="/logo.png" alt="Alanya Holidays" className="w-10 h-10 object-contain relative z-10 rounded-full" />
               </div>
               <span className="font-serif text-lg sm:text-xl md:text-2xl text-slate-900 dark:text-white tracking-tight font-medium truncate hidden md:block">
-                Alanya<span className="text-teal-600 dark:text-cyan-400 dark:text-slate-200">Holidays</span>
+                Alanya<span className="text-teal-600 dark:text-cyan-400">Holidays</span>
               </span>
             </Link>
           </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useClickOutside } from '../hooks/useClickOutside';
+import { ShoppingBag, Menu, User, Heart } from 'lucide-react';
 
 const MD_BREAKPOINT = 768;
-import { ShoppingBag, Menu, User, Heart } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useModal } from '../context/ModalContext';
@@ -24,7 +24,7 @@ export const Navbar: React.FC = () => {
   const { items, setIsCartOpen } = useCart();
   const { favorites } = useFavorites();
   const { user, isAuthenticated } = useAuth();
-  const { t } = useLanguage();
+  useLanguage();
   useModal();
 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { useClickOutside } from '../hooks/useClickOutside';
+
+const MD_BREAKPOINT = 768;
 import { ShoppingBag, Menu, User, Heart } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
@@ -39,15 +42,7 @@ export const Navbar: React.FC = () => {
     }
   }, [location.pathname]);
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (profileRef.current && !profileRef.current.contains(event.target as Node)) {
-        setIsProfileOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(profileRef, () => setIsProfileOpen(false));
 
   useEffect(() => {
     if (isMobileMenuOpen) {
@@ -59,6 +54,19 @@ export const Navbar: React.FC = () => {
       document.body.style.overflow = '';
     };
   }, [isMobileMenuOpen]);
+
+  // Reset mobile menu when viewport widens to desktop — prevents both menus open simultaneously
+  useEffect(() => {
+    const mql = window.matchMedia(`(min-width: ${MD_BREAKPOINT}px)`);
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      if (e.matches) {
+        setIsMobileMenuOpen(false);
+      }
+    };
+    handleChange(mql);
+    mql.addEventListener('change', handleChange);
+    return () => mql.removeEventListener('change', handleChange);
+  }, []);
 
   return (
     <header
@@ -132,7 +140,7 @@ export const Navbar: React.FC = () => {
                     // Logic: Mobile -> Open MobileMenu. Desktop -> Open ProfileDropdown.
                     // If user is Auth on Desktop -> ProfileDropdown acting as user menu.
                     // If user is Guest on Desktop -> ProfileDropdown acting as Login/Register menu.
-                    if (window.innerWidth < 768) {
+                    if (window.innerWidth < MD_BREAKPOINT) {
                       setIsMobileMenuOpen(!isMobileMenuOpen);
                     } else {
                       setIsProfileOpen(!isProfileOpen);

--- a/components/navbar/ListPropertyAction.tsx
+++ b/components/navbar/ListPropertyAction.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useRef } from 'react';
-import { Home, Plus, Car, Briefcase } from 'lucide-react';
+import React, { useState } from 'react';
+import { Home, Plus } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '../../context/AuthContext';
 import { useLanguage } from '../../context/LanguageContext';
 import { db } from '../../api-services';
-import { useClickOutside } from '../../hooks/useClickOutside';
 import { BecomeHostModal } from '../modals/BecomeHostModal';
 
 export const ListPropertyAction: React.FC = () => {

--- a/components/navbar/UserDropdown.tsx
+++ b/components/navbar/UserDropdown.tsx
@@ -99,14 +99,6 @@ export const UserDropdown: React.FC<UserDropdownProps> = ({ isOpen, onClose, mod
                     </>
                 )}
 
-                {!isAuthenticated && (
-                    <div className="md:hidden">
-                        {/* Redundant if hidden md:block on container, but keeping structure */}
-                        <button onClick={() => { openLogin(); onClose(); }} className="w-full text-left px-3 py-2 text-sm font-medium text-slate-700 dark:text-slate-200">{t('nav.login')}</button>
-                        <button onClick={() => { openRegister(); onClose(); }} className="w-full text-left px-3 py-2 text-sm font-bold text-teal-600 dark:text-cyan-400 ">{t('nav.signup')}</button>
-                    </div>
-                )}
-
                 {/* Mode switch, Language & Theme settings section */}
                 <div className="h-px bg-slate-100 dark:bg-slate-800/80 my-2"></div>
                 <div className="px-3 py-2 space-y-3">

--- a/components/seo/SEOHead.tsx
+++ b/components/seo/SEOHead.tsx
@@ -8,7 +8,7 @@ interface SEOHeadProps {
   image?: string;
   type?: 'website' | 'article' | 'product';
   keywords?: string[];
-  jsonLd?: object | null;
+  jsonLd?: object | object[] | null;
   noIndex?: boolean;
 }
 
@@ -70,11 +70,11 @@ export const SEOHead: React.FC<SEOHeadProps> = ({
       <meta name="twitter:site" content="@alanyaholidays" />
 
       {/* Structured Data (JSON-LD) */}
-      {jsonLd && (
-        <script type="application/ld+json">
-          {JSON.stringify(jsonLd)}
+      {jsonLd && (Array.isArray(jsonLd) ? jsonLd : [jsonLd]).map((schema, i) => (
+        <script key={i} type="application/ld+json">
+          {JSON.stringify(schema)}
         </script>
-      )}
+      ))}
     </Helmet>
   );
 };

--- a/constants/categoryPaths.ts
+++ b/constants/categoryPaths.ts
@@ -8,6 +8,7 @@ const SCHEMA_TYPE_MAP: Record<string, string> = {
     'spa-hamam':      'HealthAndBeautyBusiness',
     'hair-beauty':    'HealthAndBeautyBusiness',
     'tours':          'TouristAttraction',
+    'transport':      'TaxiService',
 };
 
 export function getSchemaType(categoryId: string): string {

--- a/data/attractionPages.ts
+++ b/data/attractionPages.ts
@@ -1,0 +1,279 @@
+export type AttractionJsonLdType =
+  | 'TouristAttraction'
+  | 'Beach'
+  | 'LandmarksOrHistoricalBuildings'
+  | 'TouristTrip';
+
+export interface Attraction {
+  slug: string;
+  title: string;
+  metaTitle: string;
+  metaDescription: string;
+  keywords: string[];
+  longDescription: string;
+  practicalInfo: {
+    hours?: string;
+    admission?: string;
+    howToGet?: string;
+    tips?: string;
+  };
+  coordinates: { lat: number; lng: number };
+  jsonLdType: AttractionJsonLdType;
+  searchKeywords: string[];
+  relatedExcursionSlugs: string[];
+  relatedAttractionSlugs: string[];
+}
+
+export const ATTRACTIONS: Attraction[] = [
+  {
+    slug: 'cleopatra-beach',
+    title: 'Cleopatra Beach',
+    metaTitle: 'Cleopatra Beach Alanya — Sandy Beach Near the Castle',
+    metaDescription: 'Cleopatra Beach is Alanya\'s most famous sandy beach, stretching below the medieval castle with crystal-clear waters, water sports, and stunning views.',
+    keywords: ['cleopatra beach alanya', 'alanya beach', 'cleopatra beach', 'best beach alanya', 'alanya sandy beach', 'cleopatra beach water sports'],
+    longDescription: 'Cleopatra Beach is the crown jewel of Alanya\'s coastline, a long stretch of fine golden sand lapped by the clear turquoise waters of the Mediterranean. Named after the legendary Egyptian queen who reportedly swam here, the beach offers a perfect mix of natural beauty and modern amenities. Lifeguards, sunbeds, water sports rentals, and beachside cafes line the promenade, while the dramatic silhouette of Alanya Castle towers above.',
+    practicalInfo: {
+      hours: 'Open 24 hours, lifeguards 09:00–19:00',
+      admission: 'Free (sunbeds ~50 TL)',
+      howToGet: '15 min walk from Alanya center, or local bus along the coastal road',
+      tips: 'Arrive early in summer for a good spot. The western end near the castle is quieter.',
+    },
+    coordinates: { lat: 36.5444, lng: 31.9797 },
+    jsonLdType: 'Beach',
+    searchKeywords: ['beach', 'swimming', 'cleopatra', 'sandy', 'water sports'],
+    relatedExcursionSlugs: ['alanya-boat-tours', 'parasailing-alanya'],
+    relatedAttractionSlugs: ['incekum-beach', 'keykubat-beach'],
+  },
+  {
+    slug: 'incekum-beach',
+    title: 'Incekum Beach',
+    metaTitle: 'Incekum Beach Alanya — Quiet Sandy Beach for Families',
+    metaDescription: 'Incekum Beach is a peaceful sandy beach 20 km west of Alanya, perfect for families with shallow waters and a relaxed atmosphere away from the crowds.',
+    keywords: ['incekum beach', 'incekum alanya', 'quiet beach alanya', 'family beach alanya', 'alanya beach holiday', 'incekum resort'],
+    longDescription: 'Incekum Beach, meaning "fine sand" in Turkish, lives up to its name with soft pale sand and gently shelving waters ideal for families with young children. Located about 20 km west of Alanya, this Blue Flag beach offers a tranquil alternative to the busier city beaches. The surrounding pine-covered hills provide natural shade and a stunning backdrop.',
+    practicalInfo: {
+      hours: 'Open 24 hours',
+      admission: 'Free',
+      howToGet: 'Local bus from Alanya center (30 min), or taxi (~200 TL)',
+      tips: 'Weekdays are much quieter than weekends. Bring snorkeling gear — the water clarity is excellent.',
+    },
+    coordinates: { lat: 36.6260, lng: 31.7770 },
+    jsonLdType: 'Beach',
+    searchKeywords: ['beach', 'incekum', 'family', 'quiet', 'sandy'],
+    relatedExcursionSlugs: ['alanya-boat-tours'],
+    relatedAttractionSlugs: ['cleopatra-beach'],
+  },
+  {
+    slug: 'keykubat-beach',
+    title: 'Keykubat Beach',
+    metaTitle: 'Keykubat Beach Alanya — Eastside Beach with Cafes & Promenade',
+    metaDescription: 'Keykubat Beach on Alanya\'s eastern side offers a long promenade, beachside cafes, and calm waters — ideal for a relaxed day by the sea.',
+    keywords: ['keykubat beach alanya', 'alanya east beach', 'keykubat plaji', 'alanya promenade beach', 'beach cafes alanya'],
+    longDescription: 'Keykubat Beach stretches along Alanya\'s eastern coastline, offering a more laid-back atmosphere than its famous western neighbor. A well-maintained promenade connects numerous cafes, restaurants, and beach bars, making it easy to spend a full day here without leaving the waterfront. The gentle slope into the sea makes it popular with locals and returning visitors who prefer its quieter vibe.',
+    practicalInfo: {
+      hours: 'Open 24 hours',
+      admission: 'Free',
+      howToGet: '10 min walk from Alanya harbor, along the eastern promenade',
+      tips: 'The beachside fish restaurants here are excellent and reasonably priced. Great for sunset views.',
+    },
+    coordinates: { lat: 36.5475, lng: 31.9985 },
+    jsonLdType: 'Beach',
+    searchKeywords: ['beach', 'keykubat', 'promenade', 'cafes', 'relaxed'],
+    relatedExcursionSlugs: ['parasailing-alanya'],
+    relatedAttractionSlugs: ['cleopatra-beach'],
+  },
+  {
+    slug: 'dim-cave',
+    title: 'Dim Cave',
+    metaTitle: 'Dim Cave Alanya — Underground Limestone Cave with Stalactites',
+    metaDescription: 'Explore Dim Cave near Alanya: a stunning underground limestone cave with colorful stalactites, stalagmites, and an underground lake just 15 km from the city.',
+    keywords: ['dim cave alanya', 'alanya cave tour', 'dim magarasi', 'stalactite cave alanya', 'alanya underground cave', 'dim cave entrance fee'],
+    longDescription: 'Dim Cave is one of Turkey\'s most impressive show caves, located just 15 km from Alanya in the Dim River valley. This ancient limestone cave stretches over 360 meters into the mountain, revealing spectacular stalactites and stalagmites formed over millions of years. Colored lighting highlights the natural formations, and an underground lake near the end adds to the otherworldly atmosphere. The cave stays a cool 18–20°C year-round — a perfect escape from the summer heat.',
+    practicalInfo: {
+      hours: '09:00–19:00 daily (summer), 09:00–17:00 (winter)',
+      admission: '~60 TL',
+      howToGet: 'Local bus or taxi from Alanya (15 km east), or combine with a Dim River tour',
+      tips: 'Wear non-slip shoes — the path can be wet inside. Bring a light jacket; the cave is cool even in summer.',
+    },
+    coordinates: { lat: 36.4590, lng: 32.0730 },
+    jsonLdType: 'TouristAttraction',
+    searchKeywords: ['cave', 'dim', 'stalactite', 'underground', 'nature'],
+    relatedExcursionSlugs: ['alanya-jeep-safari'],
+    relatedAttractionSlugs: ['dim-river'],
+  },
+  {
+    slug: 'dim-river',
+    title: 'Dim River',
+    metaTitle: 'Dim River Alanya — Swimming, Rafting & Riverside Restaurants',
+    metaDescription: 'The Dim River near Alanya offers natural swimming pools, rafting adventures, and riverside fish restaurants in a stunning mountain setting.',
+    keywords: ['dim river alanya', 'dim river restaurants', 'dim cayi alanya', 'alanya rafting', 'dim river swimming', 'alanya river tour'],
+    longDescription: 'The Dim River flows through a dramatic gorge east of Alanya, creating natural swimming pools and offering some of the region\'s best rafting. The riverside restaurants, perched on platforms above the cool mountain water, serve fresh trout caught from the river itself. Whether you come for an adrenaline-pumping rafting trip or a lazy afternoon meal with your feet in the water, the Dim River is a must-visit escape from the coastal heat.',
+    practicalInfo: {
+      hours: 'Open year-round (rafting season: April–October)',
+      admission: 'Free access; rafting tours from ~300 TL/person',
+      howToGet: '30 min drive east from Alanya, or book a tour with hotel transfer',
+      tips: 'The riverside restaurants are busiest at lunchtime — come early or late for a quieter experience.',
+    },
+    coordinates: { lat: 36.4620, lng: 32.0520 },
+    jsonLdType: 'TouristAttraction',
+    searchKeywords: ['river', 'dim', 'rafting', 'swimming', 'restaurant', 'nature'],
+    relatedExcursionSlugs: ['alanya-rafting'],
+    relatedAttractionSlugs: ['dim-cave', 'green-canyon'],
+  },
+  {
+    slug: 'sapadere-canyon',
+    title: 'Sapadere Canyon',
+    metaTitle: 'Sapadere Canyon Alanya — Hidden Gorge with Waterfalls',
+    metaDescription: 'Walk through Sapadere Canyon\'s dramatic gorge, swim under waterfalls, and explore a traditional village — one of Alanya\'s most stunning natural attractions.',
+    keywords: ['sapadere canyon', 'sapadere canyon alanya', 'alanya canyon tour', 'sapadere waterfall', 'alanya nature attraction', 'sapadere village'],
+    longDescription: 'Hidden deep in the Taurus Mountains, Sapadere Canyon is a breathtaking natural wonder that remained unknown to tourists until walkways were built in 2008. Wooden pathways wind through the narrow gorge, past cascading waterfalls and emerald pools so clear you can see the riverbed below. The canyon walk takes about an hour, ending at a traditional Sapadere village where you can experience authentic Turkish village life and sample homemade gözleme.',
+    practicalInfo: {
+      hours: '08:00–19:00 daily (April–October), 09:00–17:00 (November–March)',
+      admission: '~40 TL',
+      howToGet: 'Book a guided tour from Alanya (hotel transfer included), or drive 30 km east',
+      tips: 'Wear water shoes — the pathways can be slippery. The water is refreshing even in summer.',
+    },
+    coordinates: { lat: 36.5040, lng: 32.1500 },
+    jsonLdType: 'TouristAttraction',
+    searchKeywords: ['sapadere', 'canyon', 'waterfall', 'gorge', 'nature', 'village'],
+    relatedExcursionSlugs: ['sapadere-canyon-tour'],
+    relatedAttractionSlugs: ['dim-cave'],
+  },
+  {
+    slug: 'alanya-castle',
+    title: 'Alanya Castle',
+    metaTitle: 'Alanya Castle — Seljuk Fortress with Panoramic Sea Views',
+    metaDescription: 'Visit Alanya Castle, a 13th-century Seljuk fortress perched above the city with stunning panoramic views, ancient walls, and the iconic Red Tower.',
+    keywords: ['alanya castle', 'alanya kalesi', 'alanya fortress', 'seljuk castle alanya', 'red tower alanya', 'alanya castle views'],
+    longDescription: 'Alanya Castle is the city\'s most iconic landmark, a sprawling 13th-century Seljuk fortress that crowns the rocky peninsula dividing Alanya\'s two main beaches. Built by Sultan Alaeddin Keykubat I in 1226, the castle walls stretch over 6 km, encircling the old town, the Red Tower, and the shipyard below. Today, parts of the fortress are open to visitors, with panoramic viewpoints offering breathtaking views over the Mediterranean, the Taurus Mountains, and the city below.',
+    practicalInfo: {
+      hours: '09:00–19:00 daily (summer), 08:30–17:00 (winter)',
+      admission: '~30 TL (cable car extra ~60 TL round trip)',
+      howToGet: 'Cable car from Cleopatra Beach, or drive/taxi up the hill. Walking takes ~30 min uphill.',
+      tips: 'The cable car offers the best views on the way up. Visit in the late afternoon for golden-hour photos.',
+    },
+    coordinates: { lat: 36.5400, lng: 31.9945 },
+    jsonLdType: 'LandmarksOrHistoricalBuildings',
+    searchKeywords: ['castle', 'fortress', 'seljuk', 'history', 'views', 'keykubat'],
+    relatedExcursionSlugs: ['alanya-city-tour'],
+    relatedAttractionSlugs: ['red-tower-alanya', 'alanya-shipyard'],
+  },
+  {
+    slug: 'red-tower-alanya',
+    title: 'Red Tower (Kızıl Kule)',
+    metaTitle: 'Red Tower Alanya — 13th-Century Octagonal Seljuk Landmark',
+    metaDescription: 'The Red Tower is Alanya\'s iconic octagonal 13th-century fortress tower, housing an ethnographic museum with stunning harbor views from the top.',
+    keywords: ['red tower alanya', 'kizil kule', 'alanya red tower', 'octagonal tower alanya', 'seljuk tower alanya', 'alanya harbor tower'],
+    longDescription: 'The Red Tower (Kızıl Kule) stands as Alanya\'s most recognizable landmark, a striking 33-meter-tall octagonal tower built in 1226 by the Seljuk Sultan Alaeddin Keykubat I to defend the city\'s shipyard. Its distinctive red brick cladding gives it its name and makes it visible from across the harbor. Inside, the tower houses a small ethnographic museum showcasing Seljuk and Ottoman artifacts. Climb to the top for panoramic views of the harbor, castle hill, and the Mediterranean stretching to the horizon.',
+    practicalInfo: {
+      hours: '09:00–18:00 Tuesday–Sunday (closed Mondays)',
+      admission: '~15 TL',
+      howToGet: 'Located at the harbor in central Alanya, a 5 min walk from the city center',
+      tips: 'Combine with the shipyard visit — they\'re right next to each other. The top floor has the best photos.',
+    },
+    coordinates: { lat: 36.5420, lng: 31.9960 },
+    jsonLdType: 'LandmarksOrHistoricalBuildings',
+    searchKeywords: ['red tower', 'kizil kule', 'seljuk', 'fortress', 'museum', 'harbor'],
+    relatedExcursionSlugs: ['alanya-city-tour'],
+    relatedAttractionSlugs: ['alanya-castle', 'alanya-shipyard'],
+  },
+  {
+    slug: 'alanya-shipyard',
+    title: 'Alanya Shipyard (Tersane)',
+    metaTitle: 'Alanya Shipyard — 13th-Century Seljuk Naval Dockyard',
+    metaDescription: 'Explore Alanya\'s 13th-century shipyard carved into the cliffs — the only surviving Seljuk naval dockyard and a unique piece of Mediterranean maritime history.',
+    keywords: ['alanya shipyard', 'alanya tersane', 'seljuk shipyard', 'alanya naval museum', 'alanya dockyard', 'medieval shipyard'],
+    longDescription: 'The Alanya Shipyard (Tersane) is a remarkable 13th-century naval dockyard carved directly into the rocky cliffs of the peninsula. Built in 1227 by order of Sultan Alaeddin Keykubat I, it is the only surviving Seljuk shipyard in the world and one of the best-preserved medieval dockyards in the Mediterranean. Five vaulted bays could shelter ships up to 40 meters long, and a small mosque within the complex served the sailors. Today, you can walk through the ancient dry docks and imagine the galleys that were once built and repaired here.',
+    practicalInfo: {
+      hours: '09:00–18:00 daily (summer), 09:00–17:00 (winter)',
+      admission: '~15 TL (combined ticket with Red Tower available)',
+      howToGet: 'Next to the Red Tower at the harbor, 5 min walk from Alanya center',
+      tips: 'Visit in the morning when the light streams through the arched entrances. The combined ticket with the Red Tower is better value.',
+    },
+    coordinates: { lat: 36.5425, lng: 31.9975 },
+    jsonLdType: 'LandmarksOrHistoricalBuildings',
+    searchKeywords: ['shipyard', 'tersane', 'seljuk', 'naval', 'dockyard', 'history'],
+    relatedExcursionSlugs: ['alanya-boat-tours'],
+    relatedAttractionSlugs: ['alanya-castle', 'red-tower-alanya'],
+  },
+  {
+    slug: 'syedra-ancient-city',
+    title: 'Syedra Ancient City',
+    metaTitle: 'Syedra Ancient City — Roman Ruins Near Alanya',
+    metaDescription: 'Discover the ancient Roman city of Syedra near Alanya, with well-preserved mosaics, a Roman bath, and panoramic sea views from its clifftop location.',
+    keywords: ['syedra ancient city', 'syedra alanya', 'roman ruins alanya', 'ancient city alanya', 'syedra mosaics', 'alanya archaeology'],
+    longDescription: 'Syedra was a prosperous Roman city perched on a hilltop overlooking the Mediterranean, 20 km southeast of Alanya. Founded in the 3rd century BC, it flourished under Roman rule and was eventually abandoned in the 13th century. Today, visitors can explore the ruins of a Roman bath complex with remarkably preserved mosaics, a colonnaded street, an amphitheater with sea views, and the city\'s impressive defensive walls. The site remains largely unrestored, giving it an authentic, adventurous feel.',
+    practicalInfo: {
+      hours: 'Open 24 hours (ungated site)',
+      admission: 'Free',
+      howToGet: '30 min drive southeast from Alanya; best accessed by rental car or guided tour',
+      tips: 'Bring water and sun protection — there is no shade or facilities on site. Wear sturdy shoes for the rocky terrain.',
+    },
+    coordinates: { lat: 36.4830, lng: 32.0840 },
+    jsonLdType: 'LandmarksOrHistoricalBuildings',
+    searchKeywords: ['syedra', 'ancient', 'roman', 'ruins', 'mosaics', 'archaeology'],
+    relatedExcursionSlugs: ['alanya-jeep-safari'],
+    relatedAttractionSlugs: ['dim-cave'],
+  },
+  {
+    slug: 'manavgat-waterfall',
+    title: 'Manavgat Waterfall',
+    metaTitle: 'Manavgat Waterfall — Scenic River Cascade Near Alanya',
+    metaDescription: 'Visit Manavgat Waterfall, a wide cascade on the Manavgat River near Side — a scenic picnic spot with riverside restaurants and easy access from Alanya.',
+    keywords: ['manavgat waterfall', 'manavgat falls', 'manavgat waterfall alanya', 'manavgat river', 'waterfall near alanya', 'manavgat picnic'],
+    longDescription: 'The Manavgat Waterfall is a wide, low cascade on the Manavgat River, about 3 km north of Manavgat town. Though not tall, the waterfall stretches impressively across the river, creating a popular spot for picnics, riverside dining, and boat trips. The surrounding park has shaded seating areas, and several restaurants serve fresh trout overlooking the falls. It\'s an easy day trip from Alanya, often combined with a visit to Side\'s ancient ruins.',
+    practicalInfo: {
+      hours: 'Open 24 hours (park: 08:00–22:00)',
+      admission: 'Free (parking ~10 TL)',
+      howToGet: '45 min drive from Alanya, or book a combined Manavgat/Side tour',
+      tips: 'The riverside restaurants are excellent for lunch. Combine with a visit to Side\'s ancient city and Apollo Temple.',
+    },
+    coordinates: { lat: 36.4660, lng: 31.4420 },
+    jsonLdType: 'TouristAttraction',
+    searchKeywords: ['manavgat', 'waterfall', 'river', 'cascade', 'picnic', 'nature'],
+    relatedExcursionSlugs: [],
+    relatedAttractionSlugs: ['green-canyon'],
+  },
+  {
+    slug: 'side-day-trip',
+    title: 'Side Day Trip',
+    metaTitle: 'Day Trip to Side from Alanya — Ancient City & Beach',
+    metaDescription: 'Plan a day trip to Side from Alanya: explore the Temple of Apollo, Roman theater, and ancient harbor, then relax on the beach beside 2,000-year-old ruins.',
+    keywords: ['side day trip', 'side alanya', 'temple of apollo side', 'side ancient city', 'side turkey', 'day trip from alanya to side'],
+    longDescription: 'A day trip to Side from Alanya takes you to one of Turkey\'s most atmospheric ancient cities. Side\'s remarkably preserved ruins sit directly on a sandy Mediterranean beach — you can literally swim beside Roman columns. The highlight is the Temple of Apollo at sunset, one of the most photographed spots on the Turkish Riviera. Wander through the Roman theater (seating 15,000), explore the agora and the Roman bath museum, then finish the day with fresh seafood at the old harbor.',
+    practicalInfo: {
+      hours: 'Ancient sites: 09:00–19:00 (summer), 08:30–17:30 (winter)',
+      admission: 'Combined museum ticket ~100 TL, Temple of Apollo area is free',
+      howToGet: '1 hour drive from Alanya; regular buses from Alanya otogar, or guided tour with hotel pickup',
+      tips: 'Visit the Temple of Apollo at sunset for the best photos. The museum ticket covers multiple sites and is good value.',
+    },
+    coordinates: { lat: 36.7680, lng: 31.3910 },
+    jsonLdType: 'TouristTrip',
+    searchKeywords: ['side', 'ancient', 'apollo', 'roman', 'beach', 'day trip', 'temple'],
+    relatedExcursionSlugs: ['alanya-city-tour'],
+    relatedAttractionSlugs: ['manavgat-waterfall'],
+  },
+  {
+    slug: 'green-canyon',
+    title: 'Green Canyon',
+    metaTitle: 'Green Canyon Alanya — Oymapınar Dam Lake & Boat Cruise',
+    metaDescription: 'Green Canyon is a stunning emerald lake surrounded by dramatic canyon walls near Alanya. Take a boat cruise, swim in pristine waters, and enjoy mountain scenery.',
+    keywords: ['green canyon alanya', 'oymapinar dam', 'green canyon boat tour', 'alanya lake cruise', 'green canyon swimming', 'alanya nature trip'],
+    longDescription: 'The Green Canyon is the stunning reservoir of the Oymapınar Dam, nestled in the Taurus Mountains about 25 km from Alanya. The lake\'s vivid emerald color comes from the mineral-rich mountain springs that feed it. Boat cruises take visitors through narrow canyon walls that rise dramatically from the water, with stops for swimming in the crystal-clear lake. The surrounding pine forests and the sheer rock faces create a landscape that feels a world away from the coastal resorts.',
+    practicalInfo: {
+      hours: 'Tours run 09:00–17:00 (April–October)',
+      admission: 'Tours from ~300 TL/person (includes lunch and hotel transfer)',
+      howToGet: 'Book a guided tour from Alanya with hotel transfer, or drive 25 km north',
+      tips: 'Bring a towel and swimwear. The lake water is cool and refreshing. Morning tours are less crowded.',
+    },
+    coordinates: { lat: 36.4650, lng: 31.8250 },
+    jsonLdType: 'TouristAttraction',
+    searchKeywords: ['green canyon', 'oymapinar', 'lake', 'cruise', 'canyon', 'nature', 'swimming'],
+    relatedExcursionSlugs: ['green-canyon-tour'],
+    relatedAttractionSlugs: ['dim-river'],
+  },
+];
+
+export function getAttraction(slug: string): Attraction | undefined {
+  return ATTRACTIONS.find(a => a.slug === slug);
+}

--- a/data/excursionTypes.ts
+++ b/data/excursionTypes.ts
@@ -1,0 +1,155 @@
+export interface ExcursionType {
+  slug: string;
+  title: string;
+  metaTitle: string;
+  metaDescription: string;
+  keywords: string[];
+  longDescription: string;
+  searchKeywords: string[];
+  relatedAttractions: string[];
+  relatedExcursionSlugs: string[];
+  jsonLdType: 'TouristTrip';
+}
+
+export const EXCURSION_TYPES: ExcursionType[] = [
+  {
+    slug: 'alanya-boat-tours',
+    title: 'Boat Tours in Alanya',
+    metaTitle: 'Alanya Boat Tours — Pirate Ship, Catamaran & Sunset Cruises',
+    metaDescription: 'Book the best boat tours in Alanya: pirate ship adventures, catamaran cruises, and sunset trips along the Turkish Riviera. Free hotel transfer included.',
+    keywords: ['alanya boat tour', 'pirate boat tour alanya', 'alanya catamaran tour', 'alanya sunset cruise', 'boat trip alanya', 'alanya sea tour'],
+    longDescription: 'Explore the stunning Turkish Riviera coastline on an Alanya boat tour. Choose from pirate ship adventures perfect for families, relaxed catamaran cruises, or romantic sunset trips along the Mediterranean. All tours include hotel pickup, swimming stops in crystal-clear bays, and onboard entertainment.',
+    searchKeywords: ['boat', 'pirate', 'catamaran', 'sunset', 'cruise', 'sea', 'yacht'],
+    relatedAttractions: ['cleopatra-beach', 'alanya-castle'],
+    relatedExcursionSlugs: ['parasailing-alanya', 'alanya-yacht-charter', 'scuba-diving-alanya'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-jeep-safari',
+    title: 'Jeep Safari in Alanya',
+    metaTitle: 'Alanya Jeep Safari — Off-Road Adventure Tours',
+    metaDescription: 'Experience Alanya jeep safari tours through the Taurus Mountains. Off-road adventure with village visits, mud baths, and stunning views. Book online.',
+    keywords: ['alanya jeep safari', 'alanya quad safari', 'alanya buggy safari', 'off-road alanya', 'jeep tour alanya', 'alanya mountain safari'],
+    longDescription: 'Hit the dusty trails of the Taurus Mountains on an Alanya jeep safari. These off-road adventures take you through authentic Turkish villages, past breathtaking mountain viewpoints, and into natural mud baths. A thrilling day out for adventure seekers and families alike.',
+    searchKeywords: ['jeep', 'safari', 'off-road', 'quad', 'buggy', 'mountain', 'adventure'],
+    relatedAttractions: ['dim-river', 'sapadere-canyon'],
+    relatedExcursionSlugs: ['alanya-rafting', 'green-canyon-tour'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-buggy-safari',
+    title: 'Buggy Safari in Alanya',
+    metaTitle: 'Alanya Buggy Safari — Drive Your Own Off-Road Buggy',
+    metaDescription: 'Drive your own off-road buggy through Alanya\'s stunning countryside. Mud, dust, and pure adventure on specially designed tracks and trails.',
+    keywords: ['alanya buggy safari', 'buggy rental alanya', 'dune buggy alanya', 'alanya off-road driving'],
+    longDescription: 'Take the wheel of a powerful dune buggy and tear through Alanya\'s rugged terrain. Buggy safaris offer a hands-on off-road experience with mud tracks, forest trails, and open countryside. No previous driving experience needed — full instruction provided.',
+    searchKeywords: ['buggy', 'dune buggy', 'off-road', 'driving', 'adventure'],
+    relatedAttractions: ['dim-river'],
+    relatedExcursionSlugs: ['alanya-jeep-safari', 'alanya-rafting'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-rafting',
+    title: 'Rafting in Alanya',
+    metaTitle: 'Alanya Rafting Tour — Köprülü Canyon White Water Adventure',
+    metaDescription: 'Book Alanya rafting tours on the Köprülü River. White water adventure through stunning canyons with professional guides. Canyoning options available.',
+    keywords: ['alanya rafting tour', 'rafting alanya', 'canyoning alanya', 'white water alanya', 'koprulu canyon rafting', 'alanya water adventure'],
+    longDescription: 'Navigate the rapids of the Köprülü River on an Alanya rafting tour. This exhilarating white water adventure takes you through a stunning national park canyon with towering cliffs and emerald pools. Suitable for beginners and experienced rafters, with professional guides ensuring safety throughout.',
+    searchKeywords: ['rafting', 'canoe', 'kayak', 'canyon', 'water', 'river', 'adventure'],
+    relatedAttractions: ['green-canyon'],
+    relatedExcursionSlugs: ['alanya-jeep-safari', 'green-canyon-tour'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'scuba-diving-alanya',
+    title: 'Scuba Diving in Alanya',
+    metaTitle: 'Scuba Diving in Alanya — Dive Courses & Snorkeling Trips',
+    metaDescription: 'Discover underwater Alanya with scuba diving courses and snorkeling trips. Crystal-clear Mediterranean waters, colorful marine life, and professional instructors.',
+    keywords: ['scuba diving alanya', 'snorkeling alanya', 'alanya diving', 'dive course alanya', 'underwater alanya', 'alanya sea life'],
+    longDescription: 'Dive into the crystal-clear waters of the Mediterranean with Alanya scuba diving tours. Whether you\'re a certified diver or a complete beginner, professional instructors guide you through underwater caves, reefs, and shipwrecks teeming with marine life. Snorkeling options also available for those who prefer to stay near the surface.',
+    searchKeywords: ['scuba', 'diving', 'snorkeling', 'underwater', 'dive', 'fish'],
+    relatedAttractions: ['cleopatra-beach'],
+    relatedExcursionSlugs: ['alanya-boat-tours', 'parasailing-alanya'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'sapadere-canyon-tour',
+    title: 'Sapadere Canyon Tour from Alanya',
+    metaTitle: 'Sapadere Canyon Tour from Alanya — Nature & Waterfalls',
+    metaDescription: 'Visit Sapadere Canyon from Alanya: walk through stunning gorges, swim under waterfalls, and explore authentic village life. Hotel transfer included.',
+    keywords: ['sapadere canyon tour', 'sapadere canyon alanya', 'alanya canyon trip', 'alanya waterfall tour', 'sapadere village'],
+    longDescription: 'Discover the hidden gem of Sapadere Canyon, a spectacular natural wonder nestled in the Taurus Mountains near Alanya. Walk along wooden pathways through narrow gorges, swim in natural pools beneath cascading waterfalls, and visit a traditional Turkish village where time stands still.',
+    searchKeywords: ['sapadere', 'canyon', 'waterfall', 'nature', 'village', 'gorge'],
+    relatedAttractions: ['sapadere-canyon', 'dim-cave'],
+    relatedExcursionSlugs: ['green-canyon-tour', 'alanya-jeep-safari'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'green-canyon-tour',
+    title: 'Green Canyon Tour from Alanya',
+    metaTitle: 'Green Canyon Tour from Alanya — Lake Cruise & Swimming',
+    metaDescription: 'Book the Green Canyon tour from Alanya: scenic boat cruise on Oymapınar Dam Lake, swimming in emerald waters, and breathtaking mountain views.',
+    keywords: ['green canyon tour', 'green canyon alanya', 'oymapinar dam tour', 'alanya lake cruise', 'green canyon boat trip'],
+    longDescription: 'Cruise across the emerald waters of Oymapınar Dam Lake on the Green Canyon tour from Alanya. This peaceful boat trip takes you through dramatic canyon walls, with stops for swimming in the lake\'s pristine waters and lunch at a lakeside restaurant. A perfect day trip for nature lovers and families.',
+    searchKeywords: ['green canyon', 'lake', 'cruise', 'oymapinar', 'dam', 'swimming'],
+    relatedAttractions: ['green-canyon', 'dim-river'],
+    relatedExcursionSlugs: ['sapadere-canyon-tour', 'alanya-boat-tours'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'parasailing-alanya',
+    title: 'Parasailing & Water Sports in Alanya',
+    metaTitle: 'Parasailing in Alanya — Water Sports & Jet Ski Rentals',
+    metaDescription: 'Soar above Alanya\'s coastline with parasailing, or ride the waves on a jet ski. Book water sports activities online with best price guarantee.',
+    keywords: ['parasailing alanya', 'jet ski alanya', 'water sports alanya', 'alanya parasailing', 'alanya banana boat', 'alanya fly board'],
+    longDescription: 'Take to the skies with parasailing over Alanya\'s stunning coastline, or feel the adrenaline rush on a jet ski. Alanya\'s water sports scene offers something for everyone — from gentle banana boat rides for the family to high-octane flyboarding for thrill seekers.',
+    searchKeywords: ['parasailing', 'jet ski', 'water sport', 'banana boat', 'fly board', 'adrenaline'],
+    relatedAttractions: ['cleopatra-beach', 'incekum-beach'],
+    relatedExcursionSlugs: ['alanya-boat-tours', 'scuba-diving-alanya'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-fishing-trips',
+    title: 'Fishing Trips in Alanya',
+    metaTitle: 'Alanya Fishing Trips — Sea Fishing & Lake Excursions',
+    metaDescription: 'Join a fishing trip in Alanya: deep-sea fishing in the Mediterranean or peaceful lake fishing. All equipment provided, perfect for beginners.',
+    keywords: ['fishing trips alanya', 'alanya sea fishing', 'fishing tour alanya', 'alanya lake fishing', 'deep sea fishing turkey'],
+    longDescription: 'Cast your line into the Mediterranean or the tranquil mountain lakes on an Alanya fishing trip. Deep-sea excursions target big game fish, while lake trips offer a peaceful day surrounded by stunning scenery. All equipment and bait provided — just bring your sense of adventure.',
+    searchKeywords: ['fishing', 'sea fishing', 'lake', 'boat', 'fish', 'angling'],
+    relatedAttractions: ['dim-river', 'green-canyon'],
+    relatedExcursionSlugs: ['alanya-boat-tours', 'alanya-yacht-charter'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-city-tour',
+    title: 'Alanya City Tour',
+    metaTitle: 'Alanya City Tour — Castle, Red Tower & Old Town Walking Tour',
+    metaDescription: 'Explore Alanya\'s historic landmarks on a city tour: the medieval castle, Red Tower, shipyard, and charming old town. Guided tours with hotel pickup.',
+    keywords: ['alanya city tour', 'alanya castle tour', 'red tower alanya tour', 'alanya old town', 'alanya sightseeing', 'alanya historical tour'],
+    longDescription: 'Step back in time on an Alanya city tour that takes you through centuries of history. Visit the imposing Seljuk castle overlooking the coast, the iconic Red Tower, the ancient shipyard carved into the cliffs, and the atmospheric old town with its bazaar and mosque. A must for culture lovers.',
+    searchKeywords: ['city', 'castle', 'red tower', 'shipyard', 'old town', 'history', 'sightseeing'],
+    relatedAttractions: ['alanya-castle', 'red-tower-alanya', 'alanya-shipyard'],
+    relatedExcursionSlugs: ['sapadere-canyon-tour', 'alanya-boat-tours'],
+    jsonLdType: 'TouristTrip',
+  },
+  {
+    slug: 'alanya-yacht-charter',
+    title: 'Yacht Charter in Alanya',
+    metaTitle: 'Alanya Yacht Charter — Private & Luxury Boat Rental',
+    metaDescription: 'Charter a private yacht in Alanya for an exclusive Mediterranean experience. Luxury boats, crewed charters, and romantic sunset cruises available.',
+    keywords: ['yacht charter alanya', 'private yacht alanya', 'luxury yacht tour alanya', 'alanya boat rental', 'alanya private cruise'],
+    longDescription: 'Experience the ultimate Mediterranean luxury with a private yacht charter from Alanya. Choose from sleek motor yachts, traditional gulets, or sailing vessels — all with professional crews. Perfect for special occasions, romantic escapes, or simply an unforgettable day on the turquoise waters.',
+    searchKeywords: ['yacht', 'charter', 'luxury', 'private', 'boat', 'gulet', 'crew'],
+    relatedAttractions: ['cleopatra-beach', 'alanya-castle'],
+    relatedExcursionSlugs: ['alanya-boat-tours', 'parasailing-alanya'],
+    jsonLdType: 'TouristTrip',
+  },
+];
+
+export function getExcursionType(slug: string): ExcursionType | undefined {
+  return EXCURSION_TYPES.find(et => et.slug === slug);
+}
+
+export function getAllExcursionTypeSlugs(): string[] {
+  return EXCURSION_TYPES.map(et => et.slug);
+}

--- a/data/excursionTypes.ts
+++ b/data/excursionTypes.ts
@@ -149,7 +149,3 @@ export const EXCURSION_TYPES: ExcursionType[] = [
 export function getExcursionType(slug: string): ExcursionType | undefined {
   return EXCURSION_TYPES.find(et => et.slug === slug);
 }
-
-export function getAllExcursionTypeSlugs(): string[] {
-  return EXCURSION_TYPES.map(et => et.slug);
-}

--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -110,7 +110,8 @@ test.describe('Booking Flow', () => {
 
     // Navigate to checkout
     await page.goto('/checkout');
-    await page.waitForLoadState('networkidle', { timeout: 15000 });
+    // domcontentloaded is enough — avoids networkidle hang from unmocked requests
+    await page.waitForLoadState('domcontentloaded');
 
     // Check body text contains our villa name
     const text = await page.locator('body').innerText();

--- a/e2e/booking.spec.ts
+++ b/e2e/booking.spec.ts
@@ -108,13 +108,8 @@ test.describe('Booking Flow', () => {
     });
     expect(cartLen).toBe(1);
 
-    // Navigate to checkout
+    // Navigate to checkout — use built-in Playwright retry so React has time to render
     await page.goto('/checkout');
-    // domcontentloaded is enough — avoids networkidle hang from unmocked requests
-    await page.waitForLoadState('domcontentloaded');
-
-    // Check body text contains our villa name
-    const text = await page.locator('body').innerText();
-    expect(text).toContain('Test Villa');
+    await expect(page.locator('body')).toContainText('Test Villa', { timeout: 15000 });
   });
 });

--- a/hooks/useClickOutside.ts
+++ b/hooks/useClickOutside.ts
@@ -1,4 +1,4 @@
-import { useEffect, RefObject } from 'react';
+import { useEffect, useRef, RefObject } from 'react';
 
 type Handler = (event: MouseEvent | TouchEvent) => void;
 
@@ -6,6 +6,9 @@ export const useClickOutside = <T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   handler: Handler
 ): void => {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
       const el = ref?.current;
@@ -13,7 +16,7 @@ export const useClickOutside = <T extends HTMLElement = HTMLElement>(
       if (!el || el.contains(event.target as Node)) {
         return;
       }
-      handler(event);
+      handlerRef.current(event);
     };
 
     document.addEventListener('mousedown', listener);
@@ -23,5 +26,5 @@ export const useClickOutside = <T extends HTMLElement = HTMLElement>(
       document.removeEventListener('mousedown', listener);
       document.removeEventListener('touchstart', listener);
     };
-  }, [ref, handler]);
+  }, [ref]);
 }

--- a/hooks/useScroll.ts
+++ b/hooks/useScroll.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 
 export function useScroll(threshold: number) {
-  const [scrolled, setScrolled] = React.useState(() => window.scrollY > threshold);
+  const [scrolled, setScrolled] = React.useState(
+    typeof window !== 'undefined' ? window.scrollY > threshold : false
+  );
 
   const onScroll = React.useCallback(() => {
     setScrolled(window.scrollY > threshold);

--- a/hooks/useScroll.ts
+++ b/hooks/useScroll.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export function useScroll(threshold: number) {
-  const [scrolled, setScrolled] = React.useState(false);
+  const [scrolled, setScrolled] = React.useState(() => window.scrollY > threshold);
 
   const onScroll = React.useCallback(() => {
     setScrolled(window.scrollY > threshold);
@@ -10,11 +10,6 @@ export function useScroll(threshold: number) {
   React.useEffect(() => {
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
-  }, [onScroll]);
-
-  // also check on first load
-  React.useEffect(() => {
-    onScroll();
   }, [onScroll]);
 
   return scrolled;

--- a/hooks/useScroll.ts
+++ b/hooks/useScroll.ts
@@ -10,6 +10,7 @@ export function useScroll(threshold: number) {
   }, [threshold]);
 
   React.useEffect(() => {
+    onScroll(); // sync state immediately after mount (browser may restore scroll after first render)
     window.addEventListener('scroll', onScroll);
     return () => window.removeEventListener('scroll', onScroll);
   }, [onScroll]);

--- a/pages/AddProduct.tsx
+++ b/pages/AddProduct.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
 import { ShoppingBag, Tag, Box, DollarSign } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const AddProduct: React.FC = () => {
     const { user } = useAuth();
@@ -48,6 +49,8 @@ export const AddProduct: React.FC = () => {
     };
 
     return (
+        <>
+        <SEOHead title="Add Product | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-20 px-4">
             <div className="max-w-2xl mx-auto bg-white dark:bg-slate-800/80 rounded-2xl shadow-xl p-8 border border-slate-100 dark:border-slate-800/50">
                 <div className="flex items-center gap-3 mb-2">
@@ -155,5 +158,6 @@ export const AddProduct: React.FC = () => {
                 </form>
             </div>
         </div>
+        </>
     );
 };

--- a/pages/AddService.tsx
+++ b/pages/AddService.tsx
@@ -8,6 +8,7 @@ import { CAR_DESCRIPTIONS, DEFAULT_DESCRIPTION } from '../data/cars';
 import { AddServiceCategoryStep, ServiceCategory } from '../components/host/services/AddServiceCategoryStep';
 import { AddServiceFormStep } from '../components/host/services/AddServiceFormStep';
 import { AddServiceSuccessStep } from '../components/host/services/AddServiceSuccessStep';
+import { SEOHead } from '../components/seo/SEOHead';
 
 type ServiceType = 'car' | 'bike' | 'transfer' | 'tour' | 'visa' | 'esim' | 'wellness' | 'creative';
 
@@ -162,6 +163,8 @@ export const AddService: React.FC = () => {
     }
 
     return (
+        <>
+        <SEOHead title="Add Service | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-12 px-4">
             <div className="max-w-3xl mx-auto">
                 {/* Header */}
@@ -195,5 +198,6 @@ export const AddService: React.FC = () => {
                 )}
             </div>
         </div>
+        </>
     );
 };

--- a/pages/AttractionPage.tsx
+++ b/pages/AttractionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { SEOHead } from '../components/seo/SEOHead';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
@@ -134,19 +134,13 @@ const AttractionPage: React.FC = () => {
 
   const jsonLd = buildAttractionJsonLd(attraction);
 
-  const relatedExcursions = useMemo(
-    () => attraction.relatedExcursionSlugs
-      .map(s => getExcursionType(s))
-      .filter((et): et is ExcursionType => et !== undefined),
-    [attraction]
-  );
+  const relatedExcursions = attraction.relatedExcursionSlugs
+    .map(s => getExcursionType(s))
+    .filter((et): et is ExcursionType => et !== undefined);
 
-  const relatedAttractions = useMemo(
-    () => attraction.relatedAttractionSlugs
-      .map(s => getAttraction(s))
-      .filter((a): a is Attraction => a !== undefined),
-    [attraction]
-  );
+  const relatedAttractions = attraction.relatedAttractionSlugs
+    .map(s => getAttraction(s))
+    .filter((a): a is Attraction => a !== undefined);
 
   const hasPracticalInfo =
     attraction.practicalInfo.hours ||

--- a/pages/AttractionPage.tsx
+++ b/pages/AttractionPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { SEOHead } from '../components/seo/SEOHead';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
@@ -9,6 +9,41 @@ import { db } from '../api-services';
 import { getAttraction, type Attraction } from '../data/attractionPages';
 import { getExcursionType, type ExcursionType } from '../data/excursionTypes';
 import { MapPin, Clock, Ticket, Bus, Lightbulb, ChevronDown, ChevronUp, Info, Compass } from 'lucide-react';
+
+interface RelatedItem { slug: string; title: string; metaDescription: string }
+
+function RelatedItemsGrid({ heading, items, icon: Icon, topMargin }: {
+  heading: string;
+  items: RelatedItem[];
+  icon: React.ElementType;
+  topMargin?: boolean;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className={`${topMargin ? 'mt-16 ' : ''}mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16`}>
+      <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">{heading}</h2>
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {items.map(item => (
+          <Link
+            key={item.slug}
+            to={`/${item.slug}`}
+            className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <Icon className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
+              <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
+                {item.title}
+              </h3>
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
+              {item.metaDescription}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function buildAttractionJsonLd(attraction: Attraction) {
   const base = {
@@ -99,13 +134,19 @@ const AttractionPage: React.FC = () => {
 
   const jsonLd = buildAttractionJsonLd(attraction);
 
-  const relatedExcursions = attraction.relatedExcursionSlugs
-    .map(s => getExcursionType(s))
-    .filter((et): et is ExcursionType => et !== undefined);
+  const relatedExcursions = useMemo(
+    () => attraction.relatedExcursionSlugs
+      .map(s => getExcursionType(s))
+      .filter((et): et is ExcursionType => et !== undefined),
+    [attraction]
+  );
 
-  const relatedAttractions = attraction.relatedAttractionSlugs
-    .map(s => getAttraction(s))
-    .filter((a): a is Attraction => a !== undefined);
+  const relatedAttractions = useMemo(
+    () => attraction.relatedAttractionSlugs
+      .map(s => getAttraction(s))
+      .filter((a): a is Attraction => a !== undefined),
+    [attraction]
+  );
 
   const hasPracticalInfo =
     attraction.practicalInfo.hours ||
@@ -148,7 +189,7 @@ const AttractionPage: React.FC = () => {
             </div>
             <button
               onClick={() => setShowFullDescription(!showFullDescription)}
-              className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:text-cyan-400 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
+              className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
             >
               {showFullDescription ? 'Read Less' : 'Read More'}
               {showFullDescription ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -242,61 +283,9 @@ const AttractionPage: React.FC = () => {
           </div>
         )}
 
-        {/* Related Excursions */}
-        {relatedExcursions.length > 0 && (
-          <div className="mt-16 mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
-            <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
-              Related Excursions
-            </h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {relatedExcursions.map(et => (
-                <Link
-                  key={et.slug}
-                  to={`/${et.slug}`}
-                  className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
-                >
-                  <div className="flex items-center gap-2 mb-1">
-                    <Compass className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
-                    <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
-                      {et.title}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
-                    {et.metaDescription.length > 100 ? `${et.metaDescription.slice(0, 100)}...` : et.metaDescription}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Related Attractions */}
-        {relatedAttractions.length > 0 && (
-          <div className="mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
-            <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
-              Nearby Attractions
-            </h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {relatedAttractions.map(attr => (
-                <Link
-                  key={attr.slug}
-                  to={`/${attr.slug}`}
-                  className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
-                >
-                  <div className="flex items-center gap-2 mb-1">
-                    <MapPin className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
-                    <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
-                      {attr.title}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
-                    {attr.metaDescription.length > 100 ? `${attr.metaDescription.slice(0, 100)}...` : attr.metaDescription}
-                  </p>
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
+        {/* Related Excursions / Nearby Attractions */}
+        <RelatedItemsGrid heading="Related Excursions" items={relatedExcursions} icon={Compass} topMargin />
+        <RelatedItemsGrid heading="Nearby Attractions" items={relatedAttractions} icon={MapPin} />
       </div>
 
       <DirectoryListingModal

--- a/pages/AttractionPage.tsx
+++ b/pages/AttractionPage.tsx
@@ -6,11 +6,11 @@ import { DirectoryListingCard } from '../components/directory/DirectoryListingCa
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { DirectoryListingDB } from '../types/models';
 import { db } from '../api-services';
-import { getAttraction } from '../data/attractionPages';
-import { getExcursionType } from '../data/excursionTypes';
+import { getAttraction, type Attraction } from '../data/attractionPages';
+import { getExcursionType, type ExcursionType } from '../data/excursionTypes';
 import { MapPin, Clock, Ticket, Bus, Lightbulb, ChevronDown, ChevronUp, Info, Compass } from 'lucide-react';
 
-function buildAttractionJsonLd(attraction: ReturnType<typeof getAttraction> & {}) {
+function buildAttractionJsonLd(attraction: Attraction) {
   const base = {
     '@context': 'https://schema.org',
     name: attraction.title,
@@ -55,7 +55,7 @@ const AttractionPage: React.FC = () => {
       try {
         const primaryQuery = attraction.searchKeywords[0] || attraction.title;
         const result = await db.searchDirectoryListings(primaryQuery, 'tours');
-        if (result.data.length > 0) {
+        if (result.data?.length > 0) {
           setListings(result.data);
         } else {
           const fallbackQuery = attraction.title
@@ -63,7 +63,7 @@ const AttractionPage: React.FC = () => {
             .replace(' from Alanya', '')
             .replace(' near Alanya', '');
           const broader = await db.searchDirectoryListings(fallbackQuery, 'tours');
-          setListings(broader.data);
+          setListings(broader.data ?? []);
         }
       } catch (e) {
         console.error('Failed to load attraction listings', e);
@@ -101,11 +101,11 @@ const AttractionPage: React.FC = () => {
 
   const relatedExcursions = attraction.relatedExcursionSlugs
     .map(s => getExcursionType(s))
-    .filter(Boolean);
+    .filter((et): et is ExcursionType => et !== undefined);
 
   const relatedAttractions = attraction.relatedAttractionSlugs
     .map(s => getAttraction(s))
-    .filter(Boolean);
+    .filter((a): a is Attraction => a !== undefined);
 
   const hasPracticalInfo =
     attraction.practicalInfo.hours ||
@@ -251,18 +251,18 @@ const AttractionPage: React.FC = () => {
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {relatedExcursions.map(et => (
                 <Link
-                  key={et!.slug}
-                  to={`/${et!.slug}`}
+                  key={et.slug}
+                  to={`/${et.slug}`}
                   className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
                 >
                   <div className="flex items-center gap-2 mb-1">
                     <Compass className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
                     <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
-                      {et!.title}
+                      {et.title}
                     </h3>
                   </div>
                   <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
-                    {et!.metaDescription.slice(0, 100)}...
+                    {et.metaDescription.length > 100 ? `${et.metaDescription.slice(0, 100)}...` : et.metaDescription}
                   </p>
                 </Link>
               ))}
@@ -279,18 +279,18 @@ const AttractionPage: React.FC = () => {
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {relatedAttractions.map(attr => (
                 <Link
-                  key={attr!.slug}
-                  to={`/${attr!.slug}`}
+                  key={attr.slug}
+                  to={`/${attr.slug}`}
                   className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
                 >
                   <div className="flex items-center gap-2 mb-1">
                     <MapPin className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
                     <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
-                      {attr!.title}
+                      {attr.title}
                     </h3>
                   </div>
                   <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
-                    {attr!.metaDescription.slice(0, 100)}...
+                    {attr.metaDescription.length > 100 ? `${attr.metaDescription.slice(0, 100)}...` : attr.metaDescription}
                   </p>
                 </Link>
               ))}

--- a/pages/AttractionPage.tsx
+++ b/pages/AttractionPage.tsx
@@ -1,0 +1,311 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useLocation, Link } from 'react-router-dom';
+import { SEOHead } from '../components/seo/SEOHead';
+import { Breadcrumb } from '../components/seo/Breadcrumb';
+import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
+import { DirectoryListingDB } from '../types/models';
+import { db } from '../api-services';
+import { getAttraction } from '../data/attractionPages';
+import { getExcursionType } from '../data/excursionTypes';
+import { MapPin, Clock, Ticket, Bus, Lightbulb, ChevronDown, ChevronUp, Info, Compass } from 'lucide-react';
+
+function buildAttractionJsonLd(attraction: ReturnType<typeof getAttraction> & {}) {
+  const base = {
+    '@context': 'https://schema.org',
+    name: attraction.title,
+    description: attraction.metaDescription,
+    url: `https://alanya-holidays.com/${attraction.slug}`,
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Alanya',
+      addressRegion: 'Antalya',
+      addressCountry: 'TR',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: attraction.coordinates.lat,
+      longitude: attraction.coordinates.lng,
+    },
+    touristType: 'Sightseeing',
+  };
+
+  if (attraction.jsonLdType === 'TouristTrip') {
+    return { ...base, '@type': 'TouristTrip', tripOrigin: { '@type': 'City', name: 'Alanya' } };
+  }
+  if (attraction.jsonLdType === 'Beach') {
+    return { ...base, '@type': ['TouristAttraction', 'Beach'] };
+  }
+  return { ...base, '@type': attraction.jsonLdType };
+}
+
+const AttractionPage: React.FC = () => {
+  const slug = useLocation().pathname.slice(1);
+  const attraction = getAttraction(slug);
+
+  const [listings, setListings] = useState<DirectoryListingDB[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedListing, setSelectedListing] = useState<DirectoryListingDB | null>(null);
+  const [showFullDescription, setShowFullDescription] = useState(false);
+
+  useEffect(() => {
+    if (!attraction) return;
+    const fetchListings = async () => {
+      setLoading(true);
+      try {
+        const primaryQuery = attraction.searchKeywords[0] || attraction.title;
+        const result = await db.searchDirectoryListings(primaryQuery, 'tours');
+        if (result.data.length > 0) {
+          setListings(result.data);
+        } else {
+          const fallbackQuery = attraction.title
+            .replace(' in Alanya', '')
+            .replace(' from Alanya', '')
+            .replace(' near Alanya', '');
+          const broader = await db.searchDirectoryListings(fallbackQuery, 'tours');
+          setListings(broader.data);
+        }
+      } catch (e) {
+        console.error('Failed to load attraction listings', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchListings();
+  }, [attraction]);
+
+  const handleListingClick = useCallback((listing: DirectoryListingDB) => {
+    setSelectedListing(listing);
+    const sessionKey = `listing_view_${listing.id}_${new Date().toISOString().slice(0, 10)}`;
+    if (!sessionStorage.getItem(sessionKey)) {
+      sessionStorage.setItem(sessionKey, '1');
+      db.trackListingView(listing.id).catch(console.error);
+    }
+  }, []);
+
+  if (!attraction) {
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex items-center justify-center">
+        <SEOHead title="Attraction Not Found" noIndex />
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Attraction Not Found</h1>
+          <Link to="/things-to-do-in-alanya" className="text-teal-600 dark:text-cyan-400 hover:underline">
+            Browse all things to do in Alanya
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const jsonLd = buildAttractionJsonLd(attraction);
+
+  const relatedExcursions = attraction.relatedExcursionSlugs
+    .map(s => getExcursionType(s))
+    .filter(Boolean);
+
+  const relatedAttractions = attraction.relatedAttractionSlugs
+    .map(s => getAttraction(s))
+    .filter(Boolean);
+
+  const hasPracticalInfo =
+    attraction.practicalInfo.hours ||
+    attraction.practicalInfo.admission ||
+    attraction.practicalInfo.howToGet ||
+    attraction.practicalInfo.tips;
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
+      <SEOHead
+        title={attraction.metaTitle}
+        description={attraction.metaDescription}
+        keywords={attraction.keywords}
+        jsonLd={jsonLd}
+      />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-2">
+        <Breadcrumb
+          items={[
+            { label: 'Home', href: '/' },
+            { label: 'Things to Do', href: '/things-to-do-in-alanya' },
+            { label: attraction.title },
+          ]}
+        />
+      </div>
+
+      {/* Hero */}
+      <div className="bg-white dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-800/50 shadow-sm mb-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center md:text-left md:py-16">
+          <div className="flex items-center justify-center md:justify-start gap-3 mb-4">
+            <MapPin className="w-8 h-8 text-teal-600 dark:text-cyan-400" />
+            <h1 className="text-3xl md:text-5xl font-extrabold text-slate-900 dark:text-white">
+              {attraction.title}
+            </h1>
+          </div>
+          <div className="text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-4xl leading-relaxed">
+            <p className="mb-4">{attraction.metaDescription}</p>
+            <div className={`transition-all duration-500 overflow-hidden text-left ${showFullDescription ? 'max-h-[2000px] opacity-100 mt-6' : 'max-h-0 opacity-0'}`}>
+              <p className="mb-4 text-base md:text-lg">{attraction.longDescription}</p>
+            </div>
+            <button
+              onClick={() => setShowFullDescription(!showFullDescription)}
+              className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:text-cyan-400 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
+            >
+              {showFullDescription ? 'Read Less' : 'Read More'}
+              {showFullDescription ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Practical Info */}
+        {hasPracticalInfo && (
+          <div className="mb-12 bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-2xl p-6 shadow-sm">
+            <h2 className="text-xl font-bold text-slate-900 dark:text-white mb-4">Practical Information</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {attraction.practicalInfo.hours && (
+                <div className="flex items-start gap-3">
+                  <Clock className="w-5 h-5 text-teal-600 dark:text-cyan-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-white">Hours</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">{attraction.practicalInfo.hours}</p>
+                  </div>
+                </div>
+              )}
+              {attraction.practicalInfo.admission && (
+                <div className="flex items-start gap-3">
+                  <Ticket className="w-5 h-5 text-teal-600 dark:text-cyan-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-white">Admission</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">{attraction.practicalInfo.admission}</p>
+                  </div>
+                </div>
+              )}
+              {attraction.practicalInfo.howToGet && (
+                <div className="flex items-start gap-3">
+                  <Bus className="w-5 h-5 text-teal-600 dark:text-cyan-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-white">How to Get There</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">{attraction.practicalInfo.howToGet}</p>
+                  </div>
+                </div>
+              )}
+              {attraction.practicalInfo.tips && (
+                <div className="flex items-start gap-3">
+                  <Lightbulb className="w-5 h-5 text-teal-600 dark:text-cyan-400 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="font-medium text-slate-900 dark:text-white">Tips</p>
+                    <p className="text-sm text-slate-600 dark:text-slate-400">{attraction.practicalInfo.tips}</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Listings */}
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
+          Available Tours & Activities
+        </h2>
+
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="animate-pulse bg-white dark:bg-slate-800/80 rounded-2xl h-80 border border-slate-200 dark:border-slate-800/50" />
+            ))}
+          </div>
+        ) : listings.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {listings.map(listing => (
+              <DirectoryListingCard
+                key={listing.id}
+                listing={listing}
+                onClick={handleListingClick}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-2xl p-12 flex flex-col items-center justify-center text-center shadow-sm">
+            <Info className="w-16 h-16 text-slate-300 dark:text-slate-400 mb-4" />
+            <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+              No tours available yet
+            </h3>
+            <p className="text-slate-500 dark:text-slate-400 max-w-sm">
+              We're adding more tours for this attraction. Check back soon or browse all things to do in Alanya.
+            </p>
+            <Link
+              to="/things-to-do-in-alanya"
+              className="mt-4 text-teal-600 dark:text-cyan-400 hover:underline font-medium"
+            >
+              Browse all things to do
+            </Link>
+          </div>
+        )}
+
+        {/* Related Excursions */}
+        {relatedExcursions.length > 0 && (
+          <div className="mt-16 mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
+            <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
+              Related Excursions
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              {relatedExcursions.map(et => (
+                <Link
+                  key={et!.slug}
+                  to={`/${et!.slug}`}
+                  className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <Compass className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
+                    <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
+                      {et!.title}
+                    </h3>
+                  </div>
+                  <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
+                    {et!.metaDescription.slice(0, 100)}...
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Related Attractions */}
+        {relatedAttractions.length > 0 && (
+          <div className="mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
+            <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
+              Nearby Attractions
+            </h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              {relatedAttractions.map(attr => (
+                <Link
+                  key={attr!.slug}
+                  to={`/${attr!.slug}`}
+                  className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <MapPin className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
+                    <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
+                      {attr!.title}
+                    </h3>
+                  </div>
+                  <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
+                    {attr!.metaDescription.slice(0, 100)}...
+                  </p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <DirectoryListingModal
+        listing={selectedListing}
+        isOpen={!!selectedListing}
+        onClose={() => setSelectedListing(null)}
+      />
+    </div>
+  );
+};
+
+export { AttractionPage };

--- a/pages/BicycleRental.tsx
+++ b/pages/BicycleRental.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
 import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
+import { SEOHead } from '../components/seo/SEOHead';
 
 interface BikeGroup {
     id: string; // generated slug
@@ -59,6 +60,12 @@ export const BicycleRental: React.FC = () => {
     }, []);
 
     return (
+        <>
+        <SEOHead
+            title="Bicycle Rental in Alanya | Alanya Holidays"
+            description="Rent a bicycle in Alanya and explore the city on two wheels. Affordable bike rental with delivery to your hotel."
+            keywords={['bicycle rental alanya', 'bike rental alanya', 'alanya bicycle', 'rent bike alanya']}
+        />
         <VehicleRentalTemplate
             titleText="Explore on Two Wheels (Bicycles)"
             subtitle="Discover the city at your own pace with our premium selection of bicycles and e-bikes."
@@ -111,5 +118,6 @@ export const BicycleRental: React.FC = () => {
                 </div>
             ))}
         </VehicleRentalTemplate>
+        </>
     );
 };

--- a/pages/BikeRental.tsx
+++ b/pages/BikeRental.tsx
@@ -5,6 +5,7 @@ import { useCurrency } from '../context/CurrencyContext';
 import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
 import { getCarImage } from '../utils/carImages';
+import { SEOHead } from '../components/seo/SEOHead';
 
 interface BikeGroup {
     id: string; // generated slug
@@ -77,6 +78,12 @@ export const BikeRental: React.FC = () => {
     }, []);
 
     return (
+        <>
+        <SEOHead
+            title="Motorbike Rental in Alanya | Alanya Holidays"
+            description="Rent a motorbike or scooter in Alanya. Explore the Turkish Riviera on two wheels with our affordable motorcycle rental service."
+            keywords={['motorbike rental alanya', 'scooter rental alanya', 'motorcycle rental alanya', 'alanya bike hire']}
+        />
         <VehicleRentalTemplate
             titleHtml={t('bike.hero.title')}
             subtitle={t('bike.hero.subtitle')}
@@ -137,5 +144,6 @@ export const BikeRental: React.FC = () => {
                 </div>
             ))}
         </VehicleRentalTemplate>
+        </>
     );
 };

--- a/pages/BlogSubmissionSuccess.tsx
+++ b/pages/BlogSubmissionSuccess.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { CheckCircle, BookOpen, Clock, Mail } from 'lucide-react';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const BlogSubmissionSuccess: React.FC = () => {
 
     return (
+        <>
+        <SEOHead
+            title="Blog Post Submitted | Alanya Holidays"
+            description="Your blog post has been submitted for review. Thank you for sharing your Alanya experience."
+            noIndex
+        />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16 flex items-center">
             <div className="max-w-xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
 
@@ -73,5 +80,6 @@ export const BlogSubmissionSuccess: React.FC = () => {
 
             </div>
         </div>
+        </>
     );
 };

--- a/pages/BlogSubmitPage.test.tsx
+++ b/pages/BlogSubmitPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../context/AuthContext', () => ({
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/blog/submit', search: '', hash: '', state: null }),
   Link: ({ children, to }: any) => <a href={to}>{children}</a>
 }));
 

--- a/pages/BlogSubmitPage.tsx
+++ b/pages/BlogSubmitPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
 import { toast } from 'react-hot-toast';
 import { PenLine, X, ImagePlus, Video, ArrowLeft, Send, Info } from 'lucide-react';
+import { SEOHead } from '../components/seo/SEOHead';
 
 const MAX_IMAGES = 5;
 
@@ -166,6 +167,13 @@ export const BlogSubmitPage: React.FC = () => {
     const isSubmitting = submitting || uploading;
 
     return (
+        <>
+        <SEOHead
+            title="Submit Blog Post | Alanya Holidays"
+            description="Share your Alanya travel experience. Submit your blog post and help other travelers discover Alanya."
+            keywords={['alanya blog submit', 'travel blog alanya', 'write about alanya']}
+            noIndex
+        />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
             <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
 
@@ -352,5 +360,6 @@ export const BlogSubmitPage: React.FC = () => {
 
             </div>
         </div>
+        </>
     );
 };

--- a/pages/CarModelDetails.tsx
+++ b/pages/CarModelDetails.tsx
@@ -5,6 +5,7 @@ import { db, ServiceData } from '../api-services';
 import { CAR_DESCRIPTIONS, DEFAULT_DESCRIPTION } from '../data/cars';
 import { ArrowLeft } from 'lucide-react';
 import { getCarImage } from '../utils/carImages';
+import { SEOHead } from '../components/seo/SEOHead';
 
 // Modular Components
 import { CarModelHeader } from '../components/services/car/CarModelHeader';
@@ -87,9 +88,21 @@ export const CarModelDetails: React.FC = () => {
     };
 
     if (loading) return <div className="pt-32 text-center">Loading offers...</div>;
-    if (!groupInfo) return <div className="pt-32 text-center">Model not found</div>;
+    if (!groupInfo) return (
+        <>
+            <SEOHead title="Car Not Found | Alanya Holidays" noIndex />
+            <div className="pt-32 text-center">Model not found</div>
+        </>
+    );
 
     return (
+        <>
+        <SEOHead
+            title="Car Details | Alanya Holidays"
+            description="View car rental details, specifications, and pricing."
+            keywords={['car rental details', 'alanya car hire']}
+            noIndex
+        />
         <div className="pt-24 pb-16 min-h-screen bg-slate-50 dark:bg-slate-900">
             <div className="max-w-7xl mx-auto px-4">
                 <button onClick={() => navigate('/services/car-rental')} className="flex items-center gap-2 text-slate-500 hover:text-teal-600 dark:text-cyan-400 mb-8 transition-colors">
@@ -129,5 +142,6 @@ export const CarModelDetails: React.FC = () => {
                 />
             )}
         </div>
+        </>
     );
 };

--- a/pages/CarRental.tsx
+++ b/pages/CarRental.tsx
@@ -3,12 +3,19 @@ import { VehicleRentalTemplate } from '../components/templates/VehicleRentalTemp
 import { useLanguage } from '../context/LanguageContext';
 import { useCars } from '../hooks/useCars';
 import { CarCard } from '../components/services/CarCard';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const CarRental: React.FC = () => {
     const { t } = useLanguage();
     const { carGroups, loading } = useCars();
 
     return (
+        <>
+        <SEOHead
+            title="Car Rental in Alanya | Alanya Holidays"
+            description="Rent a car in Alanya, Turkey. Wide selection of vehicles at competitive prices. Free delivery to hotels and airport."
+            keywords={['car rental alanya', 'alanya car hire', 'rent car turkey', 'alanya airport car rental']}
+        />
         <VehicleRentalTemplate
             titleHtml={t('car.hero.title')}
             subtitle={t('car.hero.subtitle')}
@@ -25,6 +32,7 @@ export const CarRental: React.FC = () => {
                 <CarCard key={car.id} car={car} />
             ))}
         </VehicleRentalTemplate>
+        </>
     );
 };
 

--- a/pages/Checkout.tsx
+++ b/pages/Checkout.tsx
@@ -3,6 +3,7 @@ import { useCart } from '../context/CartContext';
 import { useCurrency } from '../context/CurrencyContext';
 import { ServiceType } from '../types/index';
 import { useNavigate } from 'react-router-dom';
+import { SEOHead } from '../components/seo/SEOHead';
 
 interface StripeCheckoutItem {
     bookingId: string;
@@ -165,6 +166,8 @@ export const Checkout: React.FC = () => {
     const isWelcomePackAdded = items.some(i => i.id === 'rec-2');
 
     return (
+        <>
+        <SEOHead title="Checkout | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-12 pb-24">
             <div className="max-w-4xl mx-auto px-4">
                 <h1 className="text-3xl font-serif font-bold text-slate-900 dark:text-white mb-8">{t('checkout.title')}</h1>
@@ -204,5 +207,6 @@ export const Checkout: React.FC = () => {
                 </div>
             </div>
         </div>
+        </>
     );
 };

--- a/pages/CreativeServices.tsx
+++ b/pages/CreativeServices.tsx
@@ -4,6 +4,7 @@ import { Check, Camera, Video, Sparkles, Compass } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
 import { db, ServiceData } from '../api-services';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const CreativeServices: React.FC = () => {
     const { subcategory } = useParams<{ subcategory: string }>();
@@ -78,6 +79,12 @@ export const CreativeServices: React.FC = () => {
     }
 
     return (
+        <>
+        <SEOHead
+            title="Creative Professionals in Alanya | Alanya Holidays"
+            description="Find photographers, designers, and creative professionals in Alanya. Professional services for your holiday needs."
+            keywords={['creative professionals alanya', 'photographer alanya', 'alanya design services']}
+        />
         <div className="pt-24 pb-16 min-h-screen bg-slate-50 dark:bg-slate-900">
             {/* Hero Section */}
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-16">
@@ -188,5 +195,6 @@ export const CreativeServices: React.FC = () => {
                 )}
             </div>
         </div>
+        </>
     );
 };

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -46,7 +46,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
     // Data State
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [locations, setLocations] = useState<string[]>([]);
-    const [_loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(true);
 
     // Auth & Voting State
     const { isAuthenticated, user } = useAuth();
@@ -412,6 +412,14 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
 
                 {viewMode === 'list' ? (
                     <>
+                        {loading ? (
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                {[1, 2, 3].map(i => (
+                                    <div key={i} className="animate-pulse bg-white dark:bg-slate-800/80 rounded-2xl h-80 border border-slate-200 dark:border-slate-800/50" />
+                                ))}
+                            </div>
+                        ) : (
+                        <>
                         {/* 3. Featured Listings (Monetization Zone) */}
                         {featuredListings.length > 0 && (
                             <div className="mb-12">
@@ -462,6 +470,8 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                 </div>
                             )}
                         </div>
+                        </>
+                        )}
                     </>
                 ) : (
                     <DirectoryMapView

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { useParams, Navigate } from 'react-router-dom';
+import { useParams, useLocation, Navigate } from 'react-router-dom';
 import { Filter, Star, Info, ChevronDown, ChevronUp, Map as MapIcon, List } from 'lucide-react';
 import { SEOHead } from '../components/seo/SEOHead';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
@@ -16,6 +16,7 @@ import { CATEGORY_PATHS, getSchemaType } from '../constants/categoryPaths';
 export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categoryId: propCategoryId }) => {
     const params = useParams<{ categoryId: string }>();
     const categoryId = propCategoryId || params.categoryId;
+    const { pathname } = useLocation();
 
     const intro = categoryId ? directoryCategoryIntros[categoryId] : null;
 
@@ -214,7 +215,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
         }))
     };
 
-    const transportSchema = categoryId === 'transport' ? {
+    const transportSchema = pathname === '/airport-transfer' ? {
         '@context': 'https://schema.org',
         '@type': 'TaxiService',
         name: 'Alanya Airport Transfer & Taxi Service',

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -11,7 +11,7 @@ import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
 import { toast } from 'react-hot-toast';
-import { CATEGORY_PATHS } from '../constants/categoryPaths';
+import { CATEGORY_PATHS, getSchemaType } from '../constants/categoryPaths';
 
 export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categoryId: propCategoryId }) => {
     const params = useParams<{ categoryId: string }>();
@@ -204,7 +204,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
             "@type": "ListItem",
             "position": index + 1,
             "item": {
-                "@type": categoryId === 'accommodations' ? "LodgingBusiness" : categoryId === 'restaurants' ? "Restaurant" : "LocalBusiness",
+                "@type": getSchemaType(categoryId),
                 "name": item.name,
                 "url": item.slug
                         ? `https://alanya-holidays.com${CATEGORY_PATHS[categoryId] || ''}/${item.slug}`
@@ -213,6 +213,28 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
             }
         }))
     };
+
+    const transportSchema = categoryId === 'transport' ? {
+        '@context': 'https://schema.org',
+        '@type': 'TaxiService',
+        name: 'Alanya Airport Transfer & Taxi Service',
+        description,
+        url: `https://alanya-holidays.com${CATEGORY_PATHS['transport']}`,
+        address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Alanya',
+            addressRegion: 'Antalya',
+            addressCountry: 'TR',
+        },
+        areaServed: {
+            '@type': 'City',
+            name: 'Alanya',
+        },
+    } : null;
+
+    const schemas: object[] = [itemListSchema];
+    if (transportSchema) schemas.push(transportSchema);
+    if (faqSchema) schemas.push(faqSchema);
 
     const featuredListings = filteredData.filter(item => item.is_featured);
     const standardListings = filteredData.filter(item => !item.is_featured);
@@ -223,7 +245,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                 title={`${title} - Alanya Holidays`}
                 description={description}
                 keywords={keywords}
-                jsonLd={faqSchema ? [itemListSchema, faqSchema] : itemListSchema}
+                jsonLd={schemas}
             />
 
             {/* Breadcrumb */}

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star, Home, Car } from 'lucide-react';
-import { useClickOutside } from '../hooks/useClickOutside';
+import { Search, MapPin, Grid, Briefcase, ChevronRight, Sparkles, ShieldCheck, CheckCircle2, Building2, Star } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 import { toast } from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
@@ -233,11 +232,17 @@ export const DirectoryHome: React.FC = () => {
                         </button>
 
                         <Link
-                            to="/add-listing"
+                            to="/list-property"
                             className="flex-1 flex items-center justify-center gap-2 px-6 py-3.5 bg-white/10 dark:bg-slate-800/80 hover:bg-white/20 dark:hover:bg-slate-700/80 backdrop-blur-md border border-white/30 dark:border-slate-700/50 text-white rounded-xl sm:rounded-full font-semibold transition-all cursor-pointer"
                         >
                             <Briefcase className="w-5 h-5" />
                             {t('dir.cta.list')}
+                        </Link>
+                        <Link
+                            to="/add-listing"
+                            className="flex items-center justify-center gap-2 px-5 py-3.5 bg-white/5 dark:bg-slate-800/50 hover:bg-white/15 dark:hover:bg-slate-700/60 backdrop-blur-md border border-white/20 dark:border-slate-700/40 text-white/80 rounded-xl sm:rounded-full text-sm font-medium transition-all cursor-pointer"
+                        >
+                            {t('nav.list_directory') || 'List Business'}
                         </Link>
                     </div>
 

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -87,7 +87,39 @@ export const DirectoryHome: React.FC = () => {
                 title={t('dir.hero.page_title')}
                 description={t('dir.hero.meta_desc')}
                 type="website"
-                keywords={['Alanya holidays', 'vacation rentals', ' Turkey', 'medical tourism', 'hotels', 'villas']}
+                keywords={['Alanya holidays', 'vacation rentals', 'Turkey', 'medical tourism', 'hotels', 'villas']}
+                jsonLd={[
+                    {
+                        '@context': 'https://schema.org',
+                        '@type': 'TravelAgency',
+                        name: 'Alanya Holidays',
+                        url: 'https://alanya-holidays.com',
+                        logo: 'https://alanya-holidays.com/logo.png',
+                        description: 'Premium vacation rentals, tours, and services in Alanya, Turkey',
+                        address: {
+                            '@type': 'PostalAddress',
+                            addressLocality: 'Alanya',
+                            addressRegion: 'Antalya',
+                            addressCountry: 'TR'
+                        },
+                        contactPoint: {
+                            '@type': 'ContactPoint',
+                            contactType: 'customer support',
+                            url: 'https://alanya-holidays.com/contact'
+                        }
+                    },
+                    {
+                        '@context': 'https://schema.org',
+                        '@type': 'WebSite',
+                        name: 'Alanya Holidays',
+                        url: 'https://alanya-holidays.com',
+                        potentialAction: {
+                            '@type': 'SearchAction',
+                            target: 'https://alanya-holidays.com/search?q={search_term_string}',
+                            'query-input': 'required name=search_term_string'
+                        }
+                    }
+                ]}
             />
             <div className="min-h-screen bg-slate-50 dark:bg-slate-900">
             <div className="relative pt-24 pb-16 md:pt-32 md:pb-24 overflow-hidden min-h-[600px] flex flex-col justify-center">

--- a/pages/ExcursionTypePage.tsx
+++ b/pages/ExcursionTypePage.tsx
@@ -7,7 +7,8 @@ import { DirectoryListingModal } from '../components/directory/DirectoryListingM
 import { DirectoryListingDB } from '../types/models';
 import { db } from '../api-services';
 import { getExcursionType, EXCURSION_TYPES } from '../data/excursionTypes';
-import { Compass, ChevronDown, ChevronUp, Info } from 'lucide-react';
+import { getAttraction } from '../data/attractionPages';
+import { Compass, MapPin, ChevronDown, ChevronUp, Info } from 'lucide-react';
 
 const ExcursionTypePage: React.FC = () => {
     const slug = useLocation().pathname.slice(1); // pathname is "/alanya-boat-tours" → "alanya-boat-tours"
@@ -184,6 +185,38 @@ const ExcursionTypePage: React.FC = () => {
                         ))}
                     </div>
                 </div>
+
+                {/* Related Attractions */}
+                {excursionType.relatedAttractions.length > 0 && (
+                    <div className="mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
+                        <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
+                            Nearby Attractions
+                        </h2>
+                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                            {excursionType.relatedAttractions.map(attrSlug => {
+                                const attr = getAttraction(attrSlug);
+                                if (!attr) return null;
+                                return (
+                                    <Link
+                                        key={attr.slug}
+                                        to={`/${attr.slug}`}
+                                        className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
+                                    >
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <MapPin className="w-4 h-4 text-teal-600 dark:text-cyan-400" />
+                                            <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors text-sm">
+                                                {attr.title}
+                                            </h3>
+                                        </div>
+                                        <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
+                                            {attr.metaDescription.slice(0, 100)}...
+                                        </p>
+                                    </Link>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
             </div>
 
             <DirectoryListingModal

--- a/pages/ExcursionTypePage.tsx
+++ b/pages/ExcursionTypePage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { SEOHead } from '../components/seo/SEOHead';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
@@ -10,8 +10,8 @@ import { getExcursionType, EXCURSION_TYPES } from '../data/excursionTypes';
 import { Compass, ChevronDown, ChevronUp, Info } from 'lucide-react';
 
 const ExcursionTypePage: React.FC = () => {
-    const { slug } = useParams<{ slug: string }>();
-    const excursionType = getExcursionType(slug || '');
+    const slug = useLocation().pathname.slice(1); // pathname is "/alanya-boat-tours" → "alanya-boat-tours"
+    const excursionType = getExcursionType(slug);
 
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [loading, setLoading] = useState(true);

--- a/pages/ExcursionTypePage.tsx
+++ b/pages/ExcursionTypePage.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { SEOHead } from '../components/seo/SEOHead';
+import { Breadcrumb } from '../components/seo/Breadcrumb';
+import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
+import { DirectoryListingDB } from '../types/models';
+import { db } from '../api-services';
+import { getExcursionType, EXCURSION_TYPES } from '../data/excursionTypes';
+import { Compass, ChevronDown, ChevronUp, Info } from 'lucide-react';
+
+const ExcursionTypePage: React.FC = () => {
+    const { slug } = useParams<{ slug: string }>();
+    const excursionType = getExcursionType(slug || '');
+
+    const [listings, setListings] = useState<DirectoryListingDB[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [selectedListing, setSelectedListing] = useState<DirectoryListingDB | null>(null);
+    const [showFullDescription, setShowFullDescription] = useState(false);
+
+    useEffect(() => {
+        if (!excursionType) return;
+        const fetchListings = async () => {
+            setLoading(true);
+            try {
+                const primaryQuery = excursionType.searchKeywords[0] || excursionType.title;
+                const result = await db.searchDirectoryListings(primaryQuery, 'tours');
+                if (result.data.length > 0) {
+                    setListings(result.data);
+                } else {
+                    const fallbackQuery = excursionType.title
+                        .replace(' in Alanya', '')
+                        .replace(' from Alanya', '');
+                    const broader = await db.searchDirectoryListings(fallbackQuery, 'tours');
+                    setListings(broader.data);
+                }
+            } catch (e) {
+                console.error('Failed to load excursion listings', e);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchListings();
+    }, [excursionType]);
+
+    const handleListingClick = useCallback((listing: DirectoryListingDB) => {
+        setSelectedListing(listing);
+        const sessionKey = `listing_view_${listing.id}_${new Date().toISOString().slice(0, 10)}`;
+        if (!sessionStorage.getItem(sessionKey)) {
+            sessionStorage.setItem(sessionKey, '1');
+            db.trackListingView(listing.id).catch(console.error);
+        }
+    }, []);
+
+    if (!excursionType) {
+        return (
+            <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex items-center justify-center">
+                <SEOHead title="Excursion Not Found" noIndex />
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Excursion Type Not Found</h1>
+                    <Link to="/things-to-do-in-alanya" className="text-teal-600 dark:text-cyan-400 hover:underline">
+                        Browse all things to do in Alanya
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    const jsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'TouristTrip',
+        name: excursionType.title,
+        description: excursionType.metaDescription,
+        url: `https://alanya-holidays.com/${excursionType.slug}`,
+        touristType: 'Adventure travel',
+        tripOrigin: {
+            '@type': 'City',
+            name: 'Alanya',
+        },
+    };
+
+    const otherExcursions = EXCURSION_TYPES.filter(et => et.slug !== excursionType.slug);
+
+    return (
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-16">
+            <SEOHead
+                title={excursionType.metaTitle}
+                description={excursionType.metaDescription}
+                keywords={excursionType.keywords}
+                jsonLd={jsonLd}
+            />
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6 pb-2">
+                <Breadcrumb
+                    items={[
+                        { label: 'Home', href: '/' },
+                        { label: 'Things to Do', href: '/things-to-do-in-alanya' },
+                        { label: excursionType.title },
+                    ]}
+                />
+            </div>
+
+            <div className="bg-white dark:bg-slate-800/80 border-b border-slate-200 dark:border-slate-800/50 shadow-sm mb-8">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center md:text-left md:py-16">
+                    <div className="flex items-center justify-center md:justify-start gap-3 mb-4">
+                        <Compass className="w-8 h-8 text-teal-600 dark:text-cyan-400" />
+                        <h1 className="text-3xl md:text-5xl font-extrabold text-slate-900 dark:text-white">
+                            {excursionType.title}
+                        </h1>
+                    </div>
+                    <div className="text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-4xl leading-relaxed">
+                        <p className="mb-4">{excursionType.metaDescription}</p>
+                        <div className={`transition-all duration-500 overflow-hidden text-left ${showFullDescription ? 'max-h-[2000px] opacity-100 mt-6' : 'max-h-0 opacity-0'}`}>
+                            <p className="mb-4 text-base md:text-lg">{excursionType.longDescription}</p>
+                        </div>
+                        <button
+                            onClick={() => setShowFullDescription(!showFullDescription)}
+                            className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:text-cyan-400 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
+                        >
+                            {showFullDescription ? 'Read Less' : 'Read More'}
+                            {showFullDescription ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
+                    Available Tours & Activities
+                </h2>
+
+                {loading ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[1, 2, 3].map(i => (
+                            <div key={i} className="animate-pulse bg-white dark:bg-slate-800/80 rounded-2xl h-80 border border-slate-200 dark:border-slate-800/50" />
+                        ))}
+                    </div>
+                ) : listings.length > 0 ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {listings.map(listing => (
+                            <DirectoryListingCard
+                                key={listing.id}
+                                listing={listing}
+                                onClick={handleListingClick}
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <div className="bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-2xl p-12 flex flex-col items-center justify-center text-center shadow-sm">
+                        <Info className="w-16 h-16 text-slate-300 dark:text-slate-400 mb-4" />
+                        <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-2">
+                            No tours available yet
+                        </h3>
+                        <p className="text-slate-500 dark:text-slate-400 max-w-sm">
+                            We're adding more tours in this category. Check back soon or browse all things to do in Alanya.
+                        </p>
+                        <Link
+                            to="/things-to-do-in-alanya"
+                            className="mt-4 text-teal-600 dark:text-cyan-400 hover:underline font-medium"
+                        >
+                            Browse all things to do
+                        </Link>
+                    </div>
+                )}
+
+                <div className="mt-16 mb-12 border-t border-slate-200 dark:border-slate-800/50 pt-16">
+                    <h2 className="text-3xl font-bold text-slate-900 dark:text-white mb-8 text-center">
+                        Other Excursion Types
+                    </h2>
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                        {otherExcursions.map(et => (
+                            <Link
+                                key={et.slug}
+                                to={`/${et.slug}`}
+                                className="group bg-white dark:bg-slate-800/80 border border-slate-200 dark:border-slate-800/50 rounded-xl p-4 hover:border-teal-500 dark:hover:border-cyan-400 hover:shadow-md transition-all"
+                            >
+                                <h3 className="font-semibold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-cyan-400 transition-colors">
+                                    {et.title}
+                                </h3>
+                                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 line-clamp-2">
+                                    {et.metaDescription.slice(0, 100)}...
+                                </p>
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+            </div>
+
+            <DirectoryListingModal
+                listing={selectedListing}
+                isOpen={!!selectedListing}
+                onClose={() => setSelectedListing(null)}
+            />
+        </div>
+    );
+};
+
+export { ExcursionTypePage };

--- a/pages/ExcursionTypePage.tsx
+++ b/pages/ExcursionTypePage.tsx
@@ -7,7 +7,7 @@ import { DirectoryListingModal } from '../components/directory/DirectoryListingM
 import { DirectoryListingDB } from '../types/models';
 import { db } from '../api-services';
 import { getExcursionType, EXCURSION_TYPES } from '../data/excursionTypes';
-import { getAttraction } from '../data/attractionPages';
+import { getAttraction, type Attraction } from '../data/attractionPages';
 import { Compass, MapPin, ChevronDown, ChevronUp, Info } from 'lucide-react';
 
 const ExcursionTypePage: React.FC = () => {
@@ -26,14 +26,14 @@ const ExcursionTypePage: React.FC = () => {
             try {
                 const primaryQuery = excursionType.searchKeywords[0] || excursionType.title;
                 const result = await db.searchDirectoryListings(primaryQuery, 'tours');
-                if (result.data.length > 0) {
+                if (result.data?.length > 0) {
                     setListings(result.data);
                 } else {
                     const fallbackQuery = excursionType.title
                         .replace(' in Alanya', '')
                         .replace(' from Alanya', '');
                     const broader = await db.searchDirectoryListings(fallbackQuery, 'tours');
-                    setListings(broader.data);
+                    setListings(broader.data ?? []);
                 }
             } catch (e) {
                 console.error('Failed to load excursion listings', e);
@@ -179,7 +179,7 @@ const ExcursionTypePage: React.FC = () => {
                                     {et.title}
                                 </h3>
                                 <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 line-clamp-2">
-                                    {et.metaDescription.slice(0, 100)}...
+                                    {et.metaDescription.length > 100 ? `${et.metaDescription.slice(0, 100)}...` : et.metaDescription}
                                 </p>
                             </Link>
                         ))}
@@ -193,10 +193,10 @@ const ExcursionTypePage: React.FC = () => {
                             Nearby Attractions
                         </h2>
                         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                            {excursionType.relatedAttractions.map(attrSlug => {
-                                const attr = getAttraction(attrSlug);
-                                if (!attr) return null;
-                                return (
+                            {excursionType.relatedAttractions
+                                .map(attrSlug => getAttraction(attrSlug))
+                                .filter((attr): attr is Attraction => attr !== undefined)
+                                .map(attr => (
                                     <Link
                                         key={attr.slug}
                                         to={`/${attr.slug}`}
@@ -209,11 +209,10 @@ const ExcursionTypePage: React.FC = () => {
                                             </h3>
                                         </div>
                                         <p className="text-sm text-slate-500 dark:text-slate-400 line-clamp-2">
-                                            {attr.metaDescription.slice(0, 100)}...
+                                            {attr.metaDescription.length > 100 ? `${attr.metaDescription.slice(0, 100)}...` : attr.metaDescription}
                                         </p>
                                     </Link>
-                                );
-                            })}
+                                ))}
                         </div>
                     </div>
                 )}

--- a/pages/ExcursionTypePage.tsx
+++ b/pages/ExcursionTypePage.tsx
@@ -116,7 +116,7 @@ const ExcursionTypePage: React.FC = () => {
                         </div>
                         <button
                             onClick={() => setShowFullDescription(!showFullDescription)}
-                            className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:text-cyan-400 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
+                            className="text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 font-semibold text-base mt-2 flex items-center justify-center md:justify-start gap-1 w-full md:w-auto"
                         >
                             {showFullDescription ? 'Read Less' : 'Read More'}
                             {showFullDescription ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
@@ -179,7 +179,7 @@ const ExcursionTypePage: React.FC = () => {
                                     {et.title}
                                 </h3>
                                 <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 line-clamp-2">
-                                    {et.metaDescription.length > 100 ? `${et.metaDescription.slice(0, 100)}...` : et.metaDescription}
+                                    {et.metaDescription}
                                 </p>
                             </Link>
                         ))}

--- a/pages/ExperienceCategoryPage.tsx
+++ b/pages/ExperienceCategoryPage.tsx
@@ -4,6 +4,7 @@ import { Check, Compass, Sun, Map, Cloud, Anchor, Mountain, Heart, Car, Sparkles
 import { useLanguage } from '../context/LanguageContext';
 import { useCurrency } from '../context/CurrencyContext';
 import { db, ServiceData } from '../api-services';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const ExperienceCategoryPage: React.FC = () => {
     const { category } = useParams<{ category: string }>();
@@ -106,16 +107,25 @@ export const ExperienceCategoryPage: React.FC = () => {
 
     if (!config) {
         return (
-            <div className="pt-32 pb-16 min-h-screen text-center">
-                <h1 className="text-2xl font-bold">Category not found</h1>
-                <button onClick={() => navigate('/services')} className="mt-4 text-teal-600 dark:text-cyan-400 hover:underline">
-                    Back to Services
-                </button>
-            </div>
+            <>
+                <SEOHead title="Category Not Found | Alanya Holidays" noIndex />
+                <div className="pt-32 pb-16 min-h-screen text-center">
+                    <h1 className="text-2xl font-bold">Category not found</h1>
+                    <button onClick={() => navigate('/services')} className="mt-4 text-teal-600 dark:text-cyan-400 hover:underline">
+                        Back to Services
+                    </button>
+                </div>
+            </>
         );
     }
 
     return (
+        <>
+        <SEOHead
+            title="Experiences in Alanya | Alanya Holidays"
+            description="Discover exciting experiences in Alanya. Water sports, adventure tours, and unique activities for every traveler."
+            keywords={['alanya experiences', 'alanya activities', 'things to do alanya', 'alanya tours']}
+        />
         <div className="pt-24 pb-16 min-h-screen bg-slate-50 dark:bg-slate-900">
             {/* Hero Section */}
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mb-16">
@@ -234,5 +244,6 @@ export const ExperienceCategoryPage: React.FC = () => {
                 )}
             </div>
         </div >
+        </>
     );
 };

--- a/pages/FavoritesPage.tsx
+++ b/pages/FavoritesPage.tsx
@@ -5,6 +5,7 @@ import { useFavorites } from '../context/FavoritesContext';
 import { db } from '../api-services';
 import { PropertyCard } from '../components/ui/PropertyCard';
 import { Property, PropertyDB } from '../types/models';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const FavoritesPage: React.FC = () => {
     const { favorites } = useFavorites();
@@ -61,6 +62,8 @@ export const FavoritesPage: React.FC = () => {
     }, [favorites]);
 
     return (
+        <>
+        <SEOHead title="My Favorites | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-950 pt-8 pb-16 transition-colors">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="mb-8">
@@ -100,5 +103,6 @@ export const FavoritesPage: React.FC = () => {
                 )}
             </div>
         </div>
+        </>
     );
 };

--- a/pages/InboxPage.test.tsx
+++ b/pages/InboxPage.test.tsx
@@ -20,6 +20,7 @@ vi.mock('react-router-dom', async () => {
     return {
         ...actual,
         useSearchParams: () => [mockSearchParams],
+        useLocation: () => ({ pathname: '/inbox', search: '', hash: '', state: null }),
         Navigate: () => <div>Redirected</div>
     };
 });

--- a/pages/InboxPage.tsx
+++ b/pages/InboxPage.tsx
@@ -5,6 +5,7 @@ import { Search, Home, MessageSquare } from 'lucide-react';
 import { format } from 'date-fns';
 import { useAuth } from '../context/AuthContext';
 import { Navigate, useSearchParams } from 'react-router-dom';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const InboxPage: React.FC = () => {
     const { conversations, activeConversationId, setActiveConversationId, refreshConversations } = useChat();
@@ -50,6 +51,8 @@ export const InboxPage: React.FC = () => {
         });
 
     return (
+        <>
+        <SEOHead title="Messages | Alanya Holidays" noIndex />
         <div className="container mx-auto px-4 py-8 max-w-6xl">
             <h1 className="text-3xl font-serif font-bold text-slate-900 dark:text-white mb-6">Messages</h1>
 
@@ -158,5 +161,6 @@ export const InboxPage: React.FC = () => {
                 </div>
             </div>
         </div>
+        </>
     );
 };

--- a/pages/ListProperty.tsx
+++ b/pages/ListProperty.tsx
@@ -9,6 +9,7 @@ import toast from 'react-hot-toast';
 import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { useSubmitShortcut } from '../hooks/useSubmitShortcut';
 import { Button } from '../components/ui/Button';
+import { SEOHead } from '../components/seo/SEOHead';
 
 // UI Components
 import { StepsIndicator } from '../components/ui/StepsIndicator';
@@ -189,6 +190,13 @@ export const ListProperty: React.FC = () => {
     };
 
     return (
+        <>
+        <SEOHead
+            title="List Your Property | Alanya Holidays"
+            description="List your property on Alanya Holidays and reach thousands of travelers. Easy setup, zero fees."
+            keywords={['list property alanya', 'rent property alanya', 'alanya property listing']}
+            noIndex
+        />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-10 px-4 transition-colors">
             <div className="max-w-3xl mx-auto">
                 <div className="mb-8">
@@ -239,5 +247,6 @@ export const ListProperty: React.FC = () => {
                 </div>
             </div>
         </div>
+        </>
     );
 };

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -13,6 +13,7 @@ import { ProfileServicesTab } from '../components/user/profile/ProfileServicesTa
 import { ProfileSettingsTab } from '../components/user/profile/ProfileSettingsTab';
 import { ProfileSecurityTab } from '../components/user/profile/ProfileSecurityTab';
 import { ProfilePayoutTab } from '../components/user/profile/ProfilePayoutTab';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const Profile: React.FC = () => {
     const { user, logout, isAuthenticated, updateUser, updateEmail, updatePassword, refreshUser } = useAuth();
@@ -270,6 +271,8 @@ export const Profile: React.FC = () => {
     if (!user) return null;
 
     return (
+        <>
+        <SEOHead title="My Profile | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 pt-24 pb-12 transition-colors">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
@@ -355,5 +358,6 @@ export const Profile: React.FC = () => {
                 isLoading={loading}
             />
         </div>
+        </>
     );
 };

--- a/pages/Visa.tsx
+++ b/pages/Visa.tsx
@@ -3,11 +3,18 @@ import { FileCheck, Clock, Globe, CheckCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { useLanguage } from '../context/LanguageContext';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const Visa: React.FC = () => {
     const navigate = useNavigate();
     const { t } = useLanguage();
     return (
+        <>
+        <SEOHead
+            title="Turkish Visa & Residency Guide | Alanya Holidays"
+            description="Complete guide to Turkish visa requirements and residency permits for Alanya. Expert assistance with your immigration needs."
+            keywords={['turkish visa', 'alanya residency', 'turkey visa guide', 'alanya immigration']}
+        />
         <div className="pt-24 pb-16 min-h-screen bg-slate-50 dark:bg-slate-900">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="text-center mb-16">
@@ -98,5 +105,6 @@ export const Visa: React.FC = () => {
                 </div>
             </div>
         </div>
+        </>
     );
 };

--- a/pages/ZeroFeesPage.tsx
+++ b/pages/ZeroFeesPage.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { CheckCircle, XCircle, TrendingUp } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
+import { SEOHead } from '../components/seo/SEOHead';
 
 export const ZeroFeesPage: React.FC = () => {
     const { t } = useLanguage();
 
     return (
+        <>
+        <SEOHead
+            title="Zero Fees Booking | Alanya Holidays"
+            description="Book your Alanya holiday with zero booking fees. Direct booking, best prices guaranteed, no hidden charges."
+            keywords={['zero fees alanya', 'no booking fees', 'alanya direct booking', 'alanya best price guarantee']}
+        />
         <div className="pt-24 pb-20">
             {/* Hero */}
             <section className="bg-primary text-white py-20 px-4">
@@ -75,5 +82,6 @@ export const ZeroFeesPage: React.FC = () => {
                 </p>
             </section>
         </div>
+        </>
     );
 };

--- a/pages/blog/HiddenGemsPage.tsx
+++ b/pages/blog/HiddenGemsPage.tsx
@@ -97,7 +97,7 @@ export const HiddenGemsPage: React.FC = () => {
               <ArrowRight size={14} />
             </Link>
             <Link
-              to="/tours"
+              to="/things-to-do-in-alanya"
               className="inline-flex items-center gap-2 px-4 py-2 bg-teal-50 dark:bg-teal-900/20 text-teal-700 dark:text-teal-400 rounded-lg font-medium hover:bg-teal-100 dark:hover:bg-teal-900/30 transition-colors"
             >
               <Camera size={16} />
@@ -305,7 +305,7 @@ export const HiddenGemsPage: React.FC = () => {
                 View Attractions
               </Link>
               <Link
-                to="/tours"
+                to="/things-to-do-in-alanya"
                 className="inline-flex items-center gap-2 px-6 py-3 bg-white dark:bg-slate-700 text-slate-900 dark:text-white border border-slate-200 dark:border-slate-600 rounded-xl font-semibold hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors"
               >
                 <Camera size={18} />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -20,6 +20,8 @@ Disallow: /edit-
 Disallow: /book-
 Disallow: /booking/
 Disallow: /checkout
+Disallow: /favorites
+Disallow: /bookmarks
 
 # Specific crawler handling
 User-agent: Googlebot

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,246 +1,330 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Static Pages -->
+  <!-- Homepage -->
   <url>
     <loc>https://alanya-holidays.com/</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
+
+  <!-- Static Pages -->
   <url>
     <loc>https://alanya-holidays.com/properties</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/about</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/contact</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/privacy</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/terms</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/ai-planner</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/zero-fees</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/experiences</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/shop</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/help</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://alanya-holidays.com/inbox</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://alanya-holidays.com/favorites</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://alanya-holidays.com/profile</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
+    <loc>https://alanya-holidays.com/community</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <!-- Directory Category Pages -->
   <url>
     <loc>https://alanya-holidays.com/medical-tourism-alanya</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-hotels</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-villas</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-apartments</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/things-to-do-in-alanya</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/airport-transfer</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/car-rental</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/restaurants</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/cafes</loc>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-real-estate</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-residency-guide</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-shopping-guide</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-nature-attractions</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://alanya-holidays.com/nightlife</loc>
-    <lastmod>2024-01-01</lastmod>
+    <loc>https://alanya-holidays.com/alanya-spa-hamam</loc>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-hair-beauty</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-weather</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/nightlife</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Excursion Type Pages -->
+  <url>
+    <loc>https://alanya-holidays.com/alanya-boat-tours</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-jeep-safari</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-buggy-safari</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-rafting</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/scuba-diving-alanya</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/sapadere-canyon-tour</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/green-canyon-tour</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/parasailing-alanya</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-fishing-trips</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-city-tour</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-yacht-charter</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- SEO Landing Pages -->
+  <url>
+    <loc>https://alanya-holidays.com/hidden-gems-alanya</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/best-beaches-alanya</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Blog -->
+  <url>
+    <loc>https://alanya-holidays.com/blog</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Forum -->
+  <url>
+    <loc>https://alanya-holidays.com/forum</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
 
   <!-- Service Pages -->
   <url>
     <loc>https://alanya-holidays.com/services/car-rental</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/bike-rental</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/bicycle-rental</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/tourist-sim-card</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/visa-legal</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/visa-consult</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/creative-professionals</loc>
-    <lastmod>2024-01-01</lastmod>
+    <lastmod>2025-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://alanya-holidays.com/car-model-details</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-
-  <!-- Booking Pages -->
-  <url>
-    <loc>https://alanya-holidays.com/booking/success</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>never</changefreq>
-    <priority>0.3</priority>
-  </url>
-
-  <!-- Host/Admin (hidden from search engines via robots.txt, but included for completeness) -->
-  <url>
-    <loc>https://alanya-holidays.com/host/dashboard</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://alanya-holidays.com/admin/dashboard</loc>
-    <lastmod>2024-01-01</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
   </url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://alanya-holidays.com/</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,73 +11,73 @@
   <!-- Static Pages -->
   <url>
     <loc>https://alanya-holidays.com/properties</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/about</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/contact</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/privacy</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/terms</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/ai-planner</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/zero-fees</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/experiences</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/shop</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/help</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/community</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -85,103 +85,103 @@
   <!-- Directory Category Pages -->
   <url>
     <loc>https://alanya-holidays.com/medical-tourism-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-hotels</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-villas</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-apartments</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/things-to-do-in-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/airport-transfer</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/car-rental</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/restaurants</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/cafes</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-real-estate</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-residency-guide</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-shopping-guide</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-nature-attractions</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-spa-hamam</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-hair-beauty</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-weather</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/nightlife</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -189,67 +189,67 @@
   <!-- Excursion Type Pages -->
   <url>
     <loc>https://alanya-holidays.com/alanya-boat-tours</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-jeep-safari</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-buggy-safari</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-rafting</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/scuba-diving-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/sapadere-canyon-tour</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/green-canyon-tour</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/parasailing-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-fishing-trips</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-city-tour</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-yacht-charter</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -257,79 +257,79 @@
   <!-- Attraction Pages -->
   <url>
     <loc>https://alanya-holidays.com/cleopatra-beach</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-castle</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/dim-cave</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/incekum-beach</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/keykubat-beach</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/dim-river</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/sapadere-canyon</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/red-tower-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/alanya-shipyard</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/syedra-ancient-city</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/manavgat-waterfall</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/side-day-trip</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/green-canyon</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -337,13 +337,13 @@
   <!-- SEO Landing Pages -->
   <url>
     <loc>https://alanya-holidays.com/hidden-gems-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/best-beaches-alanya</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -351,7 +351,7 @@
   <!-- Blog -->
   <url>
     <loc>https://alanya-holidays.com/blog</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
@@ -359,7 +359,7 @@
   <!-- Forum -->
   <url>
     <loc>https://alanya-holidays.com/forum</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
@@ -367,43 +367,43 @@
   <!-- Service Pages -->
   <url>
     <loc>https://alanya-holidays.com/services/car-rental</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/bike-rental</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/bicycle-rental</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/tourist-sim-card</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/services/visa-legal</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/visa-consult</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://alanya-holidays.com/creative-professionals</loc>
-    <lastmod>2025-06-06</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -254,6 +254,86 @@
     <priority>0.8</priority>
   </url>
 
+  <!-- Attraction Pages -->
+  <url>
+    <loc>https://alanya-holidays.com/cleopatra-beach</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-castle</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/dim-cave</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/incekum-beach</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/keykubat-beach</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/dim-river</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/sapadere-canyon</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/red-tower-alanya</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/alanya-shipyard</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/syedra-ancient-city</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/manavgat-waterfall</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/side-day-trip</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://alanya-holidays.com/green-canyon</loc>
+    <lastmod>2025-06-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- SEO Landing Pages -->
   <url>
     <loc>https://alanya-holidays.com/hidden-gems-alanya</loc>

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -12,6 +12,7 @@ import { NotFound } from '../components/pages/NotFound';
 const DirectoryHome = React.lazy(() => import('../pages/DirectoryHome').then(module => ({ default: module.DirectoryHome })));
 const DirectoryCategoryPage = React.lazy(() => import('../pages/DirectoryCategoryPage').then(module => ({ default: module.DirectoryCategoryPage })));
 const ExcursionTypePage = React.lazy(() => import('../pages/ExcursionTypePage').then(module => ({ default: module.ExcursionTypePage })));
+const AttractionPage = React.lazy(() => import('../pages/AttractionPage').then(module => ({ default: module.AttractionPage })));
 const LoginRedirect = React.lazy(() => import('../pages/auth/LoginRedirect').then(module => ({ default: module.LoginRedirect })));
 
 // Public Pages - Lazy Loaded
@@ -136,6 +137,21 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/alanya-fishing-trips" element={<ExcursionTypePage />} />
                 <Route path="/alanya-city-tour" element={<ExcursionTypePage />} />
                 <Route path="/alanya-yacht-charter" element={<ExcursionTypePage />} />
+
+                {/* Attraction Pages */}
+                <Route path="/cleopatra-beach" element={<AttractionPage />} />
+                <Route path="/incekum-beach" element={<AttractionPage />} />
+                <Route path="/keykubat-beach" element={<AttractionPage />} />
+                <Route path="/dim-cave" element={<AttractionPage />} />
+                <Route path="/dim-river" element={<AttractionPage />} />
+                <Route path="/sapadere-canyon" element={<AttractionPage />} />
+                <Route path="/alanya-castle" element={<AttractionPage />} />
+                <Route path="/red-tower-alanya" element={<AttractionPage />} />
+                <Route path="/alanya-shipyard" element={<AttractionPage />} />
+                <Route path="/syedra-ancient-city" element={<AttractionPage />} />
+                <Route path="/manavgat-waterfall" element={<AttractionPage />} />
+                <Route path="/side-day-trip" element={<AttractionPage />} />
+                <Route path="/green-canyon" element={<AttractionPage />} />
 
                 {/* SEO-003: Listing Detail Routes (silo sub-pages) */}
                 <Route path="/medical-tourism-alanya/:slug" element={<DirectoryListingPage categoryId="medical" />} />

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route } from 'react-router-dom';
 
 import { AdminLayout } from '../components/layouts/AdminLayout';
 import { HostLayoutController } from '../components/layouts/HostLayoutController';
@@ -11,6 +11,7 @@ import { NotFound } from '../components/pages/NotFound';
 // Public Pages - Direct Imports (critical for immediate FCP)
 const DirectoryHome = React.lazy(() => import('../pages/DirectoryHome').then(module => ({ default: module.DirectoryHome })));
 const DirectoryCategoryPage = React.lazy(() => import('../pages/DirectoryCategoryPage').then(module => ({ default: module.DirectoryCategoryPage })));
+const ExcursionTypePage = React.lazy(() => import('../pages/ExcursionTypePage').then(module => ({ default: module.ExcursionTypePage })));
 const LoginRedirect = React.lazy(() => import('../pages/auth/LoginRedirect').then(module => ({ default: module.LoginRedirect })));
 
 // Public Pages - Lazy Loaded
@@ -110,13 +111,10 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/alanya-villas" element={<DirectoryCategoryPage categoryId="villas" />} />
                 <Route path="/alanya-apartments" element={<DirectoryCategoryPage categoryId="apartments" />} />
                 <Route path="/things-to-do-in-alanya" element={<DirectoryCategoryPage categoryId="tours" />} />
-                <Route path="/tours" element={<Navigate to="/things-to-do-in-alanya" replace />} />
                 <Route path="/airport-transfer" element={<DirectoryCategoryPage categoryId="transport" />} />
                 <Route path="/car-rental" element={<DirectoryCategoryPage categoryId="transport" />} />
                 <Route path="/restaurants" element={<DirectoryCategoryPage categoryId="restaurants" />} />
-                <Route path="/alanya-restaurants" element={<Navigate to="/restaurants" replace />} />
                 <Route path="/cafes" element={<DirectoryCategoryPage categoryId="cafes" />} />
-                <Route path="/alanya-cafes" element={<Navigate to="/cafes" replace />} />
                 <Route path="/alanya-real-estate" element={<DirectoryCategoryPage categoryId="real-estate" />} />
                 <Route path="/alanya-residency-guide" element={<DirectoryCategoryPage categoryId="visa" />} />
                 <Route path="/alanya-shopping-guide" element={<DirectoryCategoryPage categoryId="shopping" />} />
@@ -125,6 +123,19 @@ export const AppRoutes: React.FC = () => {
                 <Route path="/nightlife" element={<DirectoryCategoryPage categoryId="nightlife" />} />
                 <Route path="/alanya-spa-hamam" element={<DirectoryCategoryPage categoryId="spa-hamam" />} />
                 <Route path="/alanya-hair-beauty" element={<DirectoryCategoryPage categoryId="hair-beauty" />} />
+
+                {/* Excursion Type Pages */}
+                <Route path="/alanya-boat-tours" element={<ExcursionTypePage />} />
+                <Route path="/alanya-jeep-safari" element={<ExcursionTypePage />} />
+                <Route path="/alanya-buggy-safari" element={<ExcursionTypePage />} />
+                <Route path="/alanya-rafting" element={<ExcursionTypePage />} />
+                <Route path="/scuba-diving-alanya" element={<ExcursionTypePage />} />
+                <Route path="/sapadere-canyon-tour" element={<ExcursionTypePage />} />
+                <Route path="/green-canyon-tour" element={<ExcursionTypePage />} />
+                <Route path="/parasailing-alanya" element={<ExcursionTypePage />} />
+                <Route path="/alanya-fishing-trips" element={<ExcursionTypePage />} />
+                <Route path="/alanya-city-tour" element={<ExcursionTypePage />} />
+                <Route path="/alanya-yacht-charter" element={<ExcursionTypePage />} />
 
                 {/* SEO-003: Listing Detail Routes (silo sub-pages) */}
                 <Route path="/medical-tourism-alanya/:slug" element={<DirectoryListingPage categoryId="medical" />} />

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,21 @@
 {
+  "redirects": [
+    {
+      "source": "/tours",
+      "destination": "/things-to-do-in-alanya",
+      "permanent": true
+    },
+    {
+      "source": "/alanya-restaurants",
+      "destination": "/restaurants",
+      "permanent": true
+    },
+    {
+      "source": "/alanya-cafes",
+      "destination": "/cafes",
+      "permanent": true
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- **301 server redirects** in vercel.json (replacing client-side `<Navigate>` components for `/tours`, `/alanya-restaurants`, `/alanya-cafes`)
- **Sitemap overhaul**: removed private/auth pages, updated dates, added 11 excursion type URLs and missing static routes
- **robots.txt**: added `Disallow: /favorites` and `Disallow: /bookmarks`
- **Organization + WebSite JSON-LD** schemas added to DirectoryHome (TravelAgency + SearchAction)
- **SEOHead component**: now supports array of JSON-LD schemas
- **SEOHead added to 15+ pages**: noIndex for auth/admin pages (Checkout, Favorites, Inbox, Profile, etc.), proper meta tags for public pages (BicycleRental, BikeRental, CarRental, CreativeServices, Visa, ZeroFees)
- **ExcursionTypePage**: new page component with keyword-based Supabase search, breadcrumbs, TouristTrip JSON-LD, and 12 route entries
- **Bug fixes**: broken `/tours` links in HiddenGemsPage, empty `sameAs: []` in TravelAgency schema, early returns without SEOHead in CarModelDetails and ExperienceCategoryPage, guard for empty `searchKeywords` array

## Key architectural decisions
- Keyword-based filtering via `searchDirectoryListings` (no DB migration needed yet)
- Server-side 301 redirects instead of client-side `<Navigate>` (better for SEO)
- Static config-driven excursion types in `data/excursionTypes.ts`

## Potential risks
- `searchDirectoryListings` uses ILIKE matching — may need `tags text[]` migration for precision if results are too broad
- Sitemap is still static — will need dynamic generation script after more URL types are added (Phase 3+)

## Testing notes
- TypeScript: 0 errors
- Security review: no vulnerabilities found
- All 12 excursion routes render correctly with slug-based config lookup