### PR TITLE
feat(admin): manage directory category tile photos from admin panel

### DIFF
--- a/api-services/api/storage.test.ts
+++ b/api-services/api/storage.test.ts
@@ -274,4 +274,101 @@ describe('storageService', () => {
                 .rejects.toEqual({ message: 'Delete failed' });
         });
     });
+
+    describe('getCategoryImageOverrides', () => {
+        it('maps category ids to versioned public URLs', async () => {
+            const bucket = {
+                list: vi.fn().mockResolvedValue({
+                    data: [
+                        { name: 'nature.webp', updated_at: '2026-07-04T10:00:00Z' },
+                        { name: 'cafes.png', updated_at: '2026-07-04T11:00:00Z' },
+                    ],
+                    error: null
+                }),
+                getPublicUrl: vi.fn((path: string) => ({ data: { publicUrl: `https://test.supabase.co/category-images/${path}` } }))
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            const map = await storageService.getCategoryImageOverrides();
+
+            expect(mockSupabase.storage.from).toHaveBeenCalledWith('category-images');
+            expect(map['nature']).toContain('nature.webp');
+            expect(map['nature']).toContain('?v=');
+            expect(map['cafes']).toContain('cafes.png');
+        });
+
+        it('returns empty map when bucket is missing or list fails', async () => {
+            const bucket = {
+                list: vi.fn().mockResolvedValue({ data: null, error: { message: 'Bucket not found' } })
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            await expect(storageService.getCategoryImageOverrides()).resolves.toEqual({});
+        });
+    });
+
+    describe('uploadCategoryImage', () => {
+        it('upserts to a fixed per-category path and returns versioned URL', async () => {
+            const mockFile = new File(['content'], 'photo.webp', { type: 'image/webp' });
+            const bucket = {
+                list: vi.fn().mockResolvedValue({ data: [], error: null }),
+                remove: vi.fn().mockResolvedValue({ data: null, error: null }),
+                upload: vi.fn().mockResolvedValue({ data: {}, error: null }),
+                getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/category-images/nature.webp' } })
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            const url = await storageService.uploadCategoryImage('nature', mockFile);
+
+            expect(bucket.upload).toHaveBeenCalledWith('nature.webp', mockFile, { upsert: true, cacheControl: '300' });
+            expect(url).toContain('nature.webp?v=');
+        });
+
+        it('removes a previous override with a different extension', async () => {
+            const mockFile = new File(['content'], 'photo.png', { type: 'image/png' });
+            const bucket = {
+                list: vi.fn().mockResolvedValue({ data: [{ name: 'nature.webp' }], error: null }),
+                remove: vi.fn().mockResolvedValue({ data: null, error: null }),
+                upload: vi.fn().mockResolvedValue({ data: {}, error: null }),
+                getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://test.supabase.co/category-images/nature.png' } })
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            await storageService.uploadCategoryImage('nature', mockFile);
+
+            expect(bucket.remove).toHaveBeenCalledWith(['nature.webp']);
+            expect(bucket.upload).toHaveBeenCalledWith('nature.png', mockFile, { upsert: true, cacheControl: '300' });
+        });
+
+        it('rejects files that fail validation', async () => {
+            const badFile = new File(['content'], 'photo.gif', { type: 'image/gif' });
+            await expect(storageService.uploadCategoryImage('nature', badFile)).rejects.toThrow();
+        });
+    });
+
+    describe('removeCategoryImage', () => {
+        it('removes all files for the category id', async () => {
+            const bucket = {
+                list: vi.fn().mockResolvedValue({ data: [{ name: 'nature.webp' }, { name: 'cafes.png' }], error: null }),
+                remove: vi.fn().mockResolvedValue({ data: null, error: null })
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            await storageService.removeCategoryImage('nature');
+
+            expect(bucket.remove).toHaveBeenCalledWith(['nature.webp']);
+        });
+
+        it('is a no-op when no override exists', async () => {
+            const bucket = {
+                list: vi.fn().mockResolvedValue({ data: [], error: null }),
+                remove: vi.fn()
+            };
+            mockSupabase.storage.from.mockReturnValue(bucket as any);
+
+            await storageService.removeCategoryImage('nature');
+
+            expect(bucket.remove).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/api-services/api/storage.ts
+++ b/api-services/api/storage.ts
@@ -229,4 +229,88 @@ export const storageService = {
             .remove(filePaths);
         if (error) throw error;
     },
+
+    // ============================================================
+    // Category Images (admin-managed directory category tile photos)
+    // ============================================================
+
+    /**
+     * Map of category id → public URL for admin-uploaded tile photos.
+     * Files live at the bucket root as {categoryId}.{ext}. The updated_at
+     * timestamp is appended as ?v= so overwrites bust the CDN cache.
+     * Returns {} if the bucket is missing or empty (callers fall back to
+     * the bundled /images/categories/ files).
+     */
+    async getCategoryImageOverrides(): Promise<Record<string, string>> {
+        const { data, error } = await supabase.storage
+            .from('category-images')
+            .list('', { limit: 100 });
+        if (error || !data) return {};
+
+        const map: Record<string, string> = {};
+        for (const file of data) {
+            const dot = file.name.lastIndexOf('.');
+            if (dot <= 0) continue;
+            const categoryId = file.name.slice(0, dot);
+            const { data: pub } = supabase.storage.from('category-images').getPublicUrl(file.name);
+            const version = file.updated_at ?? file.created_at ?? '';
+            map[categoryId] = version
+                ? `${pub.publicUrl}?v=${encodeURIComponent(version)}`
+                : pub.publicUrl;
+        }
+        return map;
+    },
+
+    /**
+     * Upload (or replace) the tile photo for a category. Admin-only via RLS.
+     * Returns the public URL with a cache-busting version param.
+     */
+    async uploadCategoryImage(categoryId: string, file: File): Promise<string> {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error('Not authenticated');
+
+        validateBlogMedia(file);
+
+        const ext = file.name.split('.').pop()!.toLowerCase();
+        const path = `${categoryId}.${ext}`;
+
+        // Drop a previous override with a different extension so list()
+        // never maps two files to the same category
+        const { data: existing } = await supabase.storage
+            .from('category-images')
+            .list('', { search: categoryId });
+        const stale = (existing ?? [])
+            .filter(f => f.name.replace(/\.[^.]+$/, '') === categoryId && f.name !== path)
+            .map(f => f.name);
+        if (stale.length > 0) {
+            await supabase.storage.from('category-images').remove(stale);
+        }
+
+        const { error } = await supabase.storage
+            .from('category-images')
+            .upload(path, file, { upsert: true, cacheControl: '300' });
+        if (error) throw error;
+
+        const { data } = supabase.storage.from('category-images').getPublicUrl(path);
+        return `${data.publicUrl}?v=${Date.now()}`;
+    },
+
+    /**
+     * Remove the admin override for a category, reverting the tile to the
+     * bundled default image.
+     */
+    async removeCategoryImage(categoryId: string): Promise<void> {
+        const { data: existing, error: listError } = await supabase.storage
+            .from('category-images')
+            .list('', { search: categoryId });
+        if (listError) throw listError;
+
+        const targets = (existing ?? [])
+            .filter(f => f.name.replace(/\.[^.]+$/, '') === categoryId)
+            .map(f => f.name);
+        if (targets.length === 0) return;
+
+        const { error } = await supabase.storage.from('category-images').remove(targets);
+        if (error) throw error;
+    },
 };

--- a/components/admin/directory/CategoryImagesPanel.tsx
+++ b/components/admin/directory/CategoryImagesPanel.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { storageService } from '../../../api-services';
+import { toast } from 'react-hot-toast';
+import { Upload, RotateCcw, Loader2 } from 'lucide-react';
+
+const CATEGORIES: { id: string; label: string }[] = [
+    { id: 'medical', label: 'Medical Tourism' },
+    { id: 'accommodations', label: 'Accommodations' },
+    { id: 'tours', label: 'Things to Do' },
+    { id: 'transport', label: 'Transportation' },
+    { id: 'restaurants', label: 'Restaurants' },
+    { id: 'cafes', label: 'Cafés & Coffee Shops' },
+    { id: 'nature', label: 'Beaches & Nature' },
+    { id: 'spa-hamam', label: 'Spa & Hamams' },
+    { id: 'hair-beauty', label: 'Hair & Beauty' },
+    { id: 'real-estate', label: 'Real Estate' },
+    { id: 'visa', label: 'Residency & Legal' },
+    { id: 'shopping', label: 'Shopping & Souvenirs' },
+];
+
+export const CategoryImagesPanel: React.FC = () => {
+    const [overrides, setOverrides] = useState<Record<string, string>>({});
+    const [loading, setLoading] = useState(true);
+    const [busyId, setBusyId] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const pendingCategoryRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        storageService.getCategoryImageOverrides()
+            .then(map => { if (!cancelled) setOverrides(map); })
+            .catch(e => console.error('Failed to load category image overrides', e))
+            .finally(() => { if (!cancelled) setLoading(false); });
+        return () => { cancelled = true; };
+    }, []);
+
+    const handlePick = (categoryId: string) => {
+        pendingCategoryRef.current = categoryId;
+        fileInputRef.current?.click();
+    };
+
+    const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        const categoryId = pendingCategoryRef.current;
+        e.target.value = '';
+        if (!file || !categoryId) return;
+
+        setBusyId(categoryId);
+        try {
+            const url = await storageService.uploadCategoryImage(categoryId, file);
+            setOverrides(prev => ({ ...prev, [categoryId]: url }));
+            toast.success('Category image updated');
+        } catch (error: unknown) {
+            console.error('Category image upload failed', error);
+            toast.error(error instanceof Error ? error.message : 'Upload failed');
+        } finally {
+            setBusyId(null);
+            pendingCategoryRef.current = null;
+        }
+    };
+
+    const handleReset = async (categoryId: string) => {
+        setBusyId(categoryId);
+        try {
+            await storageService.removeCategoryImage(categoryId);
+            setOverrides(prev => {
+                const next = { ...prev };
+                delete next[categoryId];
+                return next;
+            });
+            toast.success('Reverted to default image');
+        } catch (error: unknown) {
+            console.error('Category image reset failed', error);
+            toast.error(error instanceof Error ? error.message : 'Reset failed');
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+                These photos appear on the directory home page category tiles. Uploads replace the
+                default image for everyone; Reset reverts to the default. JPEG, PNG or WebP, max 5MB —
+                square images look best.
+            </p>
+
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={handleFileSelected}
+            />
+
+            {loading ? (
+                <p className="text-slate-500 text-sm">Loading...</p>
+            ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+                    {CATEGORIES.map(({ id, label }) => {
+                        const isBusy = busyId === id;
+                        const hasOverride = !!overrides[id];
+                        return (
+                            <div
+                                key={id}
+                                className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 overflow-hidden"
+                            >
+                                <div className="relative aspect-square bg-slate-100 dark:bg-slate-900">
+                                    <img
+                                        src={overrides[id] ?? `/images/categories/${id}.webp`}
+                                        alt={label}
+                                        loading="lazy"
+                                        className="w-full h-full object-cover"
+                                    />
+                                    {hasOverride && (
+                                        <span className="absolute top-2 left-2 text-[10px] font-semibold uppercase tracking-wide bg-teal-500 text-white px-1.5 py-0.5 rounded">
+                                            Custom
+                                        </span>
+                                    )}
+                                    {isBusy && (
+                                        <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+                                            <Loader2 size={22} className="text-white animate-spin" />
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="p-3 space-y-2">
+                                    <p className="text-sm font-medium text-slate-900 dark:text-white truncate">{label}</p>
+                                    <div className="flex gap-2">
+                                        <button
+                                            onClick={() => handlePick(id)}
+                                            disabled={isBusy}
+                                            className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs font-medium bg-teal-500 hover:bg-teal-600 disabled:opacity-50 text-white rounded-lg transition-colors"
+                                        >
+                                            <Upload size={13} /> Upload
+                                        </button>
+                                        {hasOverride && (
+                                            <button
+                                                onClick={() => handleReset(id)}
+                                                disabled={isBusy}
+                                                title="Revert to default image"
+                                                className="flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs font-medium text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 rounded-lg transition-colors"
+                                            >
+                                                <RotateCcw size={13} /> Reset
+                                            </button>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/pages/DirectoryHome.tsx
+++ b/pages/DirectoryHome.tsx
@@ -8,7 +8,7 @@ import { toast } from 'react-hot-toast';
 import { SEOHead } from '../components/seo/SEOHead';
 import { cn } from '../utils/cn';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '../components/ui/dropdown-menu';
-import { db } from '../api-services';
+import { db, storageService } from '../api-services';
 import { DirectoryListingDB } from '../types/models';
 import { PremiumListingsSection } from '../components/home/PremiumListingsSection';
 import { FreeListingsSection } from '../components/home/FreeListingsSection';
@@ -16,17 +16,23 @@ import { SignatureListingsSection } from '../components/home/SignatureListingsSe
 import { TravelGuideSection } from '../components/home/TravelGuideSection';
 import { RecentlyClaimedSection } from '../components/home/RecentlyClaimedSection';
 
-// Category tiles use real photos dropped into /public/images/categories/<id>.webp;
-// until a photo exists for a category, the emoji icon is shown instead.
-const CategoryTileIcon: React.FC<{ id: string; icon: string }> = ({ id, icon }) => {
-    const [imageFailed, setImageFailed] = useState(false);
-    if (imageFailed) return <>{icon}</>;
+// Category tile photo fallback chain: admin-uploaded override (Supabase
+// category-images bucket) → bundled /public/images/categories/<id>.webp →
+// emoji icon.
+const CategoryTileIcon: React.FC<{ id: string; icon: string; overrideSrc?: string }> = ({ id, icon, overrideSrc }) => {
+    const sources = useMemo(() => [
+        ...(overrideSrc ? [overrideSrc] : []),
+        `/images/categories/${id}.webp`,
+    ], [overrideSrc, id]);
+    const [srcIndex, setSrcIndex] = useState(0);
+    useEffect(() => { setSrcIndex(0); }, [sources]);
+    if (srcIndex >= sources.length) return <>{icon}</>;
     return (
         <img
-            src={`/images/categories/${id}.webp`}
+            src={sources[srcIndex]}
             alt=""
             loading="lazy"
-            onError={() => setImageFailed(true)}
+            onError={() => setSrcIndex(i => i + 1)}
             className="w-full h-full object-cover rounded-2xl"
         />
     );
@@ -58,6 +64,15 @@ export const DirectoryHome: React.FC = () => {
     const [testimonials, setTestimonials] = useState<any[]>([]);
     const [dbLocations, setDbLocations] = useState<string[]>([]);
     const [listingsLoading, setListingsLoading] = useState(true);
+    const [categoryImageOverrides, setCategoryImageOverrides] = useState<Record<string, string>>({});
+
+    useEffect(() => {
+        let cancelled = false;
+        storageService.getCategoryImageOverrides()
+            .then(map => { if (!cancelled) setCategoryImageOverrides(map); })
+            .catch(() => { /* bucket may not exist yet — bundled images are used */ });
+        return () => { cancelled = true; };
+    }, []);
 
     useEffect(() => {
         let cancelled = false;
@@ -361,7 +376,7 @@ export const DirectoryHome: React.FC = () => {
                             className="group flex flex-row sm:flex-col items-center sm:justify-center p-4 sm:p-8 bg-white dark:bg-slate-800/80 border border-slate-100 dark:border-slate-800/50 rounded-2xl shadow-sm hover:shadow-xl dark:hover:shadow-slate-900/50 hover:-translate-y-1 transition-all duration-300 text-left sm:text-center text-slate-900 dark:text-white gap-4 sm:gap-0 cursor-pointer"
                         >
                             <div className="w-12 h-12 sm:w-16 sm:h-16 bg-slate-50 dark:bg-slate-900/50 rounded-2xl flex items-center justify-center text-2xl sm:text-3xl sm:mb-4 group-hover:bg-teal-50 dark:group-hover:bg-slate-700/50 group-hover:scale-110 transition-all duration-300 flex-shrink-0 overflow-hidden">
-                                <CategoryTileIcon id={category.id} icon={category.icon} />
+                                <CategoryTileIcon id={category.id} icon={category.icon} overrideSrc={categoryImageOverrides[category.id]} />
                             </div>
                             <div className="flex-1 flex flex-col justify-center">
                                 <h3 className="text-base sm:text-lg font-semibold sm:mb-2 text-slate-900 dark:text-white">

--- a/pages/admin/DirectoryAdminPage.tsx
+++ b/pages/admin/DirectoryAdminPage.tsx
@@ -7,9 +7,10 @@ import { MOCK_DIRECTORY_DATA } from '../../data/directoryData';
 import { DirectoryToolbar } from '../../components/admin/directory/DirectoryToolbar';
 import { DirectoryTable } from '../../components/admin/directory/DirectoryTable';
 import { toast } from 'react-hot-toast';
-import { CheckCircle, XCircle, Clock } from 'lucide-react';
+import { CheckCircle, XCircle, Clock, Image as ImageIcon } from 'lucide-react';
+import { CategoryImagesPanel } from '../../components/admin/directory/CategoryImagesPanel';
 
-type AdminTab = 'approved' | 'pending' | 'rejected' | 'claims';
+type AdminTab = 'approved' | 'pending' | 'rejected' | 'claims' | 'images';
 
 export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ defaultCategory }) => {
     const navigate = useNavigate();
@@ -211,6 +212,7 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                     { key: 'pending', label: 'Pending', icon: Clock, count: pendingListings.length },
                     { key: 'rejected', label: 'Rejected', icon: XCircle, count: rejectedListings.length },
                     { key: 'claims', label: 'Claims', icon: CheckCircle, count: claims.length },
+                    { key: 'images', label: 'Category Images', icon: ImageIcon, count: 0 },
                 ] as const).map(({ key, label, icon: Icon, count }) => (
                     <button
                         key={key}
@@ -437,6 +439,8 @@ export const DirectoryAdminPage: React.FC<{ defaultCategory?: string }> = ({ def
                     ))}
                 </div>
             )}
+
+            {activeTab === 'images' && <CategoryImagesPanel />}
 
             <ConfirmationModal
                 isOpen={modalConfig.isOpen}

--- a/supabase/migrations/20260704120000_category_images_storage.sql
+++ b/supabase/migrations/20260704120000_category_images_storage.sql
@@ -1,0 +1,56 @@
+-- Migration: 20260704120000_category_images_storage
+-- Purpose: Create category-images storage bucket so admins can override the
+-- directory category tile photos from the admin panel. Public read/list
+-- (DirectoryHome lists the bucket anonymously to discover overrides),
+-- admin-only writes.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'category-images',
+    'category-images',
+    true,
+    5242880, -- 5MB in bytes
+    ARRAY['image/jpeg', 'image/png', 'image/webp']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- SELECT: public read + list
+CREATE POLICY "category_images_select" ON storage.objects
+    FOR SELECT
+    USING (bucket_id = 'category-images');
+
+-- INSERT: admins only
+CREATE POLICY "category_images_insert" ON storage.objects
+    FOR INSERT
+    WITH CHECK (
+        bucket_id = 'category-images'
+        AND EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- UPDATE: admins only (required for upsert overwrites)
+CREATE POLICY "category_images_update" ON storage.objects
+    FOR UPDATE
+    USING (
+        bucket_id = 'category-images'
+        AND EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );
+
+-- DELETE: admins only
+CREATE POLICY "category_images_delete" ON storage.objects
+    FOR DELETE
+    USING (
+        bucket_id = 'category-images'
+        AND EXISTS (
+            SELECT 1 FROM public.profiles
+            WHERE id = (SELECT auth.uid())
+            AND role = 'admin'
+        )
+    );


### PR DESCRIPTION
## Summary
- New **Category Images** tab in admin → Directory Management: a grid of the 12 categories, each with the current tile photo, an **Upload** button (JPEG/PNG/WebP, max 5MB) and a **Reset** button to revert to the bundled default.
- New public `category-images` storage bucket (migration included): public read/list, **admin-only** insert/update/delete via RLS on `profiles.role = 'admin'`.
- `storageService` gains `getCategoryImageOverrides` / `uploadCategoryImage` / `removeCategoryImage` — fixed per-category paths with upsert + `?v=updated_at` cache-busting.
- Directory home tile fallback chain is now: admin override → bundled `/images/categories/<id>.webp` → emoji. One anonymous `list()` call discovers overrides; if the bucket doesn't exist yet, everything falls back silently to the bundled photos (verified locally).

## Deploy note
⚠️ The bucket migration must be applied to the remote DB **via SQL Editor + `supabase migration repair`** (not `db push`) per the known migration drift. The feature is inert-but-safe until then.

## Test plan
- `tsc --noEmit` clean
- 36 tests pass in `storage.test.ts` + `DirectoryAdminPage.test.tsx` (7 new: override mapping, versioned URLs, extension-change cleanup, validation rejection, reset no-op)
- Visually verified directory home renders with bundled photos and no console/page errors when the bucket is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)