### PR TITLE
feat: implement admin claims tab for listing ownership transfer

### DIFF
--- a/api-services/api/directory.test.ts
+++ b/api-services/api/directory.test.ts
@@ -44,6 +44,7 @@ const makeChain = (overrides: any = {}) => {
         eq: vi.fn().mockReturnThis(),
         not: vi.fn().mockReturnThis(),
         order: vi.fn().mockReturnThis(),
+        limit: vi.fn(),
         single: vi.fn(),
         ...overrides
     };
@@ -412,6 +413,31 @@ describe('directoryService', () => {
 
             await expect(directoryService.getCategoryAnalyticsAverage('medical'))
                 .rejects.toEqual({ message: 'RPC failed' });
+        });
+    });
+
+    describe('getRecentlyClaimedListings', () => {
+        it('fetches recently claimed listings successfully', async () => {
+            const chain = makeChain();
+            chain.limit.mockResolvedValue({ data: [mockListing], error: null });
+            mockSupabase.from.mockReturnValue(chain);
+
+            const result = await directoryService.getRecentlyClaimedListings(6);
+            expect(result).toEqual([mockListing]);
+            expect(mockSupabase.from).toHaveBeenCalledWith('directory_listings');
+            expect(chain.not).toHaveBeenCalledWith('claimed_at', 'is', null);
+            expect(chain.eq).toHaveBeenCalledWith('status', 'approved');
+            expect(chain.order).toHaveBeenCalledWith('claimed_at', { ascending: false });
+            expect(chain.limit).toHaveBeenCalledWith(6);
+        });
+
+        it('throws on database error', async () => {
+            const chain = makeChain();
+            chain.limit.mockResolvedValue({ data: null, error: { message: 'Database error' } });
+            mockSupabase.from.mockReturnValue(chain);
+
+            await expect(directoryService.getRecentlyClaimedListings())
+                .rejects.toEqual({ message: 'Database error' });
         });
     });
 });

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -641,7 +641,7 @@ export const directoryService = {
                 type: 'admin_claim_notification',
                 data: {
                     businessName: claim.business_name,
-                    claimantEmail: claim.claimant_email,
+                    claimantEmail: claim.email,
                     listingId: claim.listing_id,
                 },
             },

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -627,7 +627,7 @@ export const directoryService = {
             },
         })).catch(err => console.error('Error sending admin notification:', err));
 
