### PR TITLE
Platform edits: Blog→Guides + remove Forum (T12), box/rectangle card toggle (T13)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,7 @@ import { ModalProvider } from './context/ModalContext';
 import { FavoritesProvider } from './context/FavoritesContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { LanguageProvider } from './context/LanguageContext';
+import { CardStyleProvider } from './context/CardStyleContext';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { LightboxProvider } from './context/LightboxContext';
 import { NotificationProvider } from './context/NotificationContext';
@@ -94,18 +95,20 @@ const App: React.FC = () => {
                       <ModalProvider>
                         <LightboxProvider>
                           <ChatProvider>
-                            <AppContent />
-                            <React.Suspense fallback={null}>
-                              <LoginModal />
-                              <RegisterModal />
-                            </React.Suspense>
-                            <React.Suspense fallback={null}>
-                              <Lightbox />
-                              <CartDrawer />
-                              <TripAssistant />
-                              <CookieConsent />
-                              <CommandPalette />
-                            </React.Suspense>
+                            <CardStyleProvider>
+                              <AppContent />
+                              <React.Suspense fallback={null}>
+                                <LoginModal />
+                                <RegisterModal />
+                              </React.Suspense>
+                              <React.Suspense fallback={null}>
+                                <Lightbox />
+                                <CartDrawer />
+                                <TripAssistant />
+                                <CookieConsent />
+                                <CommandPalette />
+                              </React.Suspense>
+                            </CardStyleProvider>
                           </ChatProvider>
                         </LightboxProvider>
                       </ModalProvider>

--- a/components/directory/CardStyleToggle.test.tsx
+++ b/components/directory/CardStyleToggle.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { CardStyleToggle } from './CardStyleToggle';
+import { CardStyleProvider } from '../../context/CardStyleContext';
+
+const renderToggle = () =>
+    render(
+        <CardStyleProvider>
+            <CardStyleToggle />
+        </CardStyleProvider>,
+    );
+
+describe('CardStyleToggle', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('defaults to the Box style', () => {
+        renderToggle();
+        expect(screen.getByRole('button', { name: /box/i })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: /rectangle/i })).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('switches to Rectangle and persists the choice', () => {
+        renderToggle();
+        fireEvent.click(screen.getByRole('button', { name: /rectangle/i }));
+        expect(screen.getByRole('button', { name: /rectangle/i })).toHaveAttribute('aria-pressed', 'true');
+        expect(localStorage.getItem('directory_card_style')).toBe('rectangle');
+    });
+
+    it('restores a persisted Rectangle preference on mount', () => {
+        localStorage.setItem('directory_card_style', 'rectangle');
+        renderToggle();
+        expect(screen.getByRole('button', { name: /rectangle/i })).toHaveAttribute('aria-pressed', 'true');
+    });
+});

