### PR TITLE
feat: add share button to blog post page

### DIFF
--- a/pages/BlogPostPage.test.tsx
+++ b/pages/BlogPostPage.test.tsx
@@ -1,12 +1,18 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BlogPostPage } from './BlogPostPage';
 import { db } from '../api-services';
+import { toast } from 'react-hot-toast';
 
 vi.mock('../api-services', () => ({
   db: {
     getBlogPost: vi.fn(),
   }
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+  default: { success: vi.fn(), error: vi.fn() }
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -187,6 +193,24 @@ describe('BlogPostPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Article Not Found')).toBeInTheDocument();
     });
+  });
+
+  it('copies link to clipboard and shows toast when Web Share API is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    await act(async () => {
+      render(<BlogPostPage />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(mockPost.title)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /share/i }));
+
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(toast.success).toHaveBeenCalledWith('Link copied to clipboard!');
   });
 
   it('renders SEO Head component', async () => {

--- a/pages/BlogPostPage.tsx
+++ b/pages/BlogPostPage.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, Calendar, User, Clock, Tag } from 'lucide-react';
+import { ArrowLeft, Calendar, User, Clock, Tag, Share2 } from 'lucide-react';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
 import { format } from 'date-fns';
 import DOMPurify from 'dompurify';
+import { toast } from 'react-hot-toast';
 import { db } from '../api-services';
 import { SEOHead } from '../components/seo/SEOHead';
 import { BlogPostWithTags } from '../api-services/api/blog';
@@ -87,6 +88,20 @@ export const BlogPostPage: React.FC = () => {
     const readTime = post.content
         ? Math.max(1, Math.ceil(post.content.replace(/<[^>]*>/g, '').split(/\s+/).length / 200))
         : 1;
+
+    const handleShare = async () => {
+        const shareUrl = window.location.href;
+        if (navigator.share) {
+            try {
+                await navigator.share({ title: post.title, url: shareUrl });
+            } catch (_error) {
+                // User cancelled share
+            }
+        } else {
+            navigator.clipboard.writeText(shareUrl);
+            toast.success('Link copied to clipboard!');
+        }
+    };
 
     const articleJsonLd = {
         '@context': 'https://schema.org',
@@ -182,6 +197,14 @@ export const BlogPostPage: React.FC = () => {
                         <span className="text-slate-400 dark:text-slate-600">
                             {post.views.toLocaleString()} views
                         </span>
+                        <button
+                            type="button"
+                            onClick={handleShare}
+                            className="inline-flex items-center gap-1.5 text-teal-600 dark:text-cyan-400 hover:underline"
+                        >
+                            <Share2 size={14} />
+                            Share
+                        </button>
                     </div>
 
                     {/* Title */}


### PR DESCRIPTION
## Summary
- Adds a Share button to `pages/BlogPostPage.tsx` meta row, using `navigator.share` with a clipboard-copy + toast fallback (same pattern as `components/ai/TripItinerary.tsx`).

## Testing notes
- TDD: new test added to `pages/BlogPostPage.test.tsx` covering the clipboard-fallback path (mocks `navigator.clipboard`, jsdom has no `navigator.share` by default).
- `tsc --noEmit`: 0 errors
- ESLint: 0 errors/warnings
- `vitest run`: full suite green (1507 tests, 128 files)

## Test plan
- [ ] Click Share on a published blog post in a browser without Web Share API support (desktop) — confirm link copied to clipboard and toast appears
- [ ] On mobile / a browser with Web Share API — confirm native share sheet opens with the post title and URL

(Note: this replaces #159, which got auto-closed by GitHub when its base branch was deleted instead of being retargeted.)