### PR TITLE
Hotfix: red main — remove broken duplicate RelatedListings in ForumPostPage

### DIFF
--- a/pages/ForumPostPage.tsx
+++ b/pages/ForumPostPage.tsx
@@ -257,11 +257,6 @@ export const ForumPostPage: React.FC = () => {
                 </div>
             </article>
 
-            {/* Related Directory Listings Sidebar */}
-            {post.category?.slug && (
-                <RelatedListings categorySlug={post.category.slug} limit={5} />
-            )}
-
             {/* Comment composer */}
             <div className="mt-8">
                 <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">


### PR DESCRIPTION
## main is currently failing CI (type-check)
```
pages/ForumPostPage.tsx(262,34): error TS2322: Type '{ categorySlug: string; limit: number; }'
is not assignable to type 'IntrinsicAttributes & RelatedListingsProps'.
Property 'categorySlug' does not exist ...
```
This blocks **every** open PR (CI type-checks each PR merged with main).

## Cause
A merge collision (community-linking work + the #175 related-listings sidebar) left **two** `RelatedListings` renders in `ForumPostPage.tsx`:
- A **broken duplicate** passing `categorySlug`/`limit` — props the component doesn't accept.
- The **correct** sidebar render passing the already-fetched `listings` / `title` / `loading`.

## Fix
Remove the broken duplicate. The working sidebar render (fed by `getRelatedListings(post, 5)`) is untouched, so related listings still show — just once, correctly.

## Verification
- `tsc --noEmit` clean; eslint clean.

> Should be merged first to green up main and unblock the other open PRs (#174 T5, #178 forum events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)