### PR TITLE
Traveller-centric listing copy (T5)

### DIFF
--- a/components/directory/DirectoryListingCard.tsx
+++ b/components/directory/DirectoryListingCard.tsx
@@ -51,12 +51,12 @@ export const DirectoryListingCard: React.FC<DirectoryListingCardProps> = ({
                 />
                 {listing.is_featured && (
                     <div className="absolute top-4 left-4 bg-amber-500 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg flex items-center gap-1">
-                        <Star size={12} className="fill-white" /> Featured
+                        <Star size={12} className="fill-white" /> Trusted by Travellers
                     </div>
                 )}
                 {listing.tier === 'signature' && (
                     <div className="absolute top-4 right-4 bg-purple-600 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg flex items-center gap-1">
-                        <BadgeCheck size={12} className="fill-white" /> Verified Premium
+                        <BadgeCheck size={12} className="fill-white" /> Verified Experience
                     </div>
                 )}
                 {(listing.tier === 'voyager' || listing.tier === 'partner') && (

--- a/components/home/FreeListingsSection.tsx
+++ b/components/home/FreeListingsSection.tsx
@@ -21,11 +21,11 @@ export const FreeListingsSection: React.FC<FreeListingsSectionProps> = ({ listin
                         <div className="flex items-center gap-2 mb-2">
                             <ThumbsUp className="w-5 h-5 text-teal-600 dark:text-cyan-400" />
                             <span className="text-xs uppercase font-bold text-teal-600 dark:text-cyan-400 tracking-widest">
-                                Community Favorites
+                                Loved by Travellers
                             </span>
                         </div>
                         <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
-                            Top Rated by the Community
+                            Local Favorites
                         </h2>
                         <p className="mt-2 text-slate-600 dark:text-slate-400">
                             The most upvoted listings from our community

--- a/components/home/PremiumListingsSection.tsx
+++ b/components/home/PremiumListingsSection.tsx
@@ -21,11 +21,11 @@ export const PremiumListingsSection: React.FC<PremiumListingsSectionProps> = ({ 
                         <div className="flex items-center gap-2 mb-2">
                             <Crown className="w-5 h-5 text-amber-500 dark:text-amber-400" />
                             <span className="text-xs uppercase font-bold text-amber-600 dark:text-amber-400 tracking-widest">
-                                Premium Partners
+                                Trusted by Travellers
                             </span>
                         </div>
                         <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
-                            Recommended for You
+                            Recommended by Travellers
                         </h2>
                         <p className="mt-2 text-slate-600 dark:text-slate-400">
                             Hand-picked, verified partners with outstanding service
@@ -52,7 +52,7 @@ export const PremiumListingsSection: React.FC<PremiumListingsSectionProps> = ({ 
                 {!loading && listings.length === 0 && (
                     <div className="text-center py-12 bg-white dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-700/50">
                         <Crown className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
-                        <p className="text-slate-500 dark:text-slate-400">Premium listings coming soon!</p>
+                        <p className="text-slate-500 dark:text-slate-400">Recommended listings coming soon!</p>
                     </div>
                 )}
 

--- a/components/home/SignatureListingsSection.tsx
+++ b/components/home/SignatureListingsSection.tsx
@@ -21,11 +21,11 @@ export const SignatureListingsSection: React.FC<SignatureListingsSectionProps> =
                         <div className="flex items-center gap-2 mb-2">
                             <Diamond className="w-5 h-5 text-indigo-500 dark:text-indigo-400" />
                             <span className="text-xs uppercase font-bold text-indigo-600 dark:text-indigo-400 tracking-widest">
-                                Signature Partners
+                                Curated Experience
                             </span>
                         </div>
                         <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-white">
-                            Verified Premium Partners
+                            Signature Collection
                         </h2>
                         <p className="mt-2 text-slate-600 dark:text-slate-400">
                             Top-tier verified businesses with premium service standards
@@ -52,7 +52,7 @@ export const SignatureListingsSection: React.FC<SignatureListingsSectionProps> =
                 {!loading && listings.length === 0 && (
                     <div className="text-center py-12 bg-white dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-700/50">
                         <Diamond className="w-10 h-10 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
-                        <p className="text-slate-500 dark:text-slate-400">Signature partners coming soon!</p>
+                        <p className="text-slate-500 dark:text-slate-400">Signature Collection coming soon!</p>
                     </div>
                 )}
 

--- a/pages/DirectoryCategoryPage.tsx
+++ b/pages/DirectoryCategoryPage.tsx
@@ -469,7 +469,7 @@ export const DirectoryCategoryPage: React.FC<{ categoryId?: string }> = ({ categ
                             <div className="mb-12">
                                 <h2 className="flex items-center gap-2 text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
                                     <Star className="text-amber-500 fill-amber-500" size={24} />
-                                    Featured Providers
+                                    Recommended by Travellers
                                 </h2>
                                 <div className={listingsGridClass}>
                                     {featuredListings.map(listing => (

--- a/pages/SearchPage.tsx
+++ b/pages/SearchPage.tsx
@@ -385,7 +385,7 @@ export const SearchPage: React.FC = () => {
                             <div className="mb-12">
                                 <h2 className="flex items-center gap-2 text-2xl font-bold text-slate-900 dark:text-white mb-6 px-2">
                                     <Star className="text-amber-500 fill-amber-500" size={24} />
-                                    Featured Providers
+                                    Recommended by Travellers
                                 </h2>
                                 <div className={listingsGridClass}>
                                     {featuredListings.map(listing => (


### PR DESCRIPTION
Rebrands the "Premium"/"Featured" language across the listing surfaces to the traveller-centric wording from the client's list.

## Copy changes
| Where | Before | After |
|---|---|---|
| Home – premium section | "Recommended for You" / "Premium Partners" | **"Recommended by Travellers"** / "Trusted by Travellers" |
| Home – signature section | "Verified Premium Partners" / "Signature Partners" | **"Signature Collection"** / "Curated Experience" |
| Home – free section | "Top Rated by the Community" / "Community Favorites" | **"Local Favorites"** / "Loved by Travellers" |
| Category & Search heading | "Featured Providers" | **"Recommended by Travellers"** |
| Card badge (featured) | "Featured" | **"Trusted by Travellers"** |
| Card badge (signature) | "Verified Premium" | **"Verified Experience"** |

Left `$$$ (Premium)` price-level filter untouched (different meaning). US "Favorites" spelling to match the existing site.

## Verification
- `tsc`, eslint clean; card + home-section tests green (19).

> All copy is easy to tweak — flag any line and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)