### PR TITLE
feat(directory): category tiles load real photos with emoji fallback

### DIFF
--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -16,6 +16,22 @@ import { SignatureListingsSection } from '../components/home/SignatureListingsSe
 import { TravelGuideSection } from '../components/home/TravelGuideSection';
 import { RecentlyClaimedSection } from '../components/home/RecentlyClaimedSection';
 
+// Category tiles use real photos dropped into /public/images/categories/<id>.webp;
+// until a photo exists for a category, the emoji icon is shown instead.
+const CategoryTileIcon: React.FC<{ id: string; icon: string }> = ({ id, icon }) => {
+    const [imageFailed, setImageFailed] = useState(false);
+    if (imageFailed) return <>{icon}</>;
+    return (
+        <img
+            src={`/images/categories/${id}.webp`}
+            alt=""
+            loading="lazy"
+            onError={() => setImageFailed(true)}
+            className="w-full h-full object-cover rounded-2xl"
+        />
+    );
+};
+
 export const DirectoryHome: React.FC = () => {
     const { t } = useLanguage();
     const navigate = useNavigate();
@@ -344,8 +360,8 @@ export const DirectoryHome: React.FC = () => {
                             onClick={() => navigate(category.path)}
                             className="group flex flex-row sm:flex-col items-center sm:justify-center p-4 sm:p-8 bg-white dark:bg-slate-800/80 border border-slate-100 dark:border-slate-800/50 rounded-2xl shadow-sm hover:shadow-xl dark:hover:shadow-slate-900/50 hover:-translate-y-1 transition-all duration-300 text-left sm:text-center text-slate-900 dark:text-white gap-4 sm:gap-0 cursor-pointer"
                         >
-                            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-slate-50 dark:bg-slate-900/50 rounded-2xl flex items-center justify-center text-2xl sm:text-3xl sm:mb-4 group-hover:bg-teal-50 dark:group-hover:bg-slate-700/50 group-hover:scale-110 transition-all duration-300 flex-shrink-0">
-                                {category.icon}
+                            <div className="w-12 h-12 sm:w-16 sm:h-16 bg-slate-50 dark:bg-slate-900/50 rounded-2xl flex items-center justify-center text-2xl sm:text-3xl sm:mb-4 group-hover:bg-teal-50 dark:group-hover:bg-slate-700/50 group-hover:scale-110 transition-all duration-300 flex-shrink-0 overflow-hidden">
+                                <CategoryTileIcon id={category.id} icon={category.icon} />
                             </div>
                             <div className="flex-1 flex flex-col justify-center">
                                 <h3 className="text-base sm:text-lg font-semibold sm:mb-2 text-slate-900 dark:text-white">

--- a/public/images/categories/README.md
+++ b/public/images/categories/README.md
@@ -1,0 +1,22 @@
+# Directory category photos
+
+Drop the client-provided category photos into this folder and they will
+automatically replace the emoji icons on the directory home page — no code
+change needed. Until a file exists, the emoji fallback is shown.
+
+Required filenames (`.webp`, square crop recommended, ~256×256 or larger):
+
+| File | Category |
+|---|---|
+| `medical.webp` | Medical Tourism |
+| `accommodations.webp` | Hotels & Accommodations |
+| `tours.webp` | Things to Do |
+| `transport.webp` | Airport Transfer / Transport |
+| `restaurants.webp` | Restaurants |
+| `cafes.webp` | Cafes |
+| `nature.webp` | Beaches & Nature |
+| `spa-hamam.webp` | Spa & Hamam |
+| `hair-beauty.webp` | Hair & Beauty |
+| `real-estate.webp` | Real Estate |
+| `visa.webp` | Visa & Residency |
+| `shopping.webp` | Shopping |


### PR DESCRIPTION
## Summary
- Prepares the last open Platform Edits task (**category icons → real photos**): the directory-home category grid now tries to load `/images/categories/<id>.webp` for each tile and falls back to the current emoji if the file doesn't exist.
- Adds `public/images/categories/README.md` listing the 12 exact filenames the client's photos must use.

## Why
The client hasn't provided the 12 category photos yet. With this wiring in place, finishing the task is a pure asset drop — add the `.webp` files to `public/images/categories/` and the photos appear with no code change.

## Test plan
- `tsc --noEmit` passes
- With no images present, the grid renders exactly as before (emoji fallback via `onError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)