-        return null; // Return null — RPC handled the update
+        return claim;
     },
 
     async getListingClaims(): Promise<ListingClaimDB[]> {

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -241,6 +241,26 @@ export const directoryService = {
         return data as DirectoryListingDB[];
     },
 
+    /**
+     * Get listings that were recently claimed (ordered by claimed_at DESC)
+     */
+    async getRecentlyClaimedListings(limit: number = 6): Promise<DirectoryListingDB[]> {
+        const { data, error } = await supabase
+            .from('directory_listings')
+            .select(LISTING_LOCATIONS_SELECT)
+            .not('claimed_at', 'is', null)
+            .eq('status', 'approved')
+            .order('claimed_at', { ascending: false })
+            .limit(limit);
+
+        if (error) {
+            console.error('Error fetching recently claimed listings:', error);
+            throw error;
+        }
+
+        return data as DirectoryListingDB[];
+    },
+
     async voteForListing(listingId: string, vote: 1 | -1): Promise<{ netVotes: number; userVote: number }> {
         const { data, error } = await supabase
             .rpc('vote_listing', {

--- a/api-services/api/directory.ts
+++ b/api-services/api/directory.ts
@@ -547,21 +547,17 @@ export const directoryService = {
     },
 
     async submitListingClaim(
-        claim: Omit<ListingClaimDB, 'id' | 'created_at' | 'updated_at' | 'status' | 'user_id'>
+        claim: Omit<ListingClaimDB, 'id' | 'created_at' | 'updated_at' | 'status' | 'user_id' | 'email_verified' | 'verification_token' | 'verification_expires_at' | 'rejection_reason'>
     ): Promise<ListingClaimDB> {
-        let authUserId: string | null = null;
-        try {
-            const { data: { user } } = await supabase.auth.getUser();
-            if (user) {
-                authUserId = user.id;
-            }
-        } catch (_e) {
-            // User is anonymous or not logged in, ignore auth error
+        // Auth is required — cannot submit claim anonymously
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user?.id) {
+            throw new Error('Must be logged in to submit a claim');
         }
 
         const safeData = sanitize({
             listing_id: claim.listing_id,
-            user_id: authUserId,
+            user_id: user.id,
             email: claim.email.trim(),
             phone: claim.phone.trim(),
             role: claim.role,
@@ -586,6 +582,143 @@ export const directoryService = {
             throw error;
         }
 
-        return data as ListingClaimDB;
-    }
+        const claimRecord = data as ListingClaimDB;
+
+        // Send verification email
+        await retry(() => supabase.functions.invoke('send-email', {
+            body: {
+                type: 'listing_claim_verification',
+                data: {
+                    claimantEmail: claimRecord.email,
+                    businessName: claimRecord.business_name,
+                    verificationToken: claimRecord.verification_token,
+                },
+            },
+        })).catch(err => console.error('Error sending claim verification email:', err));
+
+        return claimRecord;
+    },
+
+    async verifyClaimEmail(token: string): Promise<ListingClaimDB | null> {
+        const { data, error } = await supabase.rpc('verify_claim_email', {
+            p_token: token,
+        });
+
+        if (error) {
+            console.error('Error verifying claim email:', error);
+            return null;
+        }
+
+        if (!data || data.length === 0) {
+            return null;
+        }
+
+        const claim = data[0];
+
+        // Send admin notification
+        await retry(() => supabase.functions.invoke('send-email', {
+            body: {
+                type: 'admin_claim_notification',
+                data: {
+                    businessName: claim.business_name,
+                    claimantEmail: claim.claimant_email,
+                    listingId: claim.listing_id,
+                },
+            },
+        })).catch(err => console.error('Error sending admin notification:', err));
+
+        return null; // Return null — RPC handled the update
+    },
+
+    async getListingClaims(): Promise<ListingClaimDB[]> {
+        const { data, error } = await supabase
+            .from('listing_claims')
+            .select('*')
+            .order('created_at', { ascending: false });
+
+        if (error) {
+            console.error('Error fetching claims:', error);
+            throw error;
+        }
+
+        return (data || []) as ListingClaimDB[];
+    },
+
+    async approveListingClaim(claimId: string): Promise<boolean> {
+        const { data, error } = await supabase.rpc('approve_listing_claim', {
+            p_claim_id: claimId,
+        });
+
+        if (error) {
+            console.error('Error approving claim:', error);
+            throw error;
+        }
+
+        if (!data || !data[0]?.success) {
+            const message = data?.[0]?.message || 'Failed to approve claim';
+            throw new Error(message);
+        }
+
+        // Fetch claim details for notification
+        const { data: claim } = await supabase
+            .from('listing_claims')
+            .select('email, business_name')
+            .eq('id', claimId)
+            .single();
+
+        // Send approval email to claimant
+        if (claim) {
+            await retry(() => supabase.functions.invoke('send-email', {
+                body: {
+                    type: 'listing_claim_approved',
+                    data: {
+                        claimantEmail: claim.email,
+                        businessName: claim.business_name,
+                    },
+                },
+            })).catch(err => console.error('Error sending approval email:', err));
+        }
+
+        return true;
+    },
+
+    async rejectListingClaim(claimId: string, reason: string): Promise<boolean> {
+        const { data, error } = await supabase.rpc('reject_listing_claim', {
+            p_claim_id: claimId,
+            p_reason: reason,
+        });
+
+        if (error) {
+            console.error('Error rejecting claim:', error);
+            throw error;
+        }
+
+        if (!data || !data[0]?.success) {
+            const message = data?.[0]?.message || 'Failed to reject claim';
+            throw new Error(message);
+        }
+
+        // Fetch claim details for notification
+        const { data: claim } = await supabase
+            .from('listing_claims')
+            .select('email, business_name')
+            .eq('id', claimId)
+            .single();
+
+        // Send rejection email to claimant
+        if (claim) {
+            await retry(() => supabase.functions.invoke('send-email', {
+                body: {
+                    type: 'listing_claim_rejected',
+                    data: {
+                        claimantEmail: claim.email,
+                        businessName: claim.business_name,
+                        rejectionReason: reason,
+                    },
+                },
+            })).catch(err => console.error('Error sending rejection email:', err));
+        }
+
+        return true;
+    },
 };

--- a/components/directory/ClaimListingModal.tsx
+++ b/components/directory/ClaimListingModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { X, Check, Info, ArrowRight, ArrowLeft, Loader2, Clock } from 'lucide-react';
+import { X, Check, Info, ArrowRight, ArrowLeft, Loader2, Clock, Award } from 'lucide-react';
 import { Modal } from '../ui/Modal';
 import { db } from '../../api-services';
 import { DirectoryListingDB } from '../../types/models';
@@ -16,7 +16,7 @@ interface ClaimListingModalProps {
 export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, onClose, listing }) => {
     const { t } = useLanguage();
     const { user } = useAuth();
-    const [step, setStep] = useState<1 | 2 | 3>(1);
+    const [step, setStep] = useState<0 | 1 | 2 | 3>(0);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -35,7 +35,7 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
     // Reset and initialize data on open/listing change
     useEffect(() => {
         if (isOpen && listing) {
-            setStep(1);
+            setStep(0);
             setError(null);
             setFormData({
                 phone: '',
@@ -137,6 +137,7 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
                 </div>
 
                 {/* Step Progress Indicators */}
+                {step > 0 && (
                 <div className="flex items-center justify-between px-6 py-4 bg-slate-50/50 dark:bg-slate-900/40 border-b border-slate-100 dark:border-slate-800/30 overflow-x-auto gap-4">
                     {/* Step 1 */}
                     <div className={`flex items-center gap-2 text-xs font-semibold whitespace-nowrap ${step === 1 ? 'text-teal-600 dark:text-cyan-400' : 'text-slate-500 dark:text-slate-400'}`}>
@@ -164,8 +165,86 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
                         {t('directory.claim.modal.step3')}
                     </div>
                 </div>
+                )}
 
                 {/* Step Contents */}
+                {step === 0 && (
+                    <div className="p-6 space-y-6">
+                        <div className="space-y-4">
+                            <h3 className="font-semibold text-slate-900 dark:text-white flex items-center gap-2">
+                                <Award size={20} className="text-teal-600 dark:text-cyan-400" />
+                                Why claim ownership?
+                            </h3>
+                            <ul className="space-y-3 text-sm text-slate-700 dark:text-slate-300">
+                                <li className="flex gap-3">
+                                    <Check size={16} className="text-green-500 flex-shrink-0 mt-0.5" />
+                                    <span>Verify that this is your business</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <Check size={16} className="text-green-500 flex-shrink-0 mt-0.5" />
+                                    <span>Get control over your business page</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <Check size={16} className="text-green-500 flex-shrink-0 mt-0.5" />
+                                    <span>Update information and photos</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <Check size={16} className="text-green-500 flex-shrink-0 mt-0.5" />
+                                    <span>Respond to customer reviews</span>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <div className="space-y-4">
+                            <h3 className="font-semibold text-slate-900 dark:text-white flex items-center gap-2">
+                                <Clock size={20} className="text-teal-600 dark:text-cyan-400" />
+                                How it works
+                            </h3>
+                            <ol className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+                                <li className="flex gap-3">
+                                    <span className="font-bold text-teal-600 dark:text-cyan-400 min-w-6">1.</span>
+                                    <span>Fill out your business information</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <span className="font-bold text-teal-600 dark:text-cyan-400 min-w-6">2.</span>
+                                    <span>Verify your email (instant)</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <span className="font-bold text-teal-600 dark:text-cyan-400 min-w-6">3.</span>
+                                    <span>Admin reviews your claim (1-2 days)</span>
+                                </li>
+                                <li className="flex gap-3">
+                                    <span className="font-bold text-teal-600 dark:text-cyan-400 min-w-6">4.</span>
+                                    <span>Get approved and start managing</span>
+                                </li>
+                            </ol>
+                        </div>
+
+                        <div className="bg-teal-50/50 dark:bg-cyan-950/10 border border-teal-100 dark:border-cyan-800/30 rounded-xl p-4 text-xs text-teal-800 dark:text-cyan-300 leading-relaxed flex items-start gap-2">
+                            <Info size={16} className="mt-0.5 flex-shrink-0" />
+                            <span>We'll verify your business details to ensure only real owners can claim listings.</span>
+                        </div>
+
+                        <div className="flex items-center justify-between pt-4">
+                            <button
+                                type="button"
+                                onClick={onClose}
+                                className="text-sm font-medium text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-white transition-colors cursor-pointer"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setStep(1)}
+                                className="inline-flex items-center justify-center rounded-full font-semibold whitespace-nowrap cursor-pointer transition-all duration-200 bg-teal-600 hover:bg-teal-700 dark:bg-cyan-500 dark:hover:bg-cyan-600 text-white px-6 py-3 text-sm gap-2"
+                            >
+                                Get Started
+                                <ArrowRight size={16} />
+                            </button>
+                        </div>
+                    </div>
+                )}
+
                 {step === 1 && (
                     <form onSubmit={handleStep1Submit} className="p-6 space-y-5">
                         <div className="bg-teal-50/50 dark:bg-cyan-950/10 border border-teal-100 dark:border-cyan-800/30 rounded-xl p-4 text-xs text-teal-800 dark:text-cyan-300 leading-relaxed flex items-start gap-2">

--- a/components/directory/ClaimListingModal.tsx
+++ b/components/directory/ClaimListingModal.tsx
@@ -4,6 +4,7 @@ import { Modal } from '../ui/Modal';
 import { db } from '../../api-services';
 import { DirectoryListingDB } from '../../types/models';
 import { useLanguage } from '../../context/LanguageContext';
+import { useAuth } from '../../context/AuthContext';
 import { toast } from 'react-hot-toast';
 
 interface ClaimListingModalProps {
@@ -14,12 +15,12 @@ interface ClaimListingModalProps {
 
 export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, onClose, listing }) => {
     const { t } = useLanguage();
+    const { user } = useAuth();
     const [step, setStep] = useState<1 | 2 | 3>(1);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     const [formData, setFormData] = useState({
-        email: '',
         phone: '',
         role: '',
         additional_notes: '',
@@ -37,7 +38,6 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
             setStep(1);
             setError(null);
             setFormData({
-                email: '',
                 phone: '',
                 role: '',
                 additional_notes: '',
@@ -53,7 +53,7 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
 
     const handleStep1Submit = (e: React.FormEvent) => {
         e.preventDefault();
-        if (!formData.email || !formData.phone || !formData.role) {
+        if (!formData.phone || !formData.role) {
             toast.error(t('auth.error.required') || 'Please fill in all required fields');
             return;
         }
@@ -68,13 +68,18 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
             return;
         }
 
+        if (!user?.email) {
+            toast.error('User email not found. Please log in again.');
+            return;
+        }
+
         setLoading(true);
         setError(null);
 
         try {
             await db.submitListingClaim({
                 listing_id: listing.id,
-                email: formData.email,
+                email: user.email,
                 phone: formData.phone,
                 role: formData.role,
                 additional_notes: formData.additional_notes,
@@ -87,7 +92,10 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
             });
 
             setStep(3);
-            toast.success(t('reviews.success') || 'Claim submitted successfully!');
+            toast.success(t('directory.claim.submitted') || 'Claim submitted! Check your email to verify.');
+            setTimeout(() => {
+                onClose();
+            }, 2000);
         } catch (err: any) {
             console.error('Claim submission error:', err);
             setError(err.message || 'An error occurred while submitting your claim.');
@@ -172,20 +180,6 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
                         )}
 
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <div>
-                                <label htmlFor="claim-email" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">
-                                    {t('directory.claim.modal.email')} <span className="text-red-500">*</span>
-                                </label>
-                                <input
-                                    id="claim-email"
-                                    required
-                                    type="email"
-                                    placeholder="you@company.com"
-                                    className="w-full px-4 py-2.5 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition-all"
-                                    value={formData.email}
-                                    onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                                />
-                            </div>
                             <div>
                                 <label htmlFor="claim-phone" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">
                                     {t('directory.claim.modal.phone')} <span className="text-red-500">*</span>
@@ -397,7 +391,7 @@ export const ClaimListingModal: React.FC<ClaimListingModalProps> = ({ isOpen, on
                         <p className="text-sm text-slate-600 dark:text-slate-400 max-w-sm mx-auto mb-6 leading-relaxed">
                             {t('directory.claim.modal.success.desc')
                                 ?.replace('{name}', listing.name)
-                                ?.replace('{email}', formData.email)}
+                                ?.replace('{email}', user?.email || 'your email')}
                         </p>
 
                         <div className="bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800/40 rounded-xl p-4 max-w-sm mx-auto mb-6">

--- a/components/home/RecentlyClaimedSection.tsx
+++ b/components/home/RecentlyClaimedSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Award, ArrowRight } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingCard } from '../directory/DirectoryListingCard';
+import { useLanguage } from '../../context/LanguageContext';
+
+interface RecentlyClaimedSectionProps {
+    listings: DirectoryListingDB[];
+    loading: boolean;
+}
+
+export const RecentlyClaimedSection: React.FC<RecentlyClaimedSectionProps> = ({ listings, loading }) => {
+    const { t } = useLanguage();
+    const navigate = useNavigate();
+
+    // If not loading and no listings, hide the section entirely
+    if (!loading && listings.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="bg-gradient-to-b from-teal-50/30 to-slate-50 dark:from-teal-950/5 dark:to-slate-900/50 py-16 md:py-24 border-y border-teal-100/30 dark:border-teal-900/10">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                {/* Section Header */}
+                <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between mb-10 gap-4">
+                    <div>
+                        <div className="flex items-center gap-2 mb-2">
+                            <Award className="w-5 h-5 text-teal-600 dark:text-cyan-400" />
+                            <span className="text-xs uppercase font-bold text-teal-600 dark:text-cyan-400 tracking-widest">
+                                {t('home.recently_claimed.badge')}
+                            </span>
+                        </div>
+                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
+                            {t('home.recently_claimed.title')}
+                        </h2>
+                        <p className="mt-2 text-slate-600 dark:text-slate-400 text-sm md:text-base">
+                            {t('home.recently_claimed.subtitle')}
+                        </p>
+                    </div>
+                    <button
+                        onClick={() => navigate('/search')}
+                        className="flex items-center gap-1 text-sm font-semibold text-teal-600 dark:text-cyan-400 hover:text-teal-700 dark:hover:text-cyan-300 transition-colors self-start sm:self-auto"
+                    >
+                        {t('home.recently_claimed.view_all')} <ArrowRight size={16} />
+                    </button>
+                </div>
+
+                {/* Loading State */}
+                {loading && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[1, 2, 3].map(i => (
+                            <div key={i} className="h-96 bg-white dark:bg-slate-800 rounded-2xl animate-pulse" />
+                        ))}
+                    </div>
+                )}
+
+                {/* Listings Grid */}
+                {!loading && listings.length > 0 && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {listings.map((listing) => (
+                            <DirectoryListingCard key={listing.id} listing={listing} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/components/ui/RestoreDraftBanner.tsx
+++ b/components/ui/RestoreDraftBanner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { AlertCircle } from 'lucide-react';
+
+interface RestoreDraftBannerProps {
+  onRestore: () => void;
+  onDiscard: () => void;
+}
+
+export const RestoreDraftBanner: React.FC<RestoreDraftBannerProps> = ({ onRestore, onDiscard }) => {
+  return (
+    <div className="mb-6 bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-400 p-4 rounded flex items-center gap-3">
+      <AlertCircle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0" />
+      <div className="flex-1">
+        <p className="text-amber-900 dark:text-amber-100 font-medium">You have unsaved progress</p>
+        <p className="text-amber-700 dark:text-amber-200 text-sm mt-1">Would you like to restore your previous draft?</p>
+      </div>
+      <div className="flex gap-2 flex-shrink-0">
+        <button
+          onClick={onDiscard}
+          className="px-4 py-2 bg-amber-100 hover:bg-amber-200 dark:bg-amber-800 dark:hover:bg-amber-700 text-amber-900 dark:text-amber-100 rounded font-medium text-sm transition-colors"
+        >
+          Discard
+        </button>
+        <button
+          onClick={onRestore}
+          className="px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded font-medium text-sm transition-colors"
+        >
+          Restore
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/user/profile/ProfileDraftsTab.test.tsx
+++ b/components/user/profile/ProfileDraftsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ProfileDraftsTab } from './ProfileDraftsTab';
 import { BrowserRouter } from 'react-router-dom';
 

--- a/components/user/profile/ProfileDraftsTab.test.tsx
+++ b/components/user/profile/ProfileDraftsTab.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ProfileDraftsTab } from './ProfileDraftsTab';
+import { BrowserRouter } from 'react-router-dom';
+
+vi.mock('../../../context/LanguageContext', () => ({
+    useLanguage: () => ({ t: (k: string) => k })
+}));
+
+vi.mock('lucide-react', () => ({
+    Home: () => <div data-testid="home-icon" />,
+    MapPin: () => <div data-testid="mappin-icon" />,
+    Car: () => <div data-testid="car-icon" />,
+    Briefcase: () => <div data-testid="briefcase-icon" />,
+    FileText: () => <div data-testid="filetext-icon" />,
+    Trash2: () => <div data-testid="trash-icon" />,
+    Edit3: () => <div data-testid="edit-icon" />,
+}));
+
+vi.mock('react-hot-toast', () => ({
+    default: {
+        success: vi.fn(),
+        error: vi.fn()
+    }
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return { ...actual as any, useNavigate: () => mockNavigate };
+});
+
+const renderTab = () =>
+    render(<BrowserRouter><ProfileDraftsTab /></BrowserRouter>);
+
+describe('ProfileDraftsTab', () => {
+    let store: Record<string, string> = {};
+
+    beforeEach(() => {
+        store = {};
+        mockNavigate.mockClear();
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation((key) => store[key] || null);
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation((key, value) => { store[key] = value; });
+        vi.spyOn(Storage.prototype, 'removeItem').mockImplementation((key) => { delete store[key]; });
+        vi.spyOn(Storage.prototype, 'key').mockImplementation((index) => Object.keys(store)[index] || null);
+        Object.defineProperty(Storage.prototype, 'length', {
+            configurable: true,
+            get: () => Object.keys(store).length,
+        });
+    });
+
+    it('renders heading and shows empty state when no drafts', () => {
+        renderTab();
+        expect(screen.getByText('Unsaved Drafts')).toBeInTheDocument();
+        expect(screen.getByText('No drafts found')).toBeInTheDocument();
+    });
+
+    it('lists drafts from localStorage correctly', () => {
+        store['draft_directory_listing'] = JSON.stringify({
+            name: 'Seaside Cafe',
+            updatedAt: new Date().toISOString()
+        });
+        store['draft_property_listing'] = JSON.stringify({
+            title: 'Indie Villa',
+            updatedAt: new Date().toISOString()
+        });
+        store['draft_service_listing'] = JSON.stringify({
+            formData: { title: 'Limo Service' },
+            updatedAt: new Date().toISOString()
+        });
+        store['draft_admin_directory_listing_123'] = JSON.stringify({
+            formData: { name: 'Dentist Pro' },
+            updatedAt: new Date().toISOString()
+        });
+
+        renderTab();
+
+        expect(screen.getByText('Seaside Cafe')).toBeInTheDocument();
+        expect(screen.getByText('Indie Villa')).toBeInTheDocument();
+        expect(screen.getByText('Limo Service')).toBeInTheDocument();
+        expect(screen.getByText('Dentist Pro')).toBeInTheDocument();
+    });
+
+    it('navigates to resume editing when Resume button is clicked', () => {
+        store['draft_property_listing'] = JSON.stringify({
+            title: 'Indie Villa',
+            updatedAt: new Date().toISOString()
+        });
+
+        renderTab();
+
+        const resumeBtn = screen.getByText('Resume');
+        fireEvent.click(resumeBtn);
+
+        expect(mockNavigate).toHaveBeenCalledWith('/list-property');
+    });
+
+    it('discards draft when Discard icon is clicked', () => {
+        store['draft_property_listing'] = JSON.stringify({
+            title: 'Indie Villa',
+            updatedAt: new Date().toISOString()
+        });
+
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        renderTab();
+
+        const discardBtn = screen.getByTitle('Discard draft');
+        fireEvent.click(discardBtn);
+
+        expect(store['draft_property_listing']).toBeUndefined();
+        expect(screen.getByText('No drafts found')).toBeInTheDocument();
+    });
+});

--- a/components/user/profile/ProfileDraftsTab.tsx
+++ b/components/user/profile/ProfileDraftsTab.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Home, MapPin, Car, Briefcase, FileText, Trash2, Edit3 } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { useLanguage } from '../../../context/LanguageContext';
 
 interface DraftItem {
     key: string;
@@ -12,87 +11,74 @@ interface DraftItem {
     link: string;
 }
 
+const DRAFT_CONFIG = [
+    {
+        key: 'draft_directory_listing',
+        type: 'directory' as const,
+        titleField: (data: any) => data.name || 'Untitled Directory Listing',
+        link: '/add-listing',
+    },
+    {
+        key: 'draft_property_listing',
+        type: 'property' as const,
+        titleField: (data: any) => data.title || 'Untitled Property Listing',
+        link: '/list-property',
+    },
+    {
+        key: 'draft_service_listing',
+        type: 'service' as const,
+        titleField: (data: any) => data.formData?.title || 'Untitled Service Listing',
+        link: '/add-service',
+    },
+] as const;
+
 export const ProfileDraftsTab: React.FC = () => {
-    const { t } = useLanguage();
     const navigate = useNavigate();
     const [drafts, setDrafts] = useState<DraftItem[]>([]);
 
     const loadDrafts = () => {
         const foundDrafts: DraftItem[] = [];
 
-        // 1. Directory creation draft
-        const dir = localStorage.getItem('draft_directory_listing');
-        if (dir) {
-            try {
-                const parsed = JSON.parse(dir);
-                foundDrafts.push({
-                    key: 'draft_directory_listing',
-                    type: 'directory',
-                    title: parsed.name || 'Untitled Directory Listing',
-                    updatedAt: parsed.updatedAt,
-                    link: '/add-listing'
-                });
-            } catch (e) {
-                console.error(e);
+        // Load fixed-key drafts
+        DRAFT_CONFIG.forEach(config => {
+            const data = localStorage.getItem(config.key);
+            if (data) {
+                try {
+                    const parsed = JSON.parse(data);
+                    foundDrafts.push({
+                        key: config.key,
+                        type: config.type,
+                        title: config.titleField(parsed),
+                        updatedAt: parsed.updatedAt,
+                        link: config.link,
+                    });
+                } catch (e) {
+                    console.error(e);
+                }
             }
-        }
+        });
 
-        // 2. Property creation draft
-        const prop = localStorage.getItem('draft_property_listing');
-        if (prop) {
-            try {
-                const parsed = JSON.parse(prop);
-                foundDrafts.push({
-                    key: 'draft_property_listing',
-                    type: 'property',
-                    title: parsed.title || 'Untitled Property Listing',
-                    updatedAt: parsed.updatedAt,
-                    link: '/list-property'
-                });
-            } catch (e) {
-                console.error(e);
-            }
-        }
-
-        // 3. Service creation draft
-        const serv = localStorage.getItem('draft_service_listing');
-        if (serv) {
-            try {
-                const parsed = JSON.parse(serv);
-                foundDrafts.push({
-                    key: 'draft_service_listing',
-                    type: 'service',
-                    title: parsed.formData?.title || 'Untitled Service Listing',
-                    updatedAt: parsed.updatedAt,
-                    link: '/add-service'
-                });
-            } catch (e) {
-                console.error(e);
-            }
-        }
-
-        // 4. Admin directory edit drafts
-        for (let i = 0; i < localStorage.length; i++) {
-            const key = localStorage.key(i);
-            if (key && key.startsWith('draft_admin_directory_listing_')) {
-                const listing = localStorage.getItem(key);
-                if (listing) {
+        // Load admin directory edit drafts
+        Object.keys(localStorage).forEach(key => {
+            if (key.startsWith('draft_admin_directory_listing_')) {
+                const data = localStorage.getItem(key);
+                if (data) {
                     try {
-                        const parsed = JSON.parse(listing);
+                        const parsed = JSON.parse(data);
                         const id = key.replace('draft_admin_directory_listing_', '');
                         foundDrafts.push({
                             key,
                             type: 'admin_directory_edit',
                             title: parsed.formData?.name || 'Untitled Edit Listing',
                             updatedAt: parsed.updatedAt,
-                            link: `/admin/directory/${id}`
+                            link: `/admin/directory/${id}`,
                         });
                     } catch (e) {
                         console.error(e);
                     }
                 }
             }
-        }
+        });
 
         // Sort by updatedAt descending
         foundDrafts.sort((a, b) => {

--- a/components/user/profile/ProfileDraftsTab.tsx
+++ b/components/user/profile/ProfileDraftsTab.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Home, MapPin, Car, Briefcase, FileText, Trash2, Edit3 } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { useLanguage } from '../../../context/LanguageContext';
+
+interface DraftItem {
+    key: string;
+    type: 'directory' | 'property' | 'service' | 'admin_directory_edit';
+    title: string;
+    updatedAt: string;
+    link: string;
+}
+
+export const ProfileDraftsTab: React.FC = () => {
+    const { t } = useLanguage();
+    const navigate = useNavigate();
+    const [drafts, setDrafts] = useState<DraftItem[]>([]);
+
+    const loadDrafts = () => {
+        const foundDrafts: DraftItem[] = [];
+
+        // 1. Directory creation draft
+        const dir = localStorage.getItem('draft_directory_listing');
+        if (dir) {
+            try {
+                const parsed = JSON.parse(dir);
+                foundDrafts.push({
+                    key: 'draft_directory_listing',
+                    type: 'directory',
+                    title: parsed.name || 'Untitled Directory Listing',
+                    updatedAt: parsed.updatedAt,
+                    link: '/add-listing'
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        // 2. Property creation draft
+        const prop = localStorage.getItem('draft_property_listing');
+        if (prop) {
+            try {
+                const parsed = JSON.parse(prop);
+                foundDrafts.push({
+                    key: 'draft_property_listing',
+                    type: 'property',
+                    title: parsed.title || 'Untitled Property Listing',
+                    updatedAt: parsed.updatedAt,
+                    link: '/list-property'
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        // 3. Service creation draft
+        const serv = localStorage.getItem('draft_service_listing');
+        if (serv) {
+            try {
+                const parsed = JSON.parse(serv);
+                foundDrafts.push({
+                    key: 'draft_service_listing',
+                    type: 'service',
+                    title: parsed.formData?.title || 'Untitled Service Listing',
+                    updatedAt: parsed.updatedAt,
+                    link: '/add-service'
+                });
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
+        // 4. Admin directory edit drafts
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key && key.startsWith('draft_admin_directory_listing_')) {
+                const listing = localStorage.getItem(key);
+                if (listing) {
+                    try {
+                        const parsed = JSON.parse(listing);
+                        const id = key.replace('draft_admin_directory_listing_', '');
+                        foundDrafts.push({
+                            key,
+                            type: 'admin_directory_edit',
+                            title: parsed.formData?.name || 'Untitled Edit Listing',
+                            updatedAt: parsed.updatedAt,
+                            link: `/admin/directory/${id}`
+                        });
+                    } catch (e) {
+                        console.error(e);
+                    }
+                }
+            }
+        }
+
+        // Sort by updatedAt descending
+        foundDrafts.sort((a, b) => {
+            const dateA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+            const dateB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+            return dateB - dateA;
+        });
+
+        setDrafts(foundDrafts);
+    };
+
+    useEffect(() => {
+        loadDrafts();
+    }, []);
+
+    const handleDiscard = (key: string, e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (window.confirm('Are you sure you want to discard this draft? All unsaved progress will be permanently lost.')) {
+            localStorage.removeItem(key);
+            toast.success('Draft discarded successfully');
+            loadDrafts();
+        }
+    };
+
+    const getDraftIcon = (type: string) => {
+        switch (type) {
+            case 'directory':
+                return <MapPin className="text-teal-600 dark:text-teal-400" size={22} />;
+            case 'property':
+                return <Home className="text-indigo-600 dark:text-indigo-400" size={22} />;
+            case 'service':
+                return <Car className="text-emerald-600 dark:text-emerald-400" size={22} />;
+            default:
+                return <Briefcase className="text-slate-600 dark:text-slate-400" size={22} />;
+        }
+    };
+
+    const getDraftLabel = (type: string) => {
+        switch (type) {
+            case 'directory':
+                return 'Directory Listing';
+            case 'property':
+                return 'Property Rental';
+            case 'service':
+                return 'Service Listing';
+            case 'admin_directory_edit':
+                return 'Directory Edit (Admin)';
+            default:
+                return 'Draft';
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h2 className="text-2xl font-serif font-bold text-slate-900 dark:text-white">Unsaved Drafts</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                    Your local creation and editing drafts saved automatically on this device.
+                </p>
+            </div>
+
+            {drafts.length === 0 ? (
+                <div className="bg-white dark:bg-slate-800/80 rounded-3xl shadow-sm p-12 text-center border-2 border-dashed border-slate-100 dark:border-slate-800/50">
+                    <FileText size={48} className="mx-auto text-slate-200 dark:text-slate-600 mb-4" />
+                    <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-1">No drafts found</h3>
+                    <p className="text-sm text-slate-500 dark:text-slate-400 max-w-sm mx-auto">
+                        Your progress will automatically save here as you write directory listings, stays, or services.
+                    </p>
+                </div>
+            ) : (
+                <div className="grid gap-4">
+                    {drafts.map((draft) => (
+                        <div
+                            key={draft.key}
+                            onClick={() => navigate(draft.link)}
+                            className="bg-white dark:bg-slate-800/80 rounded-2xl p-5 shadow-sm border border-slate-100 dark:border-slate-800/50 flex items-center justify-between hover:shadow-md hover:border-teal-500/20 dark:hover:border-teal-500/20 transition-all duration-300 group cursor-pointer"
+                        >
+                            <div className="flex items-center gap-4">
+                                <div className="p-3 bg-slate-50 dark:bg-slate-900 rounded-xl group-hover:scale-105 transition-transform">
+                                    {getDraftIcon(draft.type)}
+                                </div>
+                                <div className="text-left">
+                                    <span className="inline-block text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-0.5">
+                                        {getDraftLabel(draft.type)}
+                                    </span>
+                                    <h4 className="text-base font-bold text-slate-900 dark:text-white group-hover:text-teal-600 dark:group-hover:text-teal-400 transition-colors">
+                                        {draft.title}
+                                    </h4>
+                                    <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+                                        Saved {draft.updatedAt ? new Date(draft.updatedAt).toLocaleString() : 'recently'}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={(e) => handleDiscard(draft.key, e)}
+                                    title="Discard draft"
+                                    className="p-2.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-xl transition-all active:scale-95"
+                                >
+                                    <Trash2 size={16} />
+                                </button>
+                                <button
+                                    onClick={() => navigate(draft.link)}
+                                    className="flex items-center gap-1.5 bg-slate-50 hover:bg-teal-50 dark:bg-slate-900 dark:hover:bg-teal-950/30 text-slate-700 hover:text-teal-600 dark:text-slate-300 dark:hover:text-teal-400 px-3.5 py-2 rounded-xl text-xs font-semibold transition-all active:scale-95 border border-slate-100 dark:border-slate-800/50"
+                                >
+                                    <Edit3 size={12} />
+                                    Resume
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/components/user/profile/ProfileDraftsTab.tsx
+++ b/components/user/profile/ProfileDraftsTab.tsx
@@ -59,8 +59,9 @@ export const ProfileDraftsTab: React.FC = () => {
         });
 
         // Load admin directory edit drafts
-        Object.keys(localStorage).forEach(key => {
-            if (key.startsWith('draft_admin_directory_listing_')) {
+        for (let i = 0; i < localStorage.length; i++) {
+            const key = localStorage.key(i);
+            if (key && key.startsWith('draft_admin_directory_listing_')) {
                 const data = localStorage.getItem(key);
                 if (data) {
                     try {
@@ -78,7 +79,7 @@ export const ProfileDraftsTab: React.FC = () => {
                     }
                 }
             }
-        });
+        }
 
         // Sort by updatedAt descending
         foundDrafts.sort((a, b) => {

--- a/components/user/profile/ProfileSidebar.tsx
+++ b/components/user/profile/ProfileSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Camera, Grid, Home, Car, Banknote, Settings, Shield, LogOut, Globe, Instagram, Facebook, Video, Music } from 'lucide-react';
+import { Camera, Grid, Home, Car, Banknote, Settings, Shield, LogOut, Globe, Instagram, Facebook, Video, Music, FileText } from 'lucide-react';
 import { useLanguage } from '../../../context/LanguageContext';
 import { SocialLinks } from '../../../types/models';
 
@@ -133,6 +133,13 @@ export const ProfileSidebar: React.FC<ProfileSidebarProps> = ({
                     </>
                 )}
 
+                <button
+                    onClick={() => setActiveTab('drafts')}
+                    className={`w-full flex items-center gap-3 px-6 py-4 text-left transition-colors ${activeTab === 'drafts' ? 'bg-primary/5 text-primary border-l-4 border-primary' : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700/80'}`}
+                >
+                    <FileText size={20} />
+                    <span className="font-medium">Drafts</span>
+                </button>
                 <button
                     onClick={() => setActiveTab('settings')}
                     className={`w-full flex items-center gap-3 px-6 py-4 text-left transition-colors ${activeTab === 'settings' ? 'bg-primary/5 text-primary border-l-4 border-primary' : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-700/80'}`}

--- a/deno.lock
+++ b/deno.lock
@@ -63,6 +63,7 @@
     "npm:vite-plugin-eslint@^1.8.1": "1.8.1_eslint@9.39.4_vite@6.4.3__@types+node@22.20.0__tsx@4.22.4_@types+node@22.20.0_tsx@4.22.4",
     "npm:vite@^6.2.0": "6.4.3_@types+node@22.20.0_tsx@4.22.4",
     "npm:vitest@^4.0.17": "4.1.9_@types+node@22.20.0_@vitest+coverage-v8@4.1.9_jsdom@27.4.0_vite@6.4.3__@types+node@22.20.0__tsx@4.22.4_tsx@4.22.4",
+    "npm:zod@3": "3.25.76",
     "npm:zod@^4.3.6": "4.4.3"
   },
   "jsr": {

--- a/hooks/useDraftSave.ts
+++ b/hooks/useDraftSave.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect, useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { isDraftContentEmpty } from '../utils/drafts';
+
+interface UseDraftSaveOptions<T = unknown> {
+  storageKey: string;
+  formData: T;
+  excludeKeys?: readonly string[];
+  onRestore?: (data: T) => void;
+  dependencies: unknown[];
+}
+
+export function useDraftSave<T = unknown>({
+  storageKey,
+  formData,
+  excludeKeys = [],
+  onRestore,
+  dependencies,
+}: UseDraftSaveOptions<T>) {
+  const [savedDraft, setSavedDraft] = useState<T | null>(null);
+  const showRestoreBanner = savedDraft !== null;
+
+  const hasContent = useCallback(
+    (data: T) => !isDraftContentEmpty(data as Record<string, unknown>, excludeKeys),
+    [excludeKeys]
+  );
+
+  // Load draft on mount
+  useEffect(() => {
+    const draftStr = localStorage.getItem(storageKey);
+    if (draftStr) {
+      try {
+        const parsed = JSON.parse(draftStr);
+        if (parsed && typeof parsed === 'object' && hasContent(parsed)) {
+          setSavedDraft(parsed);
+        }
+      } catch (e) {
+        console.error(`Failed to parse draft from ${storageKey}:`, e);
+      }
+    }
+  }, [storageKey, hasContent]);
+
+  // Save draft on formData change
+  useEffect(() => {
+    if (hasContent(formData)) {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          ...formData,
+          updatedAt: new Date().toISOString(),
+        })
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...dependencies, storageKey]);
+
+  const handleRestoreDraft = () => {
+    if (savedDraft) {
+      const { updatedAt: _, ...rest } = savedDraft as Record<string, unknown>;
+      onRestore?.(rest as T);
+      toast.success('Unsaved progress restored!');
+    }
+    setSavedDraft(null);
+  };
+
+  const handleDiscardDraft = () => {
+    localStorage.removeItem(storageKey);
+    setSavedDraft(null);
+    toast.success('Draft discarded');
+  };
+
+  return {
+    showRestoreBanner,
+    handleRestoreDraft,
+    handleDiscardDraft,
+  };
+}

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -872,4 +872,11 @@ export const ar = {
     'directory.claim.modal.success.next.step3': 'ستحصل على صلاحية تعديل بيانات نشاطك في أي وقت',
     'directory.claim.modal.success.next.step4': 'ستنشر تعديلاتك مباشرة بعد المراجعة',
     'directory.claim.modal.close': 'إغلاق',
+
+    // Recently Claimed Section
+    'home.recently_claimed.title': 'المطالب بها مؤخراً',
+    'home.recently_claimed.subtitle': 'الشركات المحلية التي قامت مؤخراً بالتحقق من ملكيتها وتحديث معلوماتها',
+    'home.recently_claimed.badge': 'تم التحقق من المجتمع',
+    'home.recently_claimed.view_all': 'عرض الكل',
+    'home.recently_claimed.empty': 'لا توجد قوائم مطالب بها بعد',
 };

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -933,4 +933,11 @@ export const en = {
   'directory.claim.modal.success.next.step3': 'You\'ll get access to edit your listing anytime',
   'directory.claim.modal.success.next.step4': 'Your changes will go live immediately after review',
   'directory.claim.modal.close': 'Close',
+
+  // Recently Claimed Section
+  'home.recently_claimed.title': 'Recently Claimed',
+  'home.recently_claimed.subtitle': 'Local businesses that recently verified their ownership and updated their listings',
+  'home.recently_claimed.badge': 'Community Verified',
+  'home.recently_claimed.view_all': 'View all',
+  'home.recently_claimed.empty': 'No claimed listings yet.',
 };

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -924,4 +924,11 @@ export const ru = {
   'directory.claim.modal.success.next.step3': 'Вы получите доступ к редактированию компании в любое время',
   'directory.claim.modal.success.next.step4': 'Ваши изменения будут опубликованы сразу после проверки',
   'directory.claim.modal.close': 'Закрыть',
+
+  // Recently Claimed Section
+  'home.recently_claimed.title': 'Недавно подтвержденные',
+  'home.recently_claimed.subtitle': 'Местные компании, которые недавно подтвердили право собственности и обновили информацию',
+  'home.recently_claimed.badge': 'Подтверждено сообществом',
+  'home.recently_claimed.view_all': 'Посмотреть все',
+  'home.recently_claimed.empty': 'Пока нет подтвержденных компаний',
 };

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -924,4 +924,11 @@ export const tr = {
     'directory.claim.modal.success.next.step3': 'İstediğiniz zaman işletme bilgilerinizi düzenleme yetkisi alacaksınız',
     'directory.claim.modal.success.next.step4': 'Değişiklikleriniz incelemeden hemen sonra yayına girecektir',
     'directory.claim.modal.close': 'Kapat',
+
+    // Recently Claimed Section
+    'home.recently_claimed.title': 'Yakın Zamanda Sahiplenilenler',
+    'home.recently_claimed.subtitle': 'Sahipliğini yakın zamanda doğrulayan ve bilgilerini güncelleyen yerel işletmeler',
+    'home.recently_claimed.badge': 'Topluluk Doğrulamalı',
+    'home.recently_claimed.view_all': 'Tümünü Gör',
+    'home.recently_claimed.empty': 'Henüz sahiplenilen işletme yok',
 };

--- a/pages/AddListingPage.tsx
+++ b/pages/AddListingPage.tsx
@@ -259,6 +259,38 @@ export const AddListingPage: React.FC = () => {
                         </div>
                     )}
 
+                    {showRestoreBanner && (
+                        <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
+                            <div className="flex items-start gap-3 w-full sm:w-auto">
+                                <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
+                                    <Sparkles size={20} />
+                                </div>
+                                <div className="text-left">
+                                    <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
+                                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                        We saved your progress from {savedDraft && (savedDraft as any).updatedAt ? new Date((savedDraft as any).updatedAt).toLocaleString() : 'recently'}.
+                                    </p>
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
+                                <button
+                                    type="button"
+                                    onClick={handleDiscardDraft}
+                                    className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
+                                >
+                                    Discard
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleRestoreDraft}
+                                    className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
+                                >
+                                    Restore Draft
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
                     <StepsIndicator
                         currentStep={step}
                         totalSteps={2}

--- a/pages/AddListingPage.tsx
+++ b/pages/AddListingPage.tsx
@@ -1,12 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
-import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon, Sparkles } from 'lucide-react';
+import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
 import { StepsIndicator } from '../components/ui/StepsIndicator';
 import { PhotoUploader } from '../components/ui/PhotoUploader';
+import { RestoreDraftBanner } from '../components/ui/RestoreDraftBanner';
 import { db } from '../api-services';
 import { useLanguage } from '../context/LanguageContext';
+import { useDraftSave } from '../hooks/useDraftSave';
+import { DRAFT_KEYS } from '../utils/drafts';
 
 interface FormData {
     name: string;
@@ -62,59 +65,12 @@ export const AddListingPage: React.FC = () => {
     });
     const [gallery, setGallery] = useState<File[]>([]);
 
-    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
-    const [savedDraft, setSavedDraft] = useState<FormData | null>(null);
-
-    // Load draft on mount
-    useEffect(() => {
-        const draftStr = localStorage.getItem('draft_directory_listing');
-        if (draftStr) {
-            try {
-                const parsed = JSON.parse(draftStr);
-                if (parsed && typeof parsed === 'object') {
-                    const hasContent = Object.entries(parsed).some(
-                        ([key, val]) => key !== 'updatedAt' && typeof val === 'string' && val.trim().length > 0
-                    );
-                    if (hasContent) {
-                        setSavedDraft(parsed);
-                        setShowRestoreBanner(true);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to parse draft:', e);
-            }
-        }
-    }, []);
-
-    // Save draft on formData change
-    useEffect(() => {
-        const hasContent = Object.values(formData).some((val) => typeof val === 'string' && val.trim().length > 0);
-        if (hasContent) {
-            localStorage.setItem(
-                'draft_directory_listing',
-                JSON.stringify({
-                    ...formData,
-                    updatedAt: new Date().toISOString(),
-                })
-            );
-        }
-    }, [formData]);
-
-    const handleRestoreDraft = () => {
-        if (savedDraft) {
-            // Strip out updatedAt before setting form data
-            const { updatedAt: _, ...rest } = savedDraft as any;
-            setFormData(rest);
-            toast.success('Unsaved progress restored!');
-        }
-        setShowRestoreBanner(false);
-    };
-
-    const handleDiscardDraft = () => {
-        localStorage.removeItem('draft_directory_listing');
-        setShowRestoreBanner(false);
-        toast.success('Draft discarded');
-    };
+    const { showRestoreBanner, handleRestoreDraft, handleDiscardDraft } = useDraftSave({
+        storageKey: DRAFT_KEYS.directory_listing,
+        formData,
+        onRestore: (data) => setFormData(data as FormData),
+        dependencies: [formData],
+    });
 
     // Detect subscription tier on mount
     useEffect(() => {
@@ -260,35 +216,7 @@ export const AddListingPage: React.FC = () => {
                     )}
 
                     {showRestoreBanner && (
-                        <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
-                            <div className="flex items-start gap-3 w-full sm:w-auto">
-                                <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
-                                    <Sparkles size={20} />
-                                </div>
-                                <div className="text-left">
-                                    <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
-                                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                        We saved your progress from {savedDraft && (savedDraft as any).updatedAt ? new Date((savedDraft as any).updatedAt).toLocaleString() : 'recently'}.
-                                    </p>
-                                </div>
-                            </div>
-                            <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
-                                <button
-                                    type="button"
-                                    onClick={handleDiscardDraft}
-                                    className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
-                                >
-                                    Discard
-                                </button>
-                                <button
-                                    type="button"
-                                    onClick={handleRestoreDraft}
-                                    className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
-                                >
-                                    Restore Draft
-                                </button>
-                            </div>
-                        </div>
+                        <RestoreDraftBanner onRestore={handleRestoreDraft} onDiscard={handleDiscardDraft} />
                     )}
 
                     <StepsIndicator

--- a/pages/AddListingPage.tsx
+++ b/pages/AddListingPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
-import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon } from 'lucide-react';
+import { ArrowLeft, CheckCircle, MapPin, Globe, MessageCircle, Link as LinkIcon, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
 import { StepsIndicator } from '../components/ui/StepsIndicator';
@@ -61,6 +61,60 @@ export const AddListingPage: React.FC = () => {
         google_map_url: '',
     });
     const [gallery, setGallery] = useState<File[]>([]);
+
+    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+    const [savedDraft, setSavedDraft] = useState<FormData | null>(null);
+
+    // Load draft on mount
+    useEffect(() => {
+        const draftStr = localStorage.getItem('draft_directory_listing');
+        if (draftStr) {
+            try {
+                const parsed = JSON.parse(draftStr);
+                if (parsed && typeof parsed === 'object') {
+                    const hasContent = Object.entries(parsed).some(
+                        ([key, val]) => key !== 'updatedAt' && typeof val === 'string' && val.trim().length > 0
+                    );
+                    if (hasContent) {
+                        setSavedDraft(parsed);
+                        setShowRestoreBanner(true);
+                    }
+                }
+            } catch (e) {
+                console.error('Failed to parse draft:', e);
+            }
+        }
+    }, []);
+
+    // Save draft on formData change
+    useEffect(() => {
+        const hasContent = Object.values(formData).some((val) => typeof val === 'string' && val.trim().length > 0);
+        if (hasContent) {
+            localStorage.setItem(
+                'draft_directory_listing',
+                JSON.stringify({
+                    ...formData,
+                    updatedAt: new Date().toISOString(),
+                })
+            );
+        }
+    }, [formData]);
+
+    const handleRestoreDraft = () => {
+        if (savedDraft) {
+            // Strip out updatedAt before setting form data
+            const { updatedAt: _, ...rest } = savedDraft as any;
+            setFormData(rest);
+            toast.success('Unsaved progress restored!');
+        }
+        setShowRestoreBanner(false);
+    };
+
+    const handleDiscardDraft = () => {
+        localStorage.removeItem('draft_directory_listing');
+        setShowRestoreBanner(false);
+        toast.success('Draft discarded');
+    };
 
     // Detect subscription tier on mount
     useEffect(() => {
@@ -128,6 +182,7 @@ export const AddListingPage: React.FC = () => {
                 base_score: 0,
             });
 
+            localStorage.removeItem('draft_directory_listing');
             setSubmitted(true);
             window.scrollTo({ top: 0, behavior: 'smooth' });
         } catch (err) {

--- a/pages/AddService.tsx
+++ b/pages/AddService.tsx
@@ -2,13 +2,16 @@ import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../context/LanguageContext';
 import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
-import { ArrowLeft, Sparkles } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { CAR_DESCRIPTIONS, DEFAULT_DESCRIPTION } from '../data/cars';
 import { AddServiceCategoryStep, ServiceCategory } from '../components/host/services/AddServiceCategoryStep';
 import { AddServiceFormStep } from '../components/host/services/AddServiceFormStep';
 import { AddServiceSuccessStep } from '../components/host/services/AddServiceSuccessStep';
 import { SEOHead } from '../components/seo/SEOHead';
+import { RestoreDraftBanner } from '../components/ui/RestoreDraftBanner';
+import { useDraftSave } from '../hooks/useDraftSave';
+import { DRAFT_KEYS, EXCLUDE_KEYS } from '../utils/drafts';
 
 type ServiceType = 'car' | 'bike' | 'transfer' | 'tour' | 'visa' | 'esim' | 'wellness' | 'creative';
 
@@ -63,87 +66,18 @@ export const AddService: React.FC = () => {
     const [files, setFiles] = useState<File[]>([]);
     const [itinerary, setItinerary] = useState<ItineraryItem[]>([{ time: '09:00', description: 'Start' }]);
 
-    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
-    const [savedDraft, setSavedDraft] = useState<any>(null);
-
-    // Load draft on mount
-    useEffect(() => {
-        const draftStr = localStorage.getItem('draft_service_listing');
-        if (draftStr) {
-            try {
-                const parsed = JSON.parse(draftStr);
-                if (parsed && typeof parsed === 'object') {
-                    const hasContent = Object.entries(parsed.formData || {}).some(
-                        ([key, val]) =>
-                            key !== 'type' &&
-                            key !== 'vehicleType' &&
-                            key !== 'transmission' &&
-                            key !== 'fuel' &&
-                            key !== 'seats' &&
-                            key !== 'modelSelection' &&
-                            key !== 'difficulty' &&
-                            key !== 'subcategory' &&
-                            key !== 'year' &&
-                            ((typeof val === 'string' && val.trim().length > 0) ||
-                                (typeof val === 'number' && val > 0) ||
-                                (typeof val === 'boolean' && val))
-                    );
-                    if (hasContent) {
-                        setSavedDraft(parsed);
-                        setShowRestoreBanner(true);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to parse draft:', e);
-            }
-        }
-    }, []);
-
-    // Save draft on formData/category/step change
-    useEffect(() => {
-        const hasContent = Object.entries(formData).some(
-            ([key, val]) =>
-                key !== 'type' &&
-                key !== 'vehicleType' &&
-                key !== 'transmission' &&
-                key !== 'fuel' &&
-                key !== 'seats' &&
-                key !== 'modelSelection' &&
-                key !== 'difficulty' &&
-                key !== 'subcategory' &&
-                key !== 'year' &&
-                ((typeof val === 'string' && val.trim().length > 0) ||
-                    (typeof val === 'number' && val > 0) ||
-                    (typeof val === 'boolean' && val))
-        );
-        if (hasContent) {
-            localStorage.setItem(
-                'draft_service_listing',
-                JSON.stringify({
-                    formData,
-                    category,
-                    step,
-                    updatedAt: new Date().toISOString(),
-                })
-            );
-        }
-    }, [formData, category, step]);
-
-    const handleRestoreDraft = () => {
-        if (savedDraft) {
-            if (savedDraft.formData) setFormData(savedDraft.formData);
-            if (savedDraft.category !== undefined) setCategory(savedDraft.category);
-            if (savedDraft.step !== undefined) setStep(savedDraft.step);
-            toast.success('Unsaved progress restored!');
-        }
-        setShowRestoreBanner(false);
-    };
-
-    const handleDiscardDraft = () => {
-        localStorage.removeItem('draft_service_listing');
-        setShowRestoreBanner(false);
-        toast.success('Draft discarded');
-    };
+    const draftWrapper = { formData, category, step };
+    const { showRestoreBanner, handleRestoreDraft, handleDiscardDraft } = useDraftSave({
+        storageKey: DRAFT_KEYS.service_listing,
+        formData: draftWrapper,
+        excludeKeys: EXCLUDE_KEYS.service,
+        onRestore: (data) => {
+            if (data.formData) setFormData(data.formData);
+            if (data.category !== undefined) setCategory(data.category);
+            if (data.step !== undefined) setStep(data.step);
+        },
+        dependencies: [formData, category, step],
+    });
 
     // Auto-fill description when popular model changes
     useEffect(() => {
@@ -167,7 +101,7 @@ export const AddService: React.FC = () => {
         setFormData({ ...formData, [e.target.name]: e.target.value });
     };
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         if (!user) return;
 
@@ -251,35 +185,7 @@ export const AddService: React.FC = () => {
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-12 px-4">
             <div className="max-w-3xl mx-auto">
                 {showRestoreBanner && (
-                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
-                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
-                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
-                                <Sparkles size={20} />
-                            </div>
-                            <div>
-                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
-                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                    We saved your progress from {savedDraft && savedDraft.updatedAt ? new Date(savedDraft.updatedAt).toLocaleString() : 'recently'}.
-                                </p>
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
-                            <button
-                                type="button"
-                                onClick={handleDiscardDraft}
-                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
-                            >
-                                Discard
-                            </button>
-                            <button
-                                type="button"
-                                onClick={handleRestoreDraft}
-                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
-                            >
-                                Restore Draft
-                            </button>
-                        </div>
-                    </div>
+                    <RestoreDraftBanner onRestore={handleRestoreDraft} onDiscard={handleDiscardDraft} />
                 )}
                 {/* Header */}
                 <div className="flex items-center gap-4 mb-8">

--- a/pages/AddService.tsx
+++ b/pages/AddService.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../context/LanguageContext';
 import { useAuth } from '../context/AuthContext';
 import { db } from '../api-services';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Sparkles } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { CAR_DESCRIPTIONS, DEFAULT_DESCRIPTION } from '../data/cars';
 import { AddServiceCategoryStep, ServiceCategory } from '../components/host/services/AddServiceCategoryStep';
@@ -62,6 +62,88 @@ export const AddService: React.FC = () => {
 
     const [files, setFiles] = useState<File[]>([]);
     const [itinerary, setItinerary] = useState<ItineraryItem[]>([{ time: '09:00', description: 'Start' }]);
+
+    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+    const [savedDraft, setSavedDraft] = useState<any>(null);
+
+    // Load draft on mount
+    useEffect(() => {
+        const draftStr = localStorage.getItem('draft_service_listing');
+        if (draftStr) {
+            try {
+                const parsed = JSON.parse(draftStr);
+                if (parsed && typeof parsed === 'object') {
+                    const hasContent = Object.entries(parsed.formData || {}).some(
+                        ([key, val]) =>
+                            key !== 'type' &&
+                            key !== 'vehicleType' &&
+                            key !== 'transmission' &&
+                            key !== 'fuel' &&
+                            key !== 'seats' &&
+                            key !== 'modelSelection' &&
+                            key !== 'difficulty' &&
+                            key !== 'subcategory' &&
+                            key !== 'year' &&
+                            ((typeof val === 'string' && val.trim().length > 0) ||
+                                (typeof val === 'number' && val > 0) ||
+                                (typeof val === 'boolean' && val))
+                    );
+                    if (hasContent) {
+                        setSavedDraft(parsed);
+                        setShowRestoreBanner(true);
+                    }
+                }
+            } catch (e) {
+                console.error('Failed to parse draft:', e);
+            }
+        }
+    }, []);
+
+    // Save draft on formData/category/step change
+    useEffect(() => {
+        const hasContent = Object.entries(formData).some(
+            ([key, val]) =>
+                key !== 'type' &&
+                key !== 'vehicleType' &&
+                key !== 'transmission' &&
+                key !== 'fuel' &&
+                key !== 'seats' &&
+                key !== 'modelSelection' &&
+                key !== 'difficulty' &&
+                key !== 'subcategory' &&
+                key !== 'year' &&
+                ((typeof val === 'string' && val.trim().length > 0) ||
+                    (typeof val === 'number' && val > 0) ||
+                    (typeof val === 'boolean' && val))
+        );
+        if (hasContent) {
+            localStorage.setItem(
+                'draft_service_listing',
+                JSON.stringify({
+                    formData,
+                    category,
+                    step,
+                    updatedAt: new Date().toISOString(),
+                })
+            );
+        }
+    }, [formData, category, step]);
+
+    const handleRestoreDraft = () => {
+        if (savedDraft) {
+            if (savedDraft.formData) setFormData(savedDraft.formData);
+            if (savedDraft.category !== undefined) setCategory(savedDraft.category);
+            if (savedDraft.step !== undefined) setStep(savedDraft.step);
+            toast.success('Unsaved progress restored!');
+        }
+        setShowRestoreBanner(false);
+    };
+
+    const handleDiscardDraft = () => {
+        localStorage.removeItem('draft_service_listing');
+        setShowRestoreBanner(false);
+        toast.success('Draft discarded');
+    };
 
     // Auto-fill description when popular model changes
     useEffect(() => {
@@ -149,6 +231,7 @@ export const AddService: React.FC = () => {
                 promotion_price: formData.promotionPrice ? parseFloat(formData.promotionPrice) : undefined,
                 promotion_description: formData.promotionDescription
             });
+            localStorage.removeItem('draft_service_listing');
             setStep(2);
         } catch (error) {
             console.error(error);
@@ -167,6 +250,37 @@ export const AddService: React.FC = () => {
         <SEOHead title="Add Service | Alanya Holidays" noIndex />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-12 px-4">
             <div className="max-w-3xl mx-auto">
+                {showRestoreBanner && (
+                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
+                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
+                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
+                                <Sparkles size={20} />
+                            </div>
+                            <div>
+                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
+                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                    We saved your progress from {savedDraft && savedDraft.updatedAt ? new Date(savedDraft.updatedAt).toLocaleString() : 'recently'}.
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
+                            <button
+                                type="button"
+                                onClick={handleDiscardDraft}
+                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
+                            >
+                                Discard
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleRestoreDraft}
+                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
+                            >
+                                Restore Draft
+                            </button>
+                        </div>
+                    </div>
+                )}
                 {/* Header */}
                 <div className="flex items-center gap-4 mb-8">
                     {step > 0 && (

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -14,6 +14,7 @@ import { PremiumListingsSection } from '../components/home/PremiumListingsSectio
 import { FreeListingsSection } from '../components/home/FreeListingsSection';
 import { SignatureListingsSection } from '../components/home/SignatureListingsSection';
 import { TravelGuideSection } from '../components/home/TravelGuideSection';
+import { RecentlyClaimedSection } from '../components/home/RecentlyClaimedSection';
 
 export const DirectoryHome: React.FC = () => {
     const { t } = useLanguage();
@@ -37,6 +38,7 @@ export const DirectoryHome: React.FC = () => {
     const [premiumListings, setPremiumListings] = useState<DirectoryListingDB[]>([]);
     const [freeListings, setFreeListings] = useState<DirectoryListingDB[]>([]);
     const [signatureListings, setSignatureListings] = useState<DirectoryListingDB[]>([]);
+    const [recentlyClaimedListings, setRecentlyClaimedListings] = useState<DirectoryListingDB[]>([]);
     const [testimonials, setTestimonials] = useState<any[]>([]);
     const [dbLocations, setDbLocations] = useState<string[]>([]);
     const [listingsLoading, setListingsLoading] = useState(true);
@@ -46,10 +48,11 @@ export const DirectoryHome: React.FC = () => {
         async function loadListings() {
             setListingsLoading(true);
             try {
-                const [premium, free, signatures, tests, locs] = await Promise.all([
+                const [premium, free, signatures, recentlyClaimed, tests, locs] = await Promise.all([
                     db.getPremiumListings(),
                     db.getFreeListings(),
                     db.getSignatureListings(),
+                    db.getRecentlyClaimedListings(6),
                     db.getPublicTestimonials(),
                     db.getLocations(),
                 ]);
@@ -57,6 +60,7 @@ export const DirectoryHome: React.FC = () => {
                     setPremiumListings(premium);
                     setFreeListings(free);
                     setSignatureListings(signatures);
+                    setRecentlyClaimedListings(recentlyClaimed);
                     setTestimonials(tests);
                     setDbLocations(locs.map(l => l.name));
                 }
@@ -363,6 +367,8 @@ export const DirectoryHome: React.FC = () => {
             )}
 
             <PremiumListingsSection listings={premiumListings} loading={listingsLoading} />
+
+            <RecentlyClaimedSection listings={recentlyClaimedListings} loading={listingsLoading} />
 
             {/* Travel Guide / Featured Blog Posts */}
             <TravelGuideSection />

--- a/pages/DirectoryListingPage.tsx
+++ b/pages/DirectoryListingPage.tsx
@@ -15,6 +15,7 @@ import { VideoEmbed } from '../components/ui/VideoEmbed';
 import { ListingReviewSection } from '../components/directory/ListingReviewSection';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
 import { useLanguage } from '../context/LanguageContext';
+import { useAuth } from '../context/AuthContext';
 import { ClaimListingModal } from '../components/directory/ClaimListingModal';
 
 interface DirectoryListingPageProps {
@@ -25,11 +26,20 @@ export const DirectoryListingPage: React.FC<DirectoryListingPageProps> = ({ cate
     const { slug } = useParams<{ slug: string }>();
     const navigate = useNavigate();
     const { t } = useLanguage();
+    const { user } = useAuth();
 
     const [listing, setListing] = useState<DirectoryListingDB | null>(null);
     const [related, setRelated] = useState<DirectoryListingDB[]>([]);
     const [loading, setLoading] = useState(true);
     const [isClaimModalOpen, setIsClaimModalOpen] = useState(false);
+
+    const handleClaimClick = () => {
+        if (!user) {
+            navigate(`/login?returnUrl=${encodeURIComponent(window.location.pathname)}`);
+            return;
+        }
+        setIsClaimModalOpen(true);
+    };
 
     const categoryIntro = directoryCategoryIntros[categoryId];
     const categoryPath = CATEGORY_PATHS[categoryId] || '/';
@@ -353,7 +363,7 @@ export const DirectoryListingPage: React.FC<DirectoryListingPageProps> = ({ cate
 
                                 {!listing.owner_user_id && (
                                     <button
-                                        onClick={() => setIsClaimModalOpen(true)}
+                                        onClick={handleClaimClick}
                                         className="w-full flex items-center justify-center gap-2 py-3 px-4 font-semibold rounded-xl border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-teal-500 dark:hover:border-cyan-500 hover:text-teal-600 dark:hover:text-cyan-400 transition-all cursor-pointer"
                                     >
                                         <Award size={18} className="text-teal-600 dark:text-cyan-400" /> {t('directory.claim.button')}

--- a/pages/ListProperty.tsx
+++ b/pages/ListProperty.tsx
@@ -6,7 +6,7 @@ import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
 import { PropertyFormData, PropertyDB } from '../types/models';
 import toast from 'react-hot-toast';
-import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Sparkles } from 'lucide-react';
 import { useSubmitShortcut } from '../hooks/useSubmitShortcut';
 import { Button } from '../components/ui/Button';
 import { SEOHead } from '../components/seo/SEOHead';
@@ -80,7 +80,72 @@ export const ListProperty: React.FC = () => {
         promotionDescription: '',
         icalUrl: ''
     });
+    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+    const [savedDraft, setSavedDraft] = useState<PropertyFormData | null>(null);
 
+    // Load draft on mount
+    React.useEffect(() => {
+        const draftStr = localStorage.getItem('draft_property_listing');
+        if (draftStr) {
+            try {
+                const parsed = JSON.parse(draftStr);
+                if (parsed && typeof parsed === 'object') {
+                    const hasContent = Object.entries(parsed).some(
+                        ([key, val]) =>
+                            key !== 'updatedAt' &&
+                            ((typeof val === 'string' && val.trim().length > 0) ||
+                                (typeof val === 'number' && val > 0) ||
+                                (Array.isArray(val) && val.length > 0))
+                    );
+                    if (hasContent) {
+                        setSavedDraft(parsed);
+                        setShowRestoreBanner(true);
+                    }
+                }
+            } catch (e) {
+                console.error('Failed to parse draft:', e);
+            }
+        }
+    }, []);
+
+    // Save draft on formData change
+    React.useEffect(() => {
+        const hasContent = Object.entries(formData).some(
+            ([key, val]) =>
+                key !== 'maxGuests' &&
+                key !== 'bedrooms' &&
+                key !== 'beds' &&
+                key !== 'bathrooms' &&
+                key !== 'pricePerNight' &&
+                ((typeof val === 'string' && val.trim().length > 0) ||
+                    (typeof val === 'number' && val > 0) ||
+                    (Array.isArray(val) && val.length > 0))
+        );
+        if (hasContent) {
+            localStorage.setItem(
+                'draft_property_listing',
+                JSON.stringify({
+                    ...formData,
+                    updatedAt: new Date().toISOString(),
+                })
+            );
+        }
+    }, [formData]);
+
+    const handleRestoreDraft = () => {
+        if (savedDraft) {
+            const { updatedAt: _, ...rest } = savedDraft as any;
+            setFormData(rest);
+            toast.success('Unsaved progress restored!');
+        }
+        setShowRestoreBanner(false);
+    };
+
+    const handleDiscardDraft = () => {
+        localStorage.removeItem('draft_property_listing');
+        setShowRestoreBanner(false);
+        toast.success('Draft discarded');
+    };
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
         setFormData(prev => ({ ...prev, [name]: value }));
@@ -150,6 +215,7 @@ export const ListProperty: React.FC = () => {
                 status: 'pending'
             });
 
+            localStorage.removeItem('draft_property_listing');
             setIsSuccess(true);
             window.scrollTo(0, 0);
         } catch (error) {
@@ -199,6 +265,37 @@ export const ListProperty: React.FC = () => {
         />
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-10 px-4 transition-colors">
             <div className="max-w-3xl mx-auto">
+                {showRestoreBanner && (
+                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
+                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
+                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
+                                <Sparkles size={20} />
+                            </div>
+                            <div>
+                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
+                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                    We saved your progress from {savedDraft && (savedDraft as any).updatedAt ? new Date((savedDraft as any).updatedAt).toLocaleString() : 'recently'}.
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
+                            <button
+                                type="button"
+                                onClick={handleDiscardDraft}
+                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
+                            >
+                                Discard
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleRestoreDraft}
+                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
+                            >
+                                Restore Draft
+                            </button>
+                        </div>
+                    </div>
+                )}
                 <div className="mb-8">
                     <StepsIndicator currentStep={step} totalSteps={STEPS.length} labels={STEPS.map(s => t(s))} />
                 </div>

--- a/pages/ListProperty.tsx
+++ b/pages/ListProperty.tsx
@@ -6,10 +6,13 @@ import { db } from '../api-services';
 import { useNavigate } from 'react-router-dom';
 import { PropertyFormData, PropertyDB } from '../types/models';
 import toast from 'react-hot-toast';
-import { ArrowLeft, ArrowRight, Sparkles } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { useSubmitShortcut } from '../hooks/useSubmitShortcut';
 import { Button } from '../components/ui/Button';
 import { SEOHead } from '../components/seo/SEOHead';
+import { RestoreDraftBanner } from '../components/ui/RestoreDraftBanner';
+import { useDraftSave } from '../hooks/useDraftSave';
+import { DRAFT_KEYS, EXCLUDE_KEYS } from '../utils/drafts';
 
 // UI Components
 import { StepsIndicator } from '../components/ui/StepsIndicator';
@@ -80,72 +83,13 @@ export const ListProperty: React.FC = () => {
         promotionDescription: '',
         icalUrl: ''
     });
-    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
-    const [savedDraft, setSavedDraft] = useState<PropertyFormData | null>(null);
-
-    // Load draft on mount
-    React.useEffect(() => {
-        const draftStr = localStorage.getItem('draft_property_listing');
-        if (draftStr) {
-            try {
-                const parsed = JSON.parse(draftStr);
-                if (parsed && typeof parsed === 'object') {
-                    const hasContent = Object.entries(parsed).some(
-                        ([key, val]) =>
-                            key !== 'updatedAt' &&
-                            ((typeof val === 'string' && val.trim().length > 0) ||
-                                (typeof val === 'number' && val > 0) ||
-                                (Array.isArray(val) && val.length > 0))
-                    );
-                    if (hasContent) {
-                        setSavedDraft(parsed);
-                        setShowRestoreBanner(true);
-                    }
-                }
-            } catch (e) {
-                console.error('Failed to parse draft:', e);
-            }
-        }
-    }, []);
-
-    // Save draft on formData change
-    React.useEffect(() => {
-        const hasContent = Object.entries(formData).some(
-            ([key, val]) =>
-                key !== 'maxGuests' &&
-                key !== 'bedrooms' &&
-                key !== 'beds' &&
-                key !== 'bathrooms' &&
-                key !== 'pricePerNight' &&
-                ((typeof val === 'string' && val.trim().length > 0) ||
-                    (typeof val === 'number' && val > 0) ||
-                    (Array.isArray(val) && val.length > 0))
-        );
-        if (hasContent) {
-            localStorage.setItem(
-                'draft_property_listing',
-                JSON.stringify({
-                    ...formData,
-                    updatedAt: new Date().toISOString(),
-                })
-            );
-        }
-    }, [formData]);
-
-    const handleRestoreDraft = () => {
-        if (savedDraft) {
-            const { updatedAt: _, ...rest } = savedDraft as any;
-            setFormData(rest);
-            toast.success('Unsaved progress restored!');
-        }
-        setShowRestoreBanner(false);
-    };
-
-    const handleDiscardDraft = () => {
-        localStorage.removeItem('draft_property_listing');
-        setShowRestoreBanner(false);
-        toast.success('Draft discarded');
-    };
+    const { showRestoreBanner, handleRestoreDraft, handleDiscardDraft } = useDraftSave({
+        storageKey: DRAFT_KEYS.property_listing,
+        formData,
+        excludeKeys: EXCLUDE_KEYS.property,
+        onRestore: (data) => setFormData(data as PropertyFormData),
+        dependencies: [formData],
+    });
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
         setFormData(prev => ({ ...prev, [name]: value }));
@@ -266,35 +210,7 @@ export const ListProperty: React.FC = () => {
         <div className="min-h-screen bg-slate-50 dark:bg-slate-900 py-10 px-4 transition-colors">
             <div className="max-w-3xl mx-auto">
                 {showRestoreBanner && (
-                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
-                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
-                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
-                                <Sparkles size={20} />
-                            </div>
-                            <div>
-                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
-                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                    We saved your progress from {savedDraft && (savedDraft as any).updatedAt ? new Date((savedDraft as any).updatedAt).toLocaleString() : 'recently'}.
-                                </p>
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
-                            <button
-                                type="button"
-                                onClick={handleDiscardDraft}
-                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
-                            >
-                                Discard
-                            </button>
-                            <button
-                                type="button"
-                                onClick={handleRestoreDraft}
-                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
-                            >
-                                Restore Draft
-                            </button>
-                        </div>
-                    </div>
+                    <RestoreDraftBanner onRestore={handleRestoreDraft} onDiscard={handleDiscardDraft} />
                 )}
                 <div className="mb-8">
                     <StepsIndicator currentStep={step} totalSteps={STEPS.length} labels={STEPS.map(s => t(s))} />

--- a/pages/Profile.tsx
+++ b/pages/Profile.tsx
@@ -13,6 +13,7 @@ import { ProfileServicesTab } from '../components/user/profile/ProfileServicesTa
 import { ProfileSettingsTab } from '../components/user/profile/ProfileSettingsTab';
 import { ProfileSecurityTab } from '../components/user/profile/ProfileSecurityTab';
 import { ProfilePayoutTab } from '../components/user/profile/ProfilePayoutTab';
+import { ProfileDraftsTab } from '../components/user/profile/ProfileDraftsTab';
 import { SEOHead } from '../components/seo/SEOHead';
 
 export const Profile: React.FC = () => {
@@ -27,7 +28,7 @@ export const Profile: React.FC = () => {
     const [loading, setLoading] = useState(true);
 
     // UI State
-    const [activeTab, setActiveTab] = useState<'overview' | 'my_properties' | 'my_services' | 'payouts' | 'settings' | 'security'>('overview');
+    const [activeTab, setActiveTab] = useState<'overview' | 'my_properties' | 'my_services' | 'payouts' | 'settings' | 'security' | 'drafts'>('overview');
     const [uploading, setUploading] = useState(false);
     const [isHostModalOpen, setIsHostModalOpen] = useState(false);
     const fileInputRef = React.useRef<HTMLInputElement>(null);
@@ -345,6 +346,10 @@ export const Profile: React.FC = () => {
                                 savingPayout={savingPayout}
                                 handleUpdatePayout={handleUpdatePayout}
                             />
+                        )}
+
+                        {activeTab === 'drafts' && (
+                            <ProfileDraftsTab />
                         )}
                     </div>
                 </div>

--- a/pages/VerifyClaimPage.tsx
+++ b/pages/VerifyClaimPage.tsx
@@ -21,7 +21,11 @@ export const VerifyClaimPage: React.FC = () => {
             }
 
             try {
-                await db.verifyClaimEmail(token);
+                const result = await db.verifyClaimEmail(token);
+                if (!result) {
+                    setStatus('error');
+                    return;
+                }
                 setStatus('success');
             } catch (err) {
                 console.error('Error verifying claim email:', err);

--- a/pages/VerifyClaimPage.tsx
+++ b/pages/VerifyClaimPage.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { db } from '../api-services';
+import { useLanguage } from '../context/LanguageContext';
+
+type VerificationStatus = 'loading' | 'success' | 'error';
+
+export const VerifyClaimPage: React.FC = () => {
+    const [searchParams] = useSearchParams();
+    const { t } = useLanguage();
+    const [status, setStatus] = useState<VerificationStatus>('loading');
+
+    useEffect(() => {
+        const verifyToken = async () => {
+            const token = searchParams.get('token');
+
+            if (!token) {
+                setStatus('error');
+                return;
+            }
+
+            try {
+                await db.verifyClaimEmail(token);
+                setStatus('success');
+            } catch (err) {
+                console.error('Error verifying claim email:', err);
+                setStatus('error');
+            }
+        };
+
+        verifyToken();
+    }, [searchParams]);
+
+    return (
+        <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center p-4">
+            <div className="w-full max-w-md">
+                {status === 'loading' && (
+                    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 text-center">
+                        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-teal-600 dark:border-cyan-400 mx-auto mb-6" />
+                        <p className="text-slate-600 dark:text-slate-300">{t('common.verifying') || 'Verifying your email...'}</p>
+                    </div>
+                )}
+
+                {status === 'success' && (
+                    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 text-center">
+                        <div className="flex justify-center mb-6">
+                            <div className="bg-green-100 dark:bg-green-900/30 rounded-full p-4">
+                                <CheckCircle size={48} className="text-green-600 dark:text-green-400" />
+                            </div>
+                        </div>
+                        <h1 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+                            {t('directory.claim.verified') || 'Email Verified!'}
+                        </h1>
+                        <p className="text-slate-600 dark:text-slate-300 mb-8">
+                            {t('directory.claim.verifiedMessage') || 'Your email has been verified. Your claim is now pending admin review.'}
+                        </p>
+                        <Link
+                            to="/"
+                            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-teal-600 dark:bg-cyan-500 text-white font-semibold rounded-xl hover:bg-teal-700 dark:hover:bg-cyan-600 transition-all"
+                        >
+                            {t('common.backHome') || 'Back to Home'}
+                        </Link>
+                    </div>
+                )}
+
+                {status === 'error' && (
+                    <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 text-center">
+                        <div className="flex justify-center mb-6">
+                            <div className="bg-red-100 dark:bg-red-900/30 rounded-full p-4">
+                                <XCircle size={48} className="text-red-600 dark:text-red-400" />
+                            </div>
+                        </div>
+                        <h1 className="text-2xl font-bold text-slate-900 dark:text-white mb-3">
+                            {t('directory.claim.verificationFailed') || 'Verification Failed'}
+                        </h1>
+                        <p className="text-slate-600 dark:text-slate-300 mb-8">
+                            {t('directory.claim.verificationFailedMessage') || 'The verification link is invalid or has expired. Please try claiming the listing again.'}
+                        </p>
+                        <Link
+                            to="/"
+                            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-teal-600 dark:bg-cyan-500 text-white font-semibold rounded-xl hover:bg-teal-700 dark:hover:bg-cyan-600 transition-all"
+                        >
+                            {t('common.backHome') || 'Back to Home'}
+                        </Link>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/pages/admin/AdminAddBlogPostPage.tsx
+++ b/pages/admin/AdminAddBlogPostPage.tsx
@@ -12,11 +12,12 @@ export const AdminAddBlogPostPage: React.FC = () => {
     const { user } = useAuth();
     const navigate = useNavigate();
 
-    const [title, setTitle] = useState('');
+        const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
     const [videoUrl, setVideoUrl] = useState('');
     const [isFeatured, setIsFeatured] = useState(false);
     const [submitting, setSubmitting] = useState(false);
+    const [targetStatus, setTargetStatus] = useState<'published' | 'draft'>('published');
 
     const {
         mediaFiles,
@@ -53,20 +54,20 @@ export const AdminAddBlogPostPage: React.FC = () => {
 
             const formattedContent = formatBlogContent(content.trim(), uploadedUrls);
 
-            const toastId = toast.loading('Publishing blog post...');
+            const toastId = toast.loading(targetStatus === 'published' ? 'Publishing blog post...' : 'Saving draft...');
             await db.createBlogPost({
                 title: title.trim(),
                 content: formattedContent,
                 video_url: videoUrl.trim() || undefined,
                 cover_image_url: uploadedUrls[0] || undefined,
-                status: 'published',
+                status: targetStatus,
                 is_featured: isFeatured,
             });
 
-            toast.success('Blog post published successfully!', { id: toastId });
+            toast.success(targetStatus === 'published' ? 'Blog post published successfully!' : 'Draft saved successfully!', { id: toastId });
             navigate('/admin/blog-submissions');
         } catch (err: unknown) {
-            toast.error(err instanceof Error ? err.message : 'Failed to publish post');
+            toast.error(err instanceof Error ? err.message : 'Failed to save post');
         } finally {
             setSubmitting(false);
         }
@@ -212,9 +213,18 @@ export const AdminAddBlogPostPage: React.FC = () => {
                     </label>
                 </div>
 
-                <div className="flex justify-end pt-4">
+                <div className="flex justify-end gap-3 pt-4">
                     <button
                         type="submit"
+                        onClick={() => setTargetStatus('draft')}
+                        disabled={isSubmitting}
+                        className="flex items-center gap-2 bg-slate-100 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-200 px-6 py-3 rounded-xl font-semibold transition-colors disabled:opacity-50"
+                    >
+                        Save as Draft
+                    </button>
+                    <button
+                        type="submit"
+                        onClick={() => setTargetStatus('published')}
                         disabled={isSubmitting}
                         className="flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded-xl font-semibold transition-colors disabled:opacity-50"
                     >

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -9,6 +9,7 @@ import toast from 'react-hot-toast';
 import { DirectoryListingDB, DirectoryListingCreateInput, LocationDB } from '../../types/models';
 import { slugify } from '../../utils/slugify';
 import { RestoreDraftBanner } from '../../components/ui/RestoreDraftBanner';
+import { useDraftSave } from '../../hooks/useDraftSave';
 
 import { BasicDetailsForm } from '../../components/admin/directory/BasicDetailsForm';
 import { ContactLocationForm } from '../../components/admin/directory/ContactLocationForm';
@@ -61,8 +62,26 @@ export const AdminEditDirectoryPage: React.FC = () => {
     const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>([]);
     const [availableLocations, setAvailableLocations] = useState<LocationDB[]>([]);
 
-    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
-    const [savedDraft, setSavedDraft] = useState<any>(null);
+    const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
+    const draftWrapper = { formData, descriptions, languages, certifications, selectedLocationIds };
+
+    const { showRestoreBanner, handleRestoreDraft: baseRestore, handleDiscardDraft } = useDraftSave({
+        storageKey: draftKey,
+        formData: draftWrapper,
+        onRestore: (data: any) => {
+            if (data.formData) setFormData(data.formData);
+            if (data.descriptions) setDescriptions(data.descriptions);
+            if (data.languages) setLanguages(data.languages);
+            if (data.certifications) setCertifications(data.certifications);
+            if (data.selectedLocationIds) setSelectedLocationIds(data.selectedLocationIds);
+        },
+        dependencies: [formData, descriptions, languages, certifications, selectedLocationIds, id, isEditing],
+    });
+
+    const handleRestoreDraft = () => {
+        baseRestore();
+        toast.success('Unsaved progress restored!');
+    };
 
     const loadListing = useCallback(async () => {
         try {
@@ -98,20 +117,6 @@ export const AdminEditDirectoryPage: React.FC = () => {
                 setSelectedLocationIds(
                     listing.listing_locations?.map(ll => ll.location_id) ?? []
                 );
-
-                // Check for draft edit listing
-                const draftStr = localStorage.getItem(`draft_admin_directory_listing_${id}`);
-                if (draftStr) {
-                    try {
-                        const parsed = JSON.parse(draftStr);
-                        if (parsed && typeof parsed === 'object') {
-                            setSavedDraft(parsed);
-                            setShowRestoreBanner(true);
-                        }
-                    } catch (e) {
-                        console.error('Failed to parse draft:', e);
-                    }
-                }
             }
         } catch (error) {
             console.error(error);
@@ -125,57 +130,6 @@ export const AdminEditDirectoryPage: React.FC = () => {
             loadListing();
         }
     }, [isEditing, loadListing]);
-
-    useEffect(() => {
-        if (!isEditing) {
-            const draftStr = localStorage.getItem('draft_admin_directory_listing_new');
-            if (draftStr) {
-                try {
-                    const parsed = JSON.parse(draftStr);
-                    if (parsed && typeof parsed === 'object') {
-                        setSavedDraft(parsed);
-                        setShowRestoreBanner(true);
-                    }
-                } catch (e) {
-                    console.error('Failed to parse draft:', e);
-                }
-            }
-        }
-    }, [isEditing]);
-
-    useEffect(() => {
-        const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
-        const hasContent = formData.name.trim().length > 0 || formData.short_description.trim().length > 0;
-        if (hasContent) {
-            localStorage.setItem(draftKey, JSON.stringify({
-                formData,
-                descriptions,
-                languages,
-                certifications,
-                selectedLocationIds,
-                updatedAt: new Date().toISOString()
-            }));
-        }
-    }, [formData, descriptions, languages, certifications, selectedLocationIds, id, isEditing]);
-
-    const handleRestoreDraft = () => {
-        if (savedDraft) {
-            if (savedDraft.formData) setFormData(savedDraft.formData);
-            if (savedDraft.descriptions) setDescriptions(savedDraft.descriptions);
-            if (savedDraft.languages) setLanguages(savedDraft.languages);
-            if (savedDraft.certifications) setCertifications(savedDraft.certifications);
-            if (savedDraft.selectedLocationIds) setSelectedLocationIds(savedDraft.selectedLocationIds);
-            toast.success('Unsaved progress restored!');
-        }
-        setShowRestoreBanner(false);
-    };
-
-    const handleDiscardDraft = () => {
-        const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
-        localStorage.removeItem(draftKey);
-        setShowRestoreBanner(false);
-        toast.success('Draft discarded');
-    };
 
     useEffect(() => {
         db.getLocations()

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { db } from '../../api-services';
 import { supabase } from '../../api-services/supabase';
-import { ArrowLeft, Save, Sparkles, Check } from 'lucide-react';
+import { ArrowLeft, Save, Check, Sparkles } from 'lucide-react';
 import { useSaveShortcut } from '../../hooks/useSaveShortcut';
 import { parseVideoEmbed } from '../../utils/videoEmbed';
 import toast from 'react-hot-toast';
 import { DirectoryListingDB, DirectoryListingCreateInput, LocationDB } from '../../types/models';
 import { slugify } from '../../utils/slugify';
+import { RestoreDraftBanner } from '../../components/ui/RestoreDraftBanner';
 
 import { BasicDetailsForm } from '../../components/admin/directory/BasicDetailsForm';
 import { ContactLocationForm } from '../../components/admin/directory/ContactLocationForm';
@@ -230,7 +231,7 @@ Example: {"en": "...", "tr": "...", "ru": "...", "ar": "..."}`;
 
             const validation = listingDescriptionsSchema.safeParse(parsed);
             if (!validation.success) {
-                console.error('AI response validation failed:', validation.error.flatten());
+                console.error('AI response validation failed:', validation.error);
                 throw new Error('AI response format was unexpected. Please try again.');
             }
 
@@ -280,7 +281,7 @@ Example: {"en": "...", "tr": "...", "ru": "...", "ar": "..."}`;
         setExistingImages(existingImages.filter((_, i) => i !== index));
     };
 
-    const handleSubmit = async (e?: React.FormEvent) => {
+    const handleSubmit = async (e?: React.FormEvent<HTMLFormElement>) => {
         if (e) e.preventDefault();
         setSubmitting(true);
 
@@ -376,35 +377,7 @@ Example: {"en": "...", "tr": "...", "ru": "...", "ar": "..."}`;
 
             <main className="max-w-5xl mx-auto px-4 py-8">
                 {showRestoreBanner && (
-                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
-                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
-                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
-                                <Sparkles size={20} />
-                            </div>
-                            <div>
-                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
-                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                                    We saved your progress from {savedDraft && savedDraft.updatedAt ? new Date(savedDraft.updatedAt).toLocaleString() : 'recently'}.
-                                </p>
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
-                            <button
-                                type="button"
-                                onClick={handleDiscardDraft}
-                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
-                            >
-                                Discard
-                            </button>
-                            <button
-                                type="button"
-                                onClick={handleRestoreDraft}
-                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
-                            >
-                                Restore Draft
-                            </button>
-                        </div>
-                    </div>
+                    <RestoreDraftBanner onRestore={handleRestoreDraft} onDiscard={handleDiscardDraft} />
                 )}
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
                     {/* Left Column - Main Info */}

--- a/pages/admin/AdminEditDirectoryPage.tsx
+++ b/pages/admin/AdminEditDirectoryPage.tsx
@@ -60,6 +60,9 @@ export const AdminEditDirectoryPage: React.FC = () => {
     const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>([]);
     const [availableLocations, setAvailableLocations] = useState<LocationDB[]>([]);
 
+    const [showRestoreBanner, setShowRestoreBanner] = useState(false);
+    const [savedDraft, setSavedDraft] = useState<any>(null);
+
     const loadListing = useCallback(async () => {
         try {
             const listing = await db.getDirectoryListing(id!);
@@ -94,6 +97,20 @@ export const AdminEditDirectoryPage: React.FC = () => {
                 setSelectedLocationIds(
                     listing.listing_locations?.map(ll => ll.location_id) ?? []
                 );
+
+                // Check for draft edit listing
+                const draftStr = localStorage.getItem(`draft_admin_directory_listing_${id}`);
+                if (draftStr) {
+                    try {
+                        const parsed = JSON.parse(draftStr);
+                        if (parsed && typeof parsed === 'object') {
+                            setSavedDraft(parsed);
+                            setShowRestoreBanner(true);
+                        }
+                    } catch (e) {
+                        console.error('Failed to parse draft:', e);
+                    }
+                }
             }
         } catch (error) {
             console.error(error);
@@ -107,6 +124,57 @@ export const AdminEditDirectoryPage: React.FC = () => {
             loadListing();
         }
     }, [isEditing, loadListing]);
+
+    useEffect(() => {
+        if (!isEditing) {
+            const draftStr = localStorage.getItem('draft_admin_directory_listing_new');
+            if (draftStr) {
+                try {
+                    const parsed = JSON.parse(draftStr);
+                    if (parsed && typeof parsed === 'object') {
+                        setSavedDraft(parsed);
+                        setShowRestoreBanner(true);
+                    }
+                } catch (e) {
+                    console.error('Failed to parse draft:', e);
+                }
+            }
+        }
+    }, [isEditing]);
+
+    useEffect(() => {
+        const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
+        const hasContent = formData.name.trim().length > 0 || formData.short_description.trim().length > 0;
+        if (hasContent) {
+            localStorage.setItem(draftKey, JSON.stringify({
+                formData,
+                descriptions,
+                languages,
+                certifications,
+                selectedLocationIds,
+                updatedAt: new Date().toISOString()
+            }));
+        }
+    }, [formData, descriptions, languages, certifications, selectedLocationIds, id, isEditing]);
+
+    const handleRestoreDraft = () => {
+        if (savedDraft) {
+            if (savedDraft.formData) setFormData(savedDraft.formData);
+            if (savedDraft.descriptions) setDescriptions(savedDraft.descriptions);
+            if (savedDraft.languages) setLanguages(savedDraft.languages);
+            if (savedDraft.certifications) setCertifications(savedDraft.certifications);
+            if (savedDraft.selectedLocationIds) setSelectedLocationIds(savedDraft.selectedLocationIds);
+            toast.success('Unsaved progress restored!');
+        }
+        setShowRestoreBanner(false);
+    };
+
+    const handleDiscardDraft = () => {
+        const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
+        localStorage.removeItem(draftKey);
+        setShowRestoreBanner(false);
+        toast.success('Draft discarded');
+    };
 
     useEffect(() => {
         db.getLocations()
@@ -263,6 +331,8 @@ Example: {"en": "...", "tr": "...", "ru": "...", "ar": "..."}`;
                 await db.createDirectoryListing(listingData, effectiveLocationIds);
                 toast.success('Listing created successfully');
             }
+            const draftKey = isEditing ? `draft_admin_directory_listing_${id}` : 'draft_admin_directory_listing_new';
+            localStorage.removeItem(draftKey);
 
             navigate('/admin/directory');
         } catch (error: unknown) {
@@ -305,6 +375,37 @@ Example: {"en": "...", "tr": "...", "ru": "...", "ar": "..."}`;
             </div>
 
             <main className="max-w-5xl mx-auto px-4 py-8">
+                {showRestoreBanner && (
+                    <div className="mb-8 bg-teal-50/80 dark:bg-teal-900/20 backdrop-blur-md border border-teal-200 dark:border-teal-800/50 rounded-2xl p-5 flex flex-col sm:flex-row items-center justify-between gap-4 shadow-sm animate-in fade-in slide-in-from-top-4 duration-300">
+                        <div className="flex items-start gap-3 w-full sm:w-auto text-left">
+                            <div className="p-2 bg-teal-100 dark:bg-teal-950 text-teal-600 dark:text-teal-400 rounded-xl">
+                                <Sparkles size={20} />
+                            </div>
+                            <div>
+                                <h4 className="text-sm font-bold text-slate-900 dark:text-white">Unsaved draft found</h4>
+                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                                    We saved your progress from {savedDraft && savedDraft.updatedAt ? new Date(savedDraft.updatedAt).toLocaleString() : 'recently'}.
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-3 w-full sm:w-auto justify-end">
+                            <button
+                                type="button"
+                                onClick={handleDiscardDraft}
+                                className="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-800 rounded-xl transition-all"
+                            >
+                                Discard
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleRestoreDraft}
+                                className="px-4 py-2 text-xs font-semibold bg-teal-600 hover:bg-teal-700 text-white rounded-xl transition-all shadow-md shadow-teal-600/10 active:scale-95"
+                            >
+                                Restore Draft
+                            </button>
+                        </div>
+                    </div>
+                )}
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
                     {/* Left Column - Main Info */}
                     <div className="lg:col-span-2 space-y-6">

--- a/pages/admin/DirectoryAdminPage.test.tsx
+++ b/pages/admin/DirectoryAdminPage.test.tsx
@@ -26,6 +26,9 @@ vi.mock('../../api-services', () => ({
         createDirectoryListing: vi.fn(),
         approveDirectoryListing: vi.fn(),
         rejectDirectoryListing: vi.fn(),
+        getListingClaims: vi.fn(),
+        approveListingClaim: vi.fn(),
+        rejectListingClaim: vi.fn(),
     }
 }));
 
@@ -45,6 +48,9 @@ describe('DirectoryAdminPage', () => {
         vi.clearAllMocks();
         (db.getDirectoryListingsByStatus as any).mockResolvedValue(mockListings);
         (db.getPendingDirectoryListings as any).mockResolvedValue([]);
+        (db.getListingClaims as any).mockResolvedValue([]);
+        (db.approveListingClaim as any).mockResolvedValue({});
+        (db.rejectListingClaim as any).mockResolvedValue({});
         vi.stubGlobal('confirm', vi.fn(() => true));
     });
 

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -40,6 +40,15 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         message: ''
     });
 
+    const loadClaims = useCallback(async () => {
+        try {
+            const claimsList = await db.getListingClaims();
+            setClaims(claimsList);
+        } catch (e) {
+            console.error('Failed to load claims', e);
+        }
+    }, []);
+
     const loadListings = useCallback(async () => {
         setLoading(true);
         try {
@@ -94,7 +103,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         try {
             await db.approveListingClaim(claimId);
             toast.success('Claim approved');
-            await loadListings();
+            await loadClaims();
         } catch (e: unknown) {
             toast.error(`Failed to approve claim: ${e instanceof Error ? e.message : 'Unknown error'}`);
         }
@@ -109,7 +118,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
             await db.rejectListingClaim(claimId, rejectClaimState.reason.trim());
             toast.success('Claim rejected');
             setRejectClaimState(null);
-            await loadListings();
+            await loadClaims();
         } catch (e: unknown) {
             toast.error(`Failed to reject claim: ${e instanceof Error ? e.message : 'Unknown error'}`);
         }

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -2,25 +2,27 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { db } from '../../api-services';
 import { useNavigate } from 'react-router-dom';
 import { ConfirmationModal } from '../../components/ui/ConfirmationModal';
-import { DirectoryListingDB } from '../../types/models';
+import { DirectoryListingDB, ListingClaimDB } from '../../types/models';
 import { MOCK_DIRECTORY_DATA } from '../../data/directoryData';
 import { DirectoryToolbar } from '../../components/admin/directory/DirectoryToolbar';
 import { DirectoryTable } from '../../components/admin/directory/DirectoryTable';
 import { toast } from 'react-hot-toast';
 import { CheckCircle, XCircle, Clock } from 'lucide-react';
 
-type AdminTab = 'approved' | 'pending' | 'rejected';
+type AdminTab = 'approved' | 'pending' | 'rejected' | 'claims';
 
 export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ defaultCategory }) => {
     const navigate = useNavigate();
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
     const [pendingListings, setPendingListings] = useState<DirectoryListingDB[]>([]);
     const [rejectedListings, setRejectedListings] = useState<DirectoryListingDB[]>([]);
+    const [claims, setClaims] = useState<ListingClaimDB[]>([]);
     const [activeTab, setActiveTab] = useState<AdminTab>('approved');
     const [loading, setLoading] = useState(true);
     const [filterCategory, setFilterCategory] = useState<string>(defaultCategory || 'all');
     const [searchQuery, setSearchQuery] = useState('');
     const [rejectState, setRejectState] = useState<{ id: string; reason: string } | null>(null);
+    const [rejectClaimState, setRejectClaimState] = useState<{ id: string; reason: string } | null>(null);
 
     const isCategoryLocked = !!defaultCategory;
 
@@ -42,14 +44,16 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
         setLoading(true);
         try {
             const category = isCategoryLocked ? defaultCategory : undefined;
-            const [approved, pending, rejected] = await Promise.all([
+            const [approved, pending, rejected, claimsList] = await Promise.all([
                 db.getDirectoryListingsByStatus('approved', category),
                 db.getPendingDirectoryListings(),
                 db.getDirectoryListingsByStatus('rejected', category),
+                db.getListingClaims(),
             ]);
             setListings(approved);
             setPendingListings(pending);
             setRejectedListings(rejected);
+            setClaims(claimsList);
         } catch (e) {
             console.error('Failed to load listings', e);
         } finally {
@@ -83,6 +87,31 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
             await loadListings();
         } catch (e: unknown) {
             toast.error(`Failed to reject: ${e instanceof Error ? e.message : 'Unknown error'}`);
+        }
+    };
+
+    const handleApproveClaim = async (claimId: string) => {
+        try {
+            await db.approveListingClaim(claimId);
+            toast.success('Claim approved');
+            await loadListings();
+        } catch (e: unknown) {
+            toast.error(`Failed to approve claim: ${e instanceof Error ? e.message : 'Unknown error'}`);
+        }
+    };
+
+    const handleRejectClaimSubmit = async (claimId: string) => {
+        if (!rejectClaimState?.reason.trim()) {
+            toast.error('Please provide a rejection reason');
+            return;
+        }
+        try {
+            await db.rejectListingClaim(claimId, rejectClaimState.reason.trim());
+            toast.success('Claim rejected');
+            setRejectClaimState(null);
+            await loadListings();
+        } catch (e: unknown) {
+            toast.error(`Failed to reject claim: ${e instanceof Error ? e.message : 'Unknown error'}`);
         }
     };
 
@@ -172,6 +201,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                     { key: 'approved', label: 'Approved', icon: CheckCircle, count: listings.length },
                     { key: 'pending', label: 'Pending', icon: Clock, count: pendingListings.length },
                     { key: 'rejected', label: 'Rejected', icon: XCircle, count: rejectedListings.length },
+                    { key: 'claims', label: 'Claims', icon: CheckCircle, count: claims.length },
                 ] as const).map(({ key, label, icon: Icon, count }) => (
                     <button
                         key={key}
@@ -305,6 +335,98 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                     onEdit={(id) => navigate(`/admin/directory/${id}`)}
                     onDelete={(id, name) => openActionModal('delete', id, name)}
                 />
+            )}
+
+            {activeTab === 'claims' && (
+                <div className="space-y-4">
+                    {loading ? (
+                        <p className="text-slate-500 text-sm">Loading...</p>
+                    ) : claims.length === 0 ? (
+                        <div className="text-center py-12 text-slate-500">
+                            <CheckCircle size={40} className="mx-auto mb-3 opacity-30" />
+                            <p>No listing claims</p>
+                        </div>
+                    ) : claims.map(claim => (
+                        <div key={claim.id} className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-5">
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="min-w-0">
+                                    <p className="font-semibold text-slate-900 dark:text-white truncate">{claim.business_name}</p>
+                                    <p className="text-sm text-slate-500 mt-0.5">
+                                        Claimed by: <span className="font-mono text-xs">{claim.email}</span>
+                                    </p>
+                                    <div className="flex items-center gap-2 mt-2">
+                                        {claim.email_verified ? (
+                                            <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-semibold bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                                ✓ Email Verified
+                                            </span>
+                                        ) : (
+                                            <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-semibold bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                                                ○ Pending Email
+                                            </span>
+                                        )}
+                                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-semibold bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300">
+                                            {claim.status}
+                                        </span>
+                                    </div>
+                                    <p className="text-xs text-slate-400 mt-2">
+                                        Submitted {claim.created_at ? new Date(claim.created_at).toLocaleDateString() : '—'}
+                                    </p>
+                                </div>
+                            </div>
+
+                            {rejectClaimState?.id === claim.id ? (
+                                <div className="mt-4 space-y-2">
+                                    <textarea
+                                        value={rejectClaimState.reason}
+                                        onChange={e => setRejectClaimState({ id: claim.id, reason: e.target.value })}
+                                        placeholder="Rejection reason (sent to the claimant)..."
+                                        rows={2}
+                                        className="w-full px-3 py-2 text-sm rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-white resize-none focus:ring-2 focus:ring-red-400 outline-none"
+                                    />
+                                    <div className="flex gap-2">
+                                        <button
+                                            onClick={() => handleRejectClaimSubmit(claim.id)}
+                                            className="px-4 py-1.5 text-sm font-medium bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors"
+                                        >
+                                            Confirm Reject
+                                        </button>
+                                        <button
+                                            onClick={() => setRejectClaimState(null)}
+                                            className="px-4 py-1.5 text-sm font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                                        >
+                                            Cancel
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="flex gap-2 mt-4">
+                                    {claim.status === 'pending' && claim.email_verified && (
+                                        <>
+                                            <button
+                                                onClick={() => handleApproveClaim(claim.id)}
+                                                className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium bg-green-500 hover:bg-green-600 text-white rounded-lg transition-colors"
+                                            >
+                                                <CheckCircle size={14} /> Approve
+                                            </button>
+                                            <button
+                                                onClick={() => setRejectClaimState({ id: claim.id, reason: '' })}
+                                                className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium bg-red-50 hover:bg-red-100 text-red-600 dark:bg-red-900/20 dark:hover:bg-red-900/40 dark:text-red-400 rounded-lg transition-colors"
+                                            >
+                                                <XCircle size={14} /> Reject
+                                            </button>
+                                        </>
+                                    )}
+                                    {claim.status === 'rejected' && claim.rejection_reason && (
+                                        <div className="text-sm text-slate-600 dark:text-slate-400 p-3 bg-slate-50 dark:bg-slate-900 rounded-lg">
+                                            <p className="font-semibold text-red-600 dark:text-red-400">Rejection reason:</p>
+                                            <p>{claim.rejection_reason}</p>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    ))}
+                </div>
             )}
 
             <ConfirmationModal

--- a/routes/AppRoutes.tsx
+++ b/routes/AppRoutes.tsx
@@ -62,6 +62,7 @@ const InboxPage = React.lazy(() => import('../pages/InboxPage').then(module => (
 const CreativeServices = React.lazy(() => import('../pages/CreativeServices').then(module => ({ default: module.CreativeServices })));
 const ListingTiersPage = React.lazy(() => import('../pages/ListingTiersPage').then(module => ({ default: module.ListingTiersPage })));
 const SubscribePage = React.lazy(() => import('../pages/SubscribePage').then(module => ({ default: module.SubscribePage })));
+const VerifyClaimPage = React.lazy(() => import('../pages/VerifyClaimPage').then(module => ({ default: module.VerifyClaimPage })));
 const AddListingPage = React.lazy(() => import('../pages/AddListingPage').then(module => ({ default: module.AddListingPage })));
 const DirectoryListingPage = React.lazy(() => import('../pages/DirectoryListingPage').then(module => ({ default: module.DirectoryListingPage })));
 const HiddenGemsPage = React.lazy(() => import('../pages/blog/HiddenGemsPage').then(module => ({ default: module.HiddenGemsPage })));
@@ -566,6 +567,8 @@ export const AppRoutes: React.FC = () => {
                         <AddProduct />
                     </HostRoute>
                 } />
+
+                <Route path="/verify-claim" element={<VerifyClaimPage />} />
 
                 <Route path="*" element={<NotFound />} />
             </Routes>

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -52,6 +52,10 @@ const emailDataSchemas = {
   subscription_cancellation_scheduled: z.object({ name: sOpt, periodEnd: s, link: sOpt }),
   subscription_payment_failed: z.object({ name: sOpt, link: sOpt }),
   subscription_restored: z.object({ name: sOpt, link: sOpt }),
+  listing_claim_verification: z.object({ claimantEmail: s, businessName: s, verificationToken: s }),
+  admin_claim_notification: z.object({ businessName: s, claimantEmail: s, listingId: s }),
+  listing_claim_approved: z.object({ claimantEmail: s, businessName: s }),
+  listing_claim_rejected: z.object({ claimantEmail: s, businessName: s, rejectionReason: s }),
 } as const
 
 type EmailType = keyof typeof emailDataSchemas
@@ -775,6 +779,79 @@ function generateEmailContent(type: string, data: any): { subject: string, html:
                     `,
                     data.link,
                     'View Profile'
+                )
+            };
+
+        // --- Listing Claims ---
+        case 'listing_claim_verification':
+            return {
+                subject: '✅ Verify Your Listing Claim',
+                html: getHtmlTemplate(
+                    'Verify Your Listing',
+                    `
+                    <p style="font-size: 16px;">Hi,</p>
+                    <p>Thank you for claiming <strong>${escapeHtml(data.businessName)}</strong> on Alanya Holidays!</p>
+                    <p>To complete the verification, click the button below to confirm your email address:</p>
+                    <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">Once verified, our team will review your claim and contact you within 24 hours.</p>
+                    `,
+                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/verify-claim?token=${escapeHtml(data.verificationToken)}`,
+                    'Verify Email',
+                    true
+                )
+            };
+
+        case 'admin_claim_notification':
+            return {
+                subject: '🔔 New Listing Claim Pending Review',
+                html: getHtmlTemplate(
+                    'New Claim for Review',
+                    `
+                    <p style="font-size: 16px;">A new listing claim requires your review:</p>
+                    <div class="card">
+                        <div class="info-row"><span class="label">Business Name</span><span class="value">${escapeHtml(data.businessName)}</span></div>
+                        <div class="info-row"><span class="label">Claimant Email</span><span class="value">${escapeHtml(data.claimantEmail)}</span></div>
+                        <div class="info-row"><span class="label">Listing ID</span><span class="value">${escapeHtml(data.listingId)}</span></div>
+                    </div>
+                    <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to the admin panel to review and approve or reject this claim.</p>
+                    `,
+                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/admin/directory`,
+                    'Review Claim'
+                )
+            };
+
+        case 'listing_claim_approved':
+            return {
+                subject: '🎉 Your Listing Claim Has Been Approved!',
+                html: getHtmlTemplate(
+                    'Claim Approved',
+                    `
+                    <p style="font-size: 16px;">Congratulations!</p>
+                    <p>Your claim for <strong>${escapeHtml(data.businessName)}</strong> has been approved by our team. You now own this listing and can manage all details.</p>
+                    <div class="card">
+                        <p style="text-align: center; margin: 0; color: #059669; font-weight: 600;">You are now the owner of this listing.</p>
+                    </div>
+                    <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to your account to view and update your listing.</p>
+                    `,
+                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/directory`,
+                    'View Your Listing'
+                )
+            };
+
+        case 'listing_claim_rejected':
+            return {
+                subject: '⛔ Your Listing Claim Could Not Be Approved',
+                html: getHtmlTemplate(
+                    'Claim Rejected',
+                    `
+                    <p style="font-size: 16px;">Hi,</p>
+                    <p>Unfortunately, your claim for <strong>${escapeHtml(data.businessName)}</strong> could not be approved.</p>
+                    <div class="card">
+                        <div class="info-row"><span class="label">Reason</span><span class="value" style="color:#ef4444">${escapeHtml(data.rejectionReason)}</span></div>
+                    </div>
+                    <p style="text-align: center; color: #64748b; font-size: 14px;">If you believe this is a mistake, please contact us for more information.</p>
+                    `,
+                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/contact`,
+                    'Contact Support'
                 )
             };
 

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -273,8 +273,76 @@ const getHtmlTemplate = (title: string, content: string, actionLink?: string, ac
 </html>
 `;
 
+// ponytail: data-driven claim email templates instead of 4 case statements
+const claimEmailTemplates = {
+  listing_claim_verification: {
+    subject: '✅ Verify Your Listing Claim',
+    title: 'Verify Your Listing',
+    body: (d: any) => `
+      <p style="font-size: 16px;">Hi,</p>
+      <p>Thank you for claiming <strong>${escapeHtml(d.businessName)}</strong> on Alanya Holidays!</p>
+      <p>To complete the verification, click the button below to confirm your email address:</p>
+      <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">Once verified, our team will review your claim and contact you within 24 hours.</p>
+    `,
+    link: (d: any) => `${process.env.SITE_URL || 'https://alanyaholidays.com'}/verify-claim?token=${escapeHtml(d.verificationToken)}`,
+    buttonText: 'Verify Email',
+  },
+  admin_claim_notification: {
+    subject: '🔔 New Listing Claim Pending Review',
+    title: 'New Claim for Review',
+    body: (d: any) => `
+      <p style="font-size: 16px;">A new listing claim requires your review:</p>
+      <div class="card">
+        <div class="info-row"><span class="label">Business Name</span><span class="value">${escapeHtml(d.businessName)}</span></div>
+        <div class="info-row"><span class="label">Claimant Email</span><span class="value">${escapeHtml(d.claimantEmail)}</span></div>
+        <div class="info-row"><span class="label">Listing ID</span><span class="value">${escapeHtml(d.listingId)}</span></div>
+      </div>
+      <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to the admin panel to review and approve or reject this claim.</p>
+    `,
+    link: (_d: any) => `${process.env.SITE_URL || 'https://alanyaholidays.com'}/admin/directory`,
+    buttonText: 'Review Claim',
+  },
+  listing_claim_approved: {
+    subject: '🎉 Your Listing Claim Has Been Approved!',
+    title: 'Claim Approved',
+    body: (d: any) => `
+      <p style="font-size: 16px;">Congratulations!</p>
+      <p>Your claim for <strong>${escapeHtml(d.businessName)}</strong> has been approved by our team. You now own this listing and can manage all details.</p>
+      <div class="card">
+        <p style="text-align: center; margin: 0; color: #059669; font-weight: 600;">You are now the owner of this listing.</p>
+      </div>
+      <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to your account to view and update your listing.</p>
+    `,
+    link: (_d: any) => `${process.env.SITE_URL || 'https://alanyaholidays.com'}/directory`,
+    buttonText: 'View Your Listing',
+  },
+  listing_claim_rejected: {
+    subject: '⛔ Your Listing Claim Could Not Be Approved',
+    title: 'Claim Rejected',
+    body: (d: any) => `
+      <p style="font-size: 16px;">Hi,</p>
+      <p>Unfortunately, your claim for <strong>${escapeHtml(d.businessName)}</strong> could not be approved.</p>
+      <div class="card">
+        <div class="info-row"><span class="label">Reason</span><span class="value" style="color:#ef4444">${escapeHtml(d.rejectionReason)}</span></div>
+      </div>
+      <p style="text-align: center; color: #64748b; font-size: 14px;">If you believe this is a mistake, please contact us for more information.</p>
+    `,
+    link: (_d: any) => `${process.env.SITE_URL || 'https://alanyaholidays.com'}/contact`,
+    buttonText: 'Contact Support',
+  },
+} as const;
+
 function generateEmailContent(type: string, data: any): { subject: string, html: string } {
     const itemLabel = data.itemTypeLabel || 'Property';
+
+    // Handle claim email templates
+    if (type in claimEmailTemplates) {
+      const config = claimEmailTemplates[type as keyof typeof claimEmailTemplates];
+      return {
+        subject: config.subject,
+        html: getHtmlTemplate(config.title, config.body(data), config.link(data), config.buttonText, true),
+      };
+    }
 
     switch (type) {
         // --- Host Notifications ---
@@ -779,79 +847,6 @@ function generateEmailContent(type: string, data: any): { subject: string, html:
                     `,
                     data.link,
                     'View Profile'
-                )
-            };
-
-        // --- Listing Claims ---
-        case 'listing_claim_verification':
-            return {
-                subject: '✅ Verify Your Listing Claim',
-                html: getHtmlTemplate(
-                    'Verify Your Listing',
-                    `
-                    <p style="font-size: 16px;">Hi,</p>
-                    <p>Thank you for claiming <strong>${escapeHtml(data.businessName)}</strong> on Alanya Holidays!</p>
-                    <p>To complete the verification, click the button below to confirm your email address:</p>
-                    <p style="text-align: center; color: #64748b; font-size: 14px; margin-top: 24px;">Once verified, our team will review your claim and contact you within 24 hours.</p>
-                    `,
-                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/verify-claim?token=${escapeHtml(data.verificationToken)}`,
-                    'Verify Email',
-                    true
-                )
-            };
-
-        case 'admin_claim_notification':
-            return {
-                subject: '🔔 New Listing Claim Pending Review',
-                html: getHtmlTemplate(
-                    'New Claim for Review',
-                    `
-                    <p style="font-size: 16px;">A new listing claim requires your review:</p>
-                    <div class="card">
-                        <div class="info-row"><span class="label">Business Name</span><span class="value">${escapeHtml(data.businessName)}</span></div>
-                        <div class="info-row"><span class="label">Claimant Email</span><span class="value">${escapeHtml(data.claimantEmail)}</span></div>
-                        <div class="info-row"><span class="label">Listing ID</span><span class="value">${escapeHtml(data.listingId)}</span></div>
-                    </div>
-                    <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to the admin panel to review and approve or reject this claim.</p>
-                    `,
-                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/admin/directory`,
-                    'Review Claim'
-                )
-            };
-
-        case 'listing_claim_approved':
-            return {
-                subject: '🎉 Your Listing Claim Has Been Approved!',
-                html: getHtmlTemplate(
-                    'Claim Approved',
-                    `
-                    <p style="font-size: 16px;">Congratulations!</p>
-                    <p>Your claim for <strong>${escapeHtml(data.businessName)}</strong> has been approved by our team. You now own this listing and can manage all details.</p>
-                    <div class="card">
-                        <p style="text-align: center; margin: 0; color: #059669; font-weight: 600;">You are now the owner of this listing.</p>
-                    </div>
-                    <p style="text-align: center; color: #64748b; font-size: 14px;">Log in to your account to view and update your listing.</p>
-                    `,
-                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/directory`,
-                    'View Your Listing'
-                )
-            };
-
-        case 'listing_claim_rejected':
-            return {
-                subject: '⛔ Your Listing Claim Could Not Be Approved',
-                html: getHtmlTemplate(
-                    'Claim Rejected',
-                    `
-                    <p style="font-size: 16px;">Hi,</p>
-                    <p>Unfortunately, your claim for <strong>${escapeHtml(data.businessName)}</strong> could not be approved.</p>
-                    <div class="card">
-                        <div class="info-row"><span class="label">Reason</span><span class="value" style="color:#ef4444">${escapeHtml(data.rejectionReason)}</span></div>
-                    </div>
-                    <p style="text-align: center; color: #64748b; font-size: 14px;">If you believe this is a mistake, please contact us for more information.</p>
-                    `,
-                    `${process.env.SITE_URL || 'https://alanyaholidays.com'}/contact`,
-                    'Contact Support'
                 )
             };
 

--- a/supabase/migrations/20260622000000_claim_listing_email_verification.sql
+++ b/supabase/migrations/20260622000000_claim_listing_email_verification.sql
@@ -1,0 +1,126 @@
+-- Add email verification and approval workflow to listing_claims
+
+-- Add new columns to listing_claims table
+ALTER TABLE public.listing_claims
+ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN verification_token UUID NOT NULL DEFAULT gen_random_uuid(),
+ADD COLUMN verification_expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '7 days'),
+ADD COLUMN rejection_reason TEXT;
+
+-- Create unique index on verification_token for fast lookup
+CREATE UNIQUE INDEX idx_listing_claims_verification_token ON public.listing_claims (verification_token);
+
+-- RPC: verify_claim_email - mark claim as email verified (public, called via link)
+CREATE OR REPLACE FUNCTION public.verify_claim_email(p_token UUID)
+RETURNS TABLE(
+  claim_id UUID,
+  listing_id UUID,
+  business_name TEXT,
+  claimant_email TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  UPDATE public.listing_claims
+  SET email_verified = true
+  WHERE verification_token = p_token
+    AND verification_expires_at > now()
+    AND email_verified = false
+  RETURNING
+    id,
+    listing_id,
+    listing_claims.business_name,
+    listing_claims.email;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- RPC: approve_listing_claim - admin approves, transfers ownership (admin only, SECURITY DEFINER)
+CREATE OR REPLACE FUNCTION public.approve_listing_claim(p_claim_id UUID)
+RETURNS TABLE(
+  success BOOLEAN,
+  message TEXT,
+  listing_id UUID
+) AS $$
+DECLARE
+  v_claim record;
+  v_is_admin BOOLEAN;
+  v_claimant_user_id UUID;
+BEGIN
+  -- Check if current user is admin
+  v_is_admin := public.is_admin(auth.uid()::TEXT);
+
+  IF NOT v_is_admin THEN
+    RETURN QUERY SELECT false, 'Only admins can approve claims'::TEXT, NULL::UUID;
+    RETURN;
+  END IF;
+
+  -- Fetch the claim
+  SELECT id, listing_id, user_id, business_name, contact_phone, website, address, description
+  INTO v_claim
+  FROM public.listing_claims
+  WHERE id = p_claim_id AND status = 'pending';
+
+  IF v_claim IS NULL THEN
+    RETURN QUERY SELECT false, 'Claim not found or already processed'::TEXT, NULL::UUID;
+    RETURN;
+  END IF;
+
+  v_claimant_user_id := v_claim.user_id;
+
+  -- Update the listing with claim data and set owner
+  UPDATE public.directory_listings
+  SET
+    name = v_claim.business_name,
+    whatsapp = v_claim.contact_phone,
+    website = v_claim.website,
+    address = v_claim.address,
+    short_description = v_claim.description,
+    owner_user_id = v_claimant_user_id,
+    updated_at = now()
+  WHERE id = v_claim.listing_id;
+
+  -- Mark claim as approved
+  UPDATE public.listing_claims
+  SET status = 'approved', updated_at = now()
+  WHERE id = p_claim_id;
+
+  RETURN QUERY SELECT true, 'Claim approved successfully'::TEXT, v_claim.listing_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- RPC: reject_listing_claim - admin rejects claim (admin only, SECURITY DEFINER)
+CREATE OR REPLACE FUNCTION public.reject_listing_claim(p_claim_id UUID, p_reason TEXT)
+RETURNS TABLE(
+  success BOOLEAN,
+  message TEXT
+) AS $$
+DECLARE
+  v_is_admin BOOLEAN;
+BEGIN
+  -- Check if current user is admin
+  v_is_admin := public.is_admin(auth.uid()::TEXT);
+
+  IF NOT v_is_admin THEN
+    RETURN QUERY SELECT false, 'Only admins can reject claims'::TEXT;
+    RETURN;
+  END IF;
+
+  UPDATE public.listing_claims
+  SET
+    status = 'rejected',
+    rejection_reason = p_reason,
+    updated_at = now()
+  WHERE id = p_claim_id AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT false, 'Claim not found or already processed'::TEXT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT true, 'Claim rejected successfully'::TEXT;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Grant execute permissions on RPCs to authenticated users
+GRANT EXECUTE ON FUNCTION public.verify_claim_email(UUID) TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.approve_listing_claim(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reject_listing_claim(UUID, TEXT) TO authenticated;

--- a/supabase/migrations/20260622153000_add_claimed_at_to_listings.sql
+++ b/supabase/migrations/20260622153000_add_claimed_at_to_listings.sql
@@ -1,0 +1,58 @@
+-- Add claimed_at column to directory_listings
+ALTER TABLE public.directory_listings
+ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+
+-- Recreate or update approve_listing_claim function to set claimed_at = now() on approved claim
+CREATE OR REPLACE FUNCTION public.approve_listing_claim(p_claim_id UUID)
+RETURNS TABLE(
+  success BOOLEAN,
+  message TEXT,
+  listing_id UUID
+) AS $$
+DECLARE
+  v_claim record;
+  v_is_admin BOOLEAN;
+  v_claimant_user_id UUID;
+BEGIN
+  -- Check if current user is admin
+  v_is_admin := public.is_admin(auth.uid()::TEXT);
+
+  IF NOT v_is_admin THEN
+    RETURN QUERY SELECT false, 'Only admins can approve claims'::TEXT, NULL::UUID;
+    RETURN;
+  END IF;
+
+  -- Fetch the claim
+  SELECT id, listing_id, user_id, business_name, contact_phone, website, address, description
+  INTO v_claim
+  FROM public.listing_claims
+  WHERE id = p_claim_id AND status = 'pending';
+
+  IF v_claim IS NULL THEN
+    RETURN QUERY SELECT false, 'Claim not found or already processed'::TEXT, NULL::UUID;
+    RETURN;
+  END IF;
+
+  v_claimant_user_id := v_claim.user_id;
+
+  -- Update the listing with claim data, set owner, and record claim timestamp
+  UPDATE public.directory_listings
+  SET
+    name = v_claim.business_name,
+    whatsapp = v_claim.contact_phone,
+    website = v_claim.website,
+    address = v_claim.address,
+    short_description = v_claim.description,
+    owner_user_id = v_claimant_user_id,
+    claimed_at = now(),
+    updated_at = now()
+  WHERE id = v_claim.listing_id;
+
+  -- Mark claim as approved
+  UPDATE public.listing_claims
+  SET status = 'approved', updated_at = now()
+  WHERE id = p_claim_id;
+
+  RETURN QUERY SELECT true, 'Claim approved successfully'::TEXT, v_claim.listing_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/types/models.ts
+++ b/types/models.ts
@@ -480,6 +480,10 @@ export interface ListingClaimDB {
   address?: string;
   description?: string;
   status: 'pending' | 'approved' | 'rejected';
+  email_verified: boolean;
+  verification_token: string;
+  verification_expires_at: string;
+  rejection_reason: string | null;
   created_at?: string;
   updated_at?: string;
 }

--- a/types/models.ts
+++ b/types/models.ts
@@ -455,6 +455,7 @@ export interface DirectoryListingDB {
   status: 'pending' | 'approved' | 'rejected';
   owner_user_id: string | null;
   rejection_reason: string | null;
+  claimed_at?: string;
   created_at?: string;
   updated_at?: string;
   listing_locations?: ListingLocationJunction[];

--- a/utils/drafts.ts
+++ b/utils/drafts.ts
@@ -1,0 +1,28 @@
+// Draft storage keys and metadata
+export const DRAFT_KEYS = {
+  directory_listing: 'draft_directory_listing',
+  property_listing: 'draft_property_listing',
+  service_listing: 'draft_service_listing',
+  admin_directory: (id: string) => `draft_admin_directory_listing_${id}`,
+} as const;
+
+export const DRAFT_CONFIG = {
+  directory: { label: 'Directory Listing' },
+  property: { label: 'Property Listing' },
+  service: { label: 'Service Listing' },
+  admin_directory: { label: 'Directory Entry' },
+} as const;
+
+// Fields to exclude from content checks (config/default values, not user content)
+export const EXCLUDE_KEYS = {
+  service: ['type', 'vehicleType', 'transmission', 'fuel', 'seats', 'modelSelection', 'difficulty', 'subcategory', 'year'] as const,
+  property: ['maxGuests', 'bedrooms', 'beds', 'bathrooms', 'pricePerNight'] as const,
+} as const;
+
+// Check if form data has meaningful content (any field beyond metadata has non-empty value)
+export function isDraftContentEmpty<T extends Record<string, unknown>>(data: T, excludeKeys: readonly string[] = []): boolean {
+  return !Object.entries(data).some(([key, val]) =>
+    !excludeKeys.includes(key) && key !== 'updatedAt' && typeof val === 'string' && val.trim().length > 0
+  );
+}
+


### PR DESCRIPTION
## Summary
Complete the claim listing feature by implementing the admin panel for reviewing and approving/rejecting ownership transfer claims.

- New "Claims" tab in DirectoryAdminPage showing all pending and processed claims
- Email verification status badges (verified/pending)
- Approve/reject action buttons for verified pending claims
- Inline rejection reason textarea for rejected claims
- Full claim details display (claimant email, business name, submitted date, claim status)

## Changes
- Updated DirectoryAdminPage.tsx with claims state management and UI
- Added API handlers in directory.ts for approving/rejecting claims
- Added 4 email template types in send-email/index.ts
- Created VerifyClaimPage.tsx for email verification flow
- Updated routes, models, and claim submission flow

## Test plan
- [ ] Verify DirectoryAdminPage loads without errors
- [ ] Confirm "Claims" tab appears with correct count
- [ ] Test approve flow: verified pending claim → owner_user_id updated, email sent
- [ ] Test reject flow: enter reason → claim rejected, claimant notified
- [ ] Verify buttons hidden for non-pending or unverified claims
- [ ] Check build: npm run build passes
- [ ] Run tests: npm run test (if applicable)