### PR TITLE
Rework: Forum→Community nav (T12), horizontal list layout (T13)

### DIFF
--- a/components/directory/CardStyleToggle.tsx
+++ b/components/directory/CardStyleToggle.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Square, RectangleHorizontal } from 'lucide-react';
+import { LayoutGrid, RectangleHorizontal } from 'lucide-react';
 import { useCardStyle, CardStyle } from '../../context/CardStyleContext';
 
 const OPTIONS: { value: CardStyle; label: string; Icon: React.ComponentType<{ size?: number }> }[] = [
-    { value: 'box', label: 'Box', Icon: Square },
+    { value: 'box', label: 'Box', Icon: LayoutGrid },
     { value: 'rectangle', label: 'Rectangle', Icon: RectangleHorizontal },
 ];
 

--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { DirectoryListingDB } from '../../types/models';
 import { db } from '../../api-services';
 import { useLanguage } from '../../context/LanguageContext';
-import { useCardStyle } from '../../context/CardStyleContext';
+import { useCardStyle, CardStyle } from '../../context/CardStyleContext';
 import { getListingDescription } from '../../utils/getListingDescription';
 import { getListingUrl } from '../../constants/categoryPaths';
 
@@ -16,16 +16,18 @@ interface DirectoryListingCardProps {
     isAuthenticated?: boolean;
     isVoting?: boolean;
     categoryName?: string;
+    /** Overrides the global card-style preference (e.g. home carousels force 'box'). */
+    variant?: CardStyle;
 }
 
 export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