--- a/components/directory/CardStyleToggle.tsx
+++ b/components/directory/CardStyleToggle.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Square, RectangleHorizontal } from 'lucide-react';
+import { useCardStyle, CardStyle } from '../../context/CardStyleContext';
+
+const OPTIONS: { value: CardStyle; label: string; Icon: React.ComponentType<{ size?: number }> }[] = [
+    { value: 'box', label: 'Box', Icon: Square },
+    { value: 'rectangle', label: 'Rectangle', Icon: RectangleHorizontal },
+];
+
+/** Lets users switch listing cards between rounded "box" and squared "rectangle" styles (T13). */
+export const CardStyleToggle: React.FC<{ className?: string }> = ({ className = '' }) => {
+    const { cardStyle, setCardStyle } = useCardStyle();
+
+    return (
+        <div
+            role="group"
+            aria-label="Card style"
+            className={`inline-flex items-center rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-0.5 ${className}`}
+        >
+            {OPTIONS.map(({ value, label, Icon }) => {
+                const active = cardStyle === value;
+                return (
+                    <button
+                        key={value}
+                        type="button"
+                        onClick={() => setCardStyle(value)}
+                        aria-pressed={active}
+                        title={`${label} layout`}
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                            active
+                                ? 'bg-teal-600 text-white'
+                                : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
+                        }`}
+                    >
+                        <Icon size={16} />
+                        <span className="hidden sm:inline">{label}</span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+};

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { DirectoryListingDB } from '../../types/models';
 import { db } from '../../api-services';
 import { useLanguage } from '../../context/LanguageContext';
+import { useCardStyle } from '../../context/CardStyleContext';
 import { getListingDescription } from '../../utils/getListingDescription';
 import { getListingUrl } from '../../constants/categoryPaths';
 
@@ -21,7 +22,10 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
     listing, onClick, userVote, onVote, isAuthenticated, isVoting, categoryName
 }) => {
     const { language } = useLanguage();
+    const { cardStyle } = useCardStyle();
     const displayDescription = getListingDescription(listing, language);
+    // "box" = soft rounded card; "rectangle" = squared corners (user toggle, T13)
+    const radiusClass = cardStyle === 'rectangle' ? 'rounded-none' : 'rounded-2xl';
     const netVotes = listing.net_votes || 0;
     const isPaidTier = (tier?: string) => tier && tier !== 'explorer';
 
@@ -33,7 +37,7 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
 
     return (
         <div 
-            className={`group flex flex-col bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 border border-slate-200 dark:border-slate-700 h-full ${onClick ? 'cursor-pointer' : ''}`}
+            className={`group flex flex-col bg-white dark:bg-slate-800 ${radiusClass} overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 border border-slate-200 dark:border-slate-700 h-full ${onClick ? 'cursor-pointer' : ''}`}
             onClick={() => onClick && onClick(listing)}
         >
             {/* Image */}

--- a/components/navbar/DesktopNav.tsx
+++ b/components/navbar/DesktopNav.tsx
@@ -35,8 +35,7 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({ mode = 'directory' }) =>
             {mode === 'directory' ? (
                 <>
                     <TabLink to="/" label={t('nav.directory') || 'Directory'} exact />
-                    <TabLink to="/blog" label={t('nav.blog') || 'Blog'} />
-                    <TabLink to="/forum" label={t('nav.forum') || 'Forum'} />
+                    <TabLink to="/blog" label={t('nav.blog') || 'Guides'} />
                     <TabLink to="/shop" label={t('shop') || 'Shop'} />
                 </>
             ) : (

--- a/components/navbar/MobileMenu.test.tsx
+++ b/components/navbar/MobileMenu.test.tsx
@@ -133,7 +133,6 @@ describe('MobileMenu', () => {
         renderMenu();
         expect(screen.getByText('nav.directory')).toBeInTheDocument();
         expect(screen.getByText('nav.blog')).toBeInTheDocument();
-        expect(screen.getByText('nav.forum')).toBeInTheDocument();
         expect(screen.getByText('shop')).toBeInTheDocument();
     });
 
@@ -204,7 +203,7 @@ describe('MobileMenu', () => {
 
     it('calls onClose when a directory link is clicked', () => {
         renderMenu();
-        fireEvent.click(screen.getByText('nav.forum'));
+        fireEvent.click(screen.getByText('shop'));
         expect(mockOnClose).toHaveBeenCalled();
     });
 

--- a/components/navbar/MobileMenu.tsx
+++ b/components/navbar/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Sun, Moon, Globe, ChevronDown, Home, LogOut, User, LayoutDashboard, Heart, ShoppingBag, Car, Building2, MapPin, BookOpen, MessageCircle, Briefcase, ArrowRightLeft } from 'lucide-react';
+import { Sun, Moon, Globe, ChevronDown, Home, LogOut, User, LayoutDashboard, Heart, ShoppingBag, Car, Building2, MapPin, BookOpen, Briefcase, ArrowRightLeft } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
 import { useLanguage, Language } from '../../context/LanguageContext';
@@ -63,11 +63,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, mode, s
                         </Link>
                         <Link to="/blog" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <BookOpen size={18} className="text-slate-400" />
-                            {t('nav.blog') || 'Blog'}
-                        </Link>
-                        <Link to="/forum" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
-                            <MessageCircle size={18} className="text-slate-400" />
-                            {t('nav.forum') || 'Forum'}
+                            {t('nav.blog') || 'Guides'}
                         </Link>
                         <Link to="/shop" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <ShoppingBag size={18} className="text-slate-400" />

--- a/context/CardStyleContext.tsx
+++ b/context/CardStyleContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useCallback, useContext, useState, ReactNode } from 'react';
+
+export type CardStyle = 'box' | 'rectangle';
+
+const STORAGE_KEY = 'directory_card_style';
+
+interface CardStyleContextValue {
+    cardStyle: CardStyle;
+    setCardStyle: (style: CardStyle) => void;
+}
+
+const CardStyleContext = createContext<CardStyleContextValue | undefined>(undefined);
+
+export const CardStyleProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+    const [cardStyle, setCardStyleState] = useState<CardStyle>(() => {
+        const saved = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+        return saved === 'rectangle' ? 'rectangle' : 'box';
+    });
+
+    const setCardStyle = useCallback((style: CardStyle) => {
+        setCardStyleState(style);
+        try {
+            localStorage.setItem(STORAGE_KEY, style);
+        } catch {
+            // ignore storage failures (private mode, etc.)
+        }
+    }, []);
+
+    return (
+        <CardStyleContext.Provider value={{ cardStyle, setCardStyle }}>
+            {children}
+        </CardStyleContext.Provider>
+    );
+};
+
+// Falls back to the 'box' default when used outside a provider (e.g. isolated
+// component tests) so consumers never need to be wrapped just to render.
+export const useCardStyle = (): CardStyleContextValue => {
+    return useContext(CardStyleContext) ?? { cardStyle: 'box', setCardStyle: () => {} };
+};

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -5,7 +5,7 @@ export const ar = {
     'nav.directory': 'الدليل',
     'directory.villas': 'فيلات',
     'directory.apartments': 'شقق',
-    'nav.blog': 'المدونة',
+    'nav.blog': 'الأدلة',
     'nav.forum': 'المنتدى',
     'nav.events': 'الفعاليات',
     'nav.members': 'الأعضاء',

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -5,7 +5,7 @@ export const en = {
   'nav.directory': 'Directory',
   'directory.villas': 'Villas',
   'directory.apartments': 'Apartments',
-  'nav.blog': 'Blog',
+  'nav.blog': 'Guides',
   'nav.forum': 'Forum',
   'nav.events': 'Events',
   'nav.members': 'Members',

--- a/locales/ru.ts
+++ b/locales/ru.ts
@@ -5,7 +5,7 @@ export const ru = {
   'nav.directory': 'Каталог',
   'directory.villas': 'Виллы',
   'directory.apartments': 'Апартаменты',
-  'nav.blog': 'Блог',
+  'nav.blog': 'Гиды',
   'nav.forum': 'Форум',
   'nav.events': 'События',
   'nav.members': 'Участники',

--- a/locales/tr.ts
+++ b/locales/tr.ts
@@ -5,7 +5,7 @@ export const tr = {
     'nav.directory': 'Rehber',
     'directory.villas': 'Villalar',
     'directory.apartments': 'Daireler',
-    'nav.blog': 'Blog',
+    'nav.blog': 'Rehberler',
     'nav.forum': 'Forum',
     'nav.events': 'Etkinlikler',
     'nav.members': 'Üyeler',

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from '../components/seo/Breadcrumb';
 import { useAuth } from '../context/AuthContext';
 import { directoryCategoryIntros } from '../data/directoryData';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+import { CardStyleToggle } from '../components/directory/CardStyleToggle';
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
@@ -423,6 +424,8 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                 <MapIcon size={16} /> Map
                             </button>
                         </div>
+
+                        {viewMode === 'list' && <CardStyleToggle className="shrink-0" />}
 
                         <label className="flex items-center gap-2 cursor-pointer text-slate-700 dark:text-slate-300 whitespace-nowrap">
                             <input

--- a/pages/SearchPage.tsx
+++ b/pages/SearchPage.tsx
@@ -5,6 +5,7 @@ import { SEOHead } from '../components/seo/SEOHead';
 import { Breadcrumb } from '../components/seo/Breadcrumb';
 import { useAuth } from '../context/AuthContext';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
+import { CardStyleToggle } from '../components/directory/CardStyleToggle';
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
@@ -327,6 +328,8 @@ export const SearchPage: React.FC = () => {
                                 <MapIcon size={16} /> Map
                             </button>
                         </div>
+
+                        {viewMode === 'list' && <CardStyleToggle className="shrink-0" />}
 
                         <label className="flex items-center gap-2 cursor-pointer text-slate-700 dark:text-slate-300 whitespace-nowrap">
                             <input


### PR DESCRIPTION
Two more Platform Edits items.

## T12 — "Forum" → "Community" / "Blog" → "Guides"
Per the decision (keep the existing `/community` hub):
- **Removed the standalone "Forum" nav item** (desktop + mobile). The `/community` hub — which links to the forum — is untouched, so the forum stays reachable.
- **Renamed the "Blog" nav label to "Guides"** in all 4 locales. **Route stays `/blog`** (no URL change → no SEO/redirect risk). Footer label follows automatically.
- Dropped the now-unused `MessageCircle` import; updated MobileMenu tests.

## T13 — Box ↔ Rectangle card style toggle
Per the decision (add a user toggle):
- **`CardStyleContext`** — persisted preference (`box` default), applies site-wide; `useCardStyle` falls back to the default outside a provider.
- **`DirectoryListingCard`** switches corner radius: `box` = rounded, `rectangle` = squared.
- **`CardStyleToggle`** control added to the list-view toolbar on DirectoryCategoryPage + SearchPage (shown only in list mode).
- Context + toggle tests.

> **Interpretation note:** I read "boxes → rectangles" as the **card corner style** (rounded vs squared) — the literal wording, and low-risk. If the client actually meant a **grid-vs-list layout** (vertical cards vs horizontal rows), say so and I'll extend the rectangle variant to a horizontal layout.

## Verification
- `tsc`, eslint clean on all changed files
- Tests: nav (26), DirectoryListingCard (6, renders without provider via the default), CardStyleToggle (3) — all green

## Still open — need client (not in this PR)
- **T5** — final approved copy for the Premium/Featured listing sections
- **T14** — real photos for the 12 directory categories
- Parked bonus: "instant booking" = opt-in member messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)