-    listing, onClick, userVote, onVote, isAuthenticated, isVoting, categoryName
+    listing, onClick, userVote, onVote, isAuthenticated, isVoting, categoryName, variant
 }) => {
     const { language } = useLanguage();
     const { cardStyle } = useCardStyle();
     const displayDescription = getListingDescription(listing, language);
-    // "box" = soft rounded card; "rectangle" = squared corners (user toggle, T13)
-    const radiusClass = cardStyle === 'rectangle' ? 'rounded-none' : 'rounded-2xl';
+    // T13: "box" = vertical card (grid); "rectangle" = horizontal row (list).
+    const isList = (variant ?? cardStyle) === 'rectangle';
     const netVotes = listing.net_votes || 0;
     const isPaidTier = (tier?: string) => tier && tier !== 'explorer';
 
@@ -36,12 +38,12 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
     };
 
     return (
-        <div 
-            className={`group flex flex-col bg-white dark:bg-slate-800 ${radiusClass} overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 border border-slate-200 dark:border-slate-700 h-full ${onClick ? 'cursor-pointer' : ''}`}
+        <div
+            className={`group bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-all duration-300 border border-slate-200 dark:border-slate-700 ${isList ? 'flex flex-col sm:flex-row' : 'flex flex-col h-full'} ${onClick ? 'cursor-pointer' : ''}`}
             onClick={() => onClick && onClick(listing)}
         >
             {/* Image */}
-            <div className="relative w-full h-56 flex-shrink-0">
+            <div className={`relative flex-shrink-0 ${isList ? 'w-full h-56 sm:w-72 sm:h-auto' : 'w-full h-56'}`}>
                 <img
                     src={listing.gallery?.[0] || 'https://images.unsplash.com/photo-1542037104857-ffbb0b9155fb'}
                     alt={listing.name}

--- a/components/home/FreeListingsSection.tsx
+++ b/components/home/FreeListingsSection.tsx
@@ -60,7 +60,7 @@ export const FreeListingsSection: React.FC<FreeListingsSectionProps> = ({ listin
                 {!loading && listings.length > 0 && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         {listings.map((listing) => (
-                            <DirectoryListingCard key={listing.id} listing={listing} />
+                            <DirectoryListingCard key={listing.id} listing={listing} variant="box" />
                         ))}
                     </div>
                 )}

--- a/components/home/PremiumListingsSection.tsx
+++ b/components/home/PremiumListingsSection.tsx
@@ -60,7 +60,7 @@ export const PremiumListingsSection: React.FC<PremiumListingsSectionProps> = ({ 
                 {!loading && listings.length > 0 && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         {listings.map((listing) => (
-                            <DirectoryListingCard key={listing.id} listing={listing} />
+                            <DirectoryListingCard key={listing.id} listing={listing} variant="box" />
                         ))}
                     </div>
                 )}

--- a/components/home/RecentlyClaimedSection.tsx
+++ b/components/home/RecentlyClaimedSection.tsx
@@ -59,7 +59,7 @@ export const RecentlyClaimedSection: React.FC<RecentlyClaimedSectionProps> = ({ 
                 {!loading && listings.length > 0 && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         {listings.map((listing) => (
-                            <DirectoryListingCard key={listing.id} listing={listing} />
+                            <DirectoryListingCard key={listing.id} listing={listing} variant="box" />
                         ))}
                     </div>
                 )}

--- a/components/home/SignatureListingsSection.tsx
+++ b/components/home/SignatureListingsSection.tsx
@@ -60,7 +60,7 @@ export const SignatureListingsSection: React.FC<SignatureListingsSectionProps> =
                 {!loading && listings.length > 0 && (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                         {listings.map((listing) => (
-                            <DirectoryListingCard key={listing.id} listing={listing} />
+                            <DirectoryListingCard key={listing.id} listing={listing} variant="box" />
                         ))}
                     </div>
                 )}

--- a/components/navbar/DesktopNav.tsx
+++ b/components/navbar/DesktopNav.tsx
@@ -36,6 +36,7 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({ mode = 'directory' }) =>
                 <>
                     <TabLink to="/" label={t('nav.directory') || 'Directory'} exact />
                     <TabLink to="/blog" label={t('nav.blog') || 'Guides'} />
+                    <TabLink to="/forum" label={t('nav.community') || 'Community'} />
                     <TabLink to="/shop" label={t('shop') || 'Shop'} />
                 </>
             ) : (

--- a/components/navbar/MobileMenu.test.tsx
+++ b/components/navbar/MobileMenu.test.tsx
@@ -133,6 +133,7 @@ describe('MobileMenu', () => {
         renderMenu();
         expect(screen.getByText('nav.directory')).toBeInTheDocument();
         expect(screen.getByText('nav.blog')).toBeInTheDocument();
+        expect(screen.getByText('nav.community')).toBeInTheDocument();
         expect(screen.getByText('shop')).toBeInTheDocument();
     });
 

--- a/components/navbar/MobileMenu.tsx
+++ b/components/navbar/MobileMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Sun, Moon, Globe, ChevronDown, Home, LogOut, User, LayoutDashboard, Heart, ShoppingBag, Car, Building2, MapPin, BookOpen, Briefcase, ArrowRightLeft } from 'lucide-react';
+import { Sun, Moon, Globe, ChevronDown, Home, LogOut, User, LayoutDashboard, Heart, ShoppingBag, Car, Building2, MapPin, BookOpen, MessageCircle, Briefcase, ArrowRightLeft } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
 import { useLanguage, Language } from '../../context/LanguageContext';
@@ -64,6 +64,10 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose, mode, s
                         <Link to="/blog" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <BookOpen size={18} className="text-slate-400" />
                             {t('nav.blog') || 'Guides'}
+                        </Link>
+                        <Link to="/forum" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
+                            <MessageCircle size={18} className="text-slate-400" />
+                            {t('nav.community') || 'Community'}
                         </Link>
                         <Link to="/shop" onClick={onClose} className="flex items-center gap-3 px-4 py-4 rounded-xl hover:bg-slate-50 dark:hover:bg-slate-800/90 font-medium text-slate-700 dark:text-slate-200 min-h-[44px]">
                             <ShoppingBag size={18} className="text-slate-400" />

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../context/AuthContext';
 import { directoryCategoryIntros } from '../data/directoryData';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
 import { CardStyleToggle } from '../components/directory/CardStyleToggle';
+import { useCardStyle } from '../context/CardStyleContext';
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
@@ -30,6 +31,11 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
     const [maxPriceLevel, setMaxPriceLevel] = useState<number>(4);
     const [languageFilter, setLanguageFilter] = useState('all');
     const [sortBy, setSortBy] = useState('recommended');
+    const { cardStyle } = useCardStyle();
+    // T13: rectangle = single-column list of horizontal cards; box = multi-column grid.
+    const listingsGridClass = cardStyle === 'rectangle'
+        ? 'grid grid-cols-1 gap-4'
+        : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6';
 
     // UI State
     const [showFullIntro, setShowFullIntro] = useState(false);
@@ -465,7 +471,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                     <Star className="text-amber-500 fill-amber-500" size={24} />
                                     Featured Providers
                                 </h2>
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <div className={listingsGridClass}>
                                     {featuredListings.map(listing => (
                                         <DirectoryListingCard
                                             key={listing.id}
@@ -487,7 +493,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                                 All Listings
                             </h2>
                             {standardListings.length > 0 ? (
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <div className={listingsGridClass}>
                                     {standardListings.map(listing => (
                                         <DirectoryListingCard
                                             key={listing.id}

--- a/pages/SearchPage.tsx
+++ b/pages/SearchPage.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from '../components/seo/Breadcrumb';
 import { useAuth } from '../context/AuthContext';
 import { DirectoryListingCard } from '../components/directory/DirectoryListingCard';
 import { CardStyleToggle } from '../components/directory/CardStyleToggle';
+import { useCardStyle } from '../context/CardStyleContext';
 import { DirectoryListingModal } from '../components/directory/DirectoryListingModal';
 import { DirectoryMapView } from '../components/directory/DirectoryMapView';
 import { db } from '../api-services';
@@ -50,6 +51,11 @@ export const SearchPage: React.FC = () => {
     const [sortBy, setSortBy] = useState('recommended');
     const [selectedListing, setSelectedListing] = useState<DirectoryListingDB | null>(null);
     const [viewMode, setViewMode] = useState<'list' | 'map'>('list');
+    const { cardStyle } = useCardStyle();
+    // T13: rectangle = single-column list of horizontal cards; box = multi-column grid.
+    const listingsGridClass = cardStyle === 'rectangle'
+        ? 'grid grid-cols-1 gap-4'
+        : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6';
 
     // Data State
     const [listings, setListings] = useState<DirectoryListingDB[]>([]);
@@ -381,7 +387,7 @@ export const SearchPage: React.FC = () => {
                                     <Star className="text-amber-500 fill-amber-500" size={24} />
                                     Featured Providers
                                 </h2>
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <div className={listingsGridClass}>
                                     {featuredListings.map(listing => (
                                         <DirectoryListingCard
                                             key={listing.id}
@@ -404,7 +410,7 @@ export const SearchPage: React.FC = () => {
                                 All Listings
                             </h2>
                             {standardListings.length > 0 ? (
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <div className={listingsGridClass}>
                                     {standardListings.map(listing => (
                                         <DirectoryListingCard
                                             key={listing.id}


### PR DESCRIPTION
Reworks two earlier items per feedback.

## T12 — restore Forum access as "Community"
Removing the Forum nav item entirely left the forum unreachable. Per the client's "change Forum to Community", it's now **re-added as a "Community" nav item** (label `nav.community`, all locales) pointing to **/forum** — one click to the forum, on desktop + mobile. "Blog → Guides" is unchanged; the `/community` hub page is untouched.

> If you'd rather "Community" open the richer `/community` hub page (Events/Members + a forum link) instead of going straight to `/forum`, it's a one-line change — say the word.

## T13 — rectangle is now a real horizontal list layout
Reworked from corner-style (rounded vs squared) to an actual **grid-vs-list** layout:
- **Box** = vertical card grid (unchanged)
- **Rectangle** = full-width **horizontal rows** (image left, content right)

- `DirectoryListingCard` gets a `variant` prop + `isList` layout (stacks on mobile, horizontal on `sm+`).
- DirectoryCategoryPage + SearchPage collapse the card grid to a single column in rectangle mode.
- Home carousels pass `variant="box"` so the global toggle can't break their fixed grids.

## Verification
- `tsc`, eslint clean; tests: nav (26), DirectoryListingCard (6), CardStyleToggle (9 total) